### PR TITLE
Dilation support for Conv

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![][codecov-img]][codecov-url]
 
 [gitlab-img]: https://gitlab.com/JuliaGPU/CuArrays.jl/badges/master/pipeline.svg
-[gitlab-url]: https://gitlab.com/JuliaGPU/CuArrays.jl/commits/master
+[gitlab-url]: https://gitlab.com/JuliaGPU/CuArrays.jl/pipelines
 
 [codecov-img]: https://codecov.io/gh/JuliaGPU/CuArrays.jl/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JuliaGPU/CuArrays.jl

--- a/src/dnn/helpers.jl
+++ b/src/dnn/helpers.jl
@@ -92,12 +92,12 @@ end
 pdsize(w, nd)=Cint[reverse(psize(w,nd))...]
 psize(w, nd)=(isa(w,Integer)  ? fill(w,nd) : length(w) != nd ? error("Dimension mismatch") : w)
 
-function ConvDesc(T, N, padding, stride, upscale, mode)
+function ConvDesc(T, N, padding, stride, dilation, upscale, mode)
     cd = cudnnConvolutionDescriptor_t[0]
     cudnnCreateConvolutionDescriptor(cd)
-    CUDNN_VERSION >= 4000 ? cudnnSetConvolutionNdDescriptor(cd[1],N,cdsize(padding,N),cdsize(stride,N),cdsize(upscale,N),mode,cudnnDataType(T)) :
-    CUDNN_VERSION >= 3000 ? cudnnSetConvolutionNdDescriptor_v3(cd[1],N,cdsize(padding,N),cdsize(stride,N),cdsize(upscale,N),mode,cudnnDataType(T)) :
-    cudnnSetConvolutionNdDescriptor(cd[1],N,cdsize(padding,N),cdsize(stride,N),cdsize(upscale,N),mode)
+    CUDNN_VERSION >= 4000 ? cudnnSetConvolutionNdDescriptor(cd[1],N,cdsize(padding,N),cdsize(stride,N),cdsize(dilation,N),cdsize(upscale,N),mode,cudnnDataType(T)) :
+    CUDNN_VERSION >= 3000 ? cudnnSetConvolutionNdDescriptor_v3(cd[1],N,cdsize(padding,N),cdsize(stride,N),cdsize(dilation,N),cdsize(upscale,N),mode,cudnnDataType(T)) :
+    cudnnSetConvolutionNdDescriptor(cd[1],N,cdsize(padding,N),cdsize(stride,N),cdsize(dilation,N),cdsize(upscale,N),mode)
     this = ConvDesc(cd[1])
     finalizer(this, free)
     return this

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -174,8 +174,8 @@ end
 
 function cudnnGetConvolutionForwardWorkspaceSize(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N};
                                                  handle=libcudnn_handle[], algo=0, padding=0, stride=1,
-                                                 upscale=1, mode=0) where {T,N}
-    cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
+                                                 dilation=1, mode=0) where {T,N}
+    cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     workspace_size = Ref{Cint}()
     cudnnGetConvolutionForwardWorkspaceSize(handle, TensorDesc(x), FilterDesc(w), cd, TensorDesc(y), algo, workspace_size)
     return Int(workspace_size[])
@@ -202,8 +202,8 @@ end
 
 function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
                                                       handle=libcudnn_handle[], algo=0, padding=0, stride=1,
-                                                      upscale=1, mode=0) where {T,N}
-    cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
+                                                      dilation=1, mode=0) where {T,N}
+    cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     workspace_size = Ref{Cint}()
     cudnnGetConvolutionBackwardDataWorkspaceSize(handle, FilterDesc(w), TensorDesc(dy), cd, TensorDesc(dx), algo, workspace_size)
     return Int(workspace_size[])

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -62,12 +62,12 @@ function cudnnCreateConvolutionDescriptor(convDesc)
     @check ccall((:cudnnCreateConvolutionDescriptor,libcudnn),cudnnStatus_t,(Ptr{cudnnConvolutionDescriptor_t},),convDesc)
 end
 
-function cudnnSetConvolutionNdDescriptor(convDesc,arrayLength,padA,filterStrideA,dilationA,upscaleA,mode,dataType)
-    @check ccall((:cudnnSetConvolutionNdDescriptor,libcudnn),cudnnStatus_t,(cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},cudnnConvolutionMode_t,cudnnDataType_t),convDesc,arrayLength,padA,filterStrideA,dilationA,upscaleA,mode,dataType)
+function cudnnSetConvolutionNdDescriptor(convDesc,arrayLength,padA,filterStrideA,dilationA,mode,dataType)
+    @check ccall((:cudnnSetConvolutionNdDescriptor,libcudnn),cudnnStatus_t,(cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},cudnnConvolutionMode_t,cudnnDataType_t),convDesc,arrayLength,padA,filterStrideA,dilationA,mode,dataType)
 end
 
-function cudnnGetConvolutionNdDescriptor(convDesc,arrayLengthRequested,arrayLength,padA,strideA,dilationA,upscaleA,mode,dataType)
-    @check ccall((:cudnnGetConvolutionNdDescriptor,libcudnn),cudnnStatus_t,(cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{cudnnConvolutionMode_t},Ptr{cudnnDataType_t}),convDesc,arrayLengthRequested,arrayLength,padA,strideA,dilationA,upscaleA,mode,dataType)
+function cudnnGetConvolutionNdDescriptor(convDesc,arrayLengthRequested,arrayLength,padA,strideA,dilationA,mode,dataType)
+    @check ccall((:cudnnGetConvolutionNdDescriptor,libcudnn),cudnnStatus_t,(cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{cudnnConvolutionMode_t},Ptr{cudnnDataType_t}),convDesc,arrayLengthRequested,arrayLength,padA,strideA,dilationA,mode,dataType)
 end
 
 function cudnnDestroyConvolutionDescriptor(convDesc)
@@ -217,7 +217,7 @@ end
 function cudnnConvolutionBackwardFilter(dw::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
                                         handle=libcudnn_handle[], algo=0, workspace=C_NULL, workspace_size=0,
                                         alpha=1, beta=0, padding=0, stride=1, dilation=1, mode=0) where {T,N}
-    cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
+    cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     cudnnConvolutionBackwardFilter(
         handle,Ref(T(alpha)),TensorDesc(x),x,TensorDesc(dy),dy,cd,algo,workspace,
         workspace_size,Ref(T(beta)),FilterDesc(dw),dw)

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -62,12 +62,12 @@ function cudnnCreateConvolutionDescriptor(convDesc)
     @check ccall((:cudnnCreateConvolutionDescriptor,libcudnn),cudnnStatus_t,(Ptr{cudnnConvolutionDescriptor_t},),convDesc)
 end
 
-function cudnnSetConvolutionNdDescriptor(convDesc,arrayLength,padA,filterStrideA,upscaleA,mode,dataType)
-    @check ccall((:cudnnSetConvolutionNdDescriptor,libcudnn),cudnnStatus_t,(cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},cudnnConvolutionMode_t,cudnnDataType_t),convDesc,arrayLength,padA,filterStrideA,upscaleA,mode,dataType)
+function cudnnSetConvolutionNdDescriptor(convDesc,arrayLength,padA,filterStrideA,dilationA,upscaleA,mode,dataType)
+    @check ccall((:cudnnSetConvolutionNdDescriptor,libcudnn),cudnnStatus_t,(cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},cudnnConvolutionMode_t,cudnnDataType_t),convDesc,arrayLength,padA,filterStrideA,dilationA,upscaleA,mode,dataType)
 end
 
-function cudnnGetConvolutionNdDescriptor(convDesc,arrayLengthRequested,arrayLength,padA,strideA,upscaleA,mode,dataType)
-    @check ccall((:cudnnGetConvolutionNdDescriptor,libcudnn),cudnnStatus_t,(cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{cudnnConvolutionMode_t},Ptr{cudnnDataType_t}),convDesc,arrayLengthRequested,arrayLength,padA,strideA,upscaleA,mode,dataType)
+function cudnnGetConvolutionNdDescriptor(convDesc,arrayLengthRequested,arrayLength,padA,strideA,dilationA,upscaleA,mode,dataType)
+    @check ccall((:cudnnGetConvolutionNdDescriptor,libcudnn),cudnnStatus_t,(cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{cudnnConvolutionMode_t},Ptr{cudnnDataType_t}),convDesc,arrayLengthRequested,arrayLength,padA,strideA,dilationA,upscaleA,mode,dataType)
 end
 
 function cudnnDestroyConvolutionDescriptor(convDesc)
@@ -127,8 +127,8 @@ end
 
 function cudnnConvolutionForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N};
                                  handle=libcudnn_handle[], algo=0, workSpace=C_NULL, workSpaceSizeInBytes=0,
-                                 alpha=1, beta=0, padding=0, stride=1, upscale=1, mode=0) where {T,N}
-    cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
+                                 alpha=1, beta=0, padding=0, stride=1, dilation=1, upscale=1, mode=0) where {T,N}
+    cd = ConvDesc(T, N-2, padding, stride, dilation, upscale, mode)
     cudnnConvolutionForward(
       handle,Ref(T(alpha)),TensorDesc(x),x,FilterDesc(w),w,cd,algo,workSpace,
       workSpaceSizeInBytes,Ref(T(beta)),TensorDesc(y),y)
@@ -141,8 +141,8 @@ end
 
 function cudnnConvolutionBackwardData(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
                                       handle=libcudnn_handle[], algo=0, workSpace=C_NULL, workSpaceSizeInBytes=0,
-                                      alpha=1, beta=0, padding=0, stride=1, upscale=1, mode=0) where {T,N}
-    cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
+                                      alpha=1, beta=0, padding=0, stride=1, dilation=1, upscale=1, mode=0) where {T,N}
+    cd = ConvDesc(T, N-2, padding, stride, dilation, upscale, mode)
     cudnnConvolutionBackwardData(
         handle,Ref(T(alpha)),FilterDesc(w),w,TensorDesc(dy),dy,cd,algo,workSpace,
         workSpaceSizeInBytes,Ref(T(beta)),TensorDesc(dx),dx)
@@ -155,8 +155,8 @@ end
 
 function cudnnConvolutionBackwardFilter(dw::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
                                         handle=libcudnn_handle[], algo=0, workSpace=C_NULL, workSpaceSizeInBytes=0,
-                                        alpha=1, beta=0, padding=0, stride=1, upscale=1, mode=0) where {T,N}
-    cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
+                                        alpha=1, beta=0, padding=0, stride=1, dilation=1, upscale=1, mode=0) where {T,N}
+    cd = ConvDesc(T, N-2, padding, stride, dilation, upscale, mode)
     cudnnConvolutionBackwardFilter(
         handle,Ref(T(alpha)),TensorDesc(x),x,TensorDesc(dy),dy,cd,algo,workSpace,
         workSpaceSizeInBytes,Ref(T(beta)),FilterDesc(dw),dw)

--- a/src/dnn/nnlib.jl
+++ b/src/dnn/nnlib.jl
@@ -80,47 +80,51 @@ function conv!(y::CuArray{T}, x::CuArray{T}, w::CuArray{T};
   end
   if workspace === nothing
     workspace_size =
-      cudnnGetConvolutionForwardWorkspaceSize(y, x, w, padding=pad, stride=stride,
+      cudnnGetConvolutionForwardWorkspaceSize(y, x, w, padding=pad, stride=stride, dilation=dilation,
                                               algo=algo, mode=mode)
     workspace = workspace_size != 0 ? conv_workspace(workspace_size) : workspace
   else
     workspace_size = length(workspace[])
   end
-  cudnnConvolutionForward(y, x, w, padding=pad, stride=stride, mode=mode, alpha=alpha,
-                          algo=algo, workspace=workspace, workspace_size=workspace_size)
+  cudnnConvolutionForward(y, x, w, padding=pad, stride=stride, dilation=dilation, mode=mode, 
+			  alpha=alpha, algo=algo, workspace=workspace, workspace_size=workspace_size)
 end
 
 function ∇conv_filter!(dw::CuArray{T}, dy::CuArray{T}, x::CuArray{T}, w::CuArray{T};
                        pad=0, stride=1, mode=0, alpha=1, dilation=1,
                        workspace::Union{CuVector, Nothing}=nothing, algo=0) where T<:CUDNNFloat
-  all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
+  if CUDNN_VERSION < 6000
+    all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in cuDNN version < 6")
+  end
   if workspace === nothing
     workspace_size =
-      cudnnGetConvolutionBackwardFilterWorkspaceSize(dw, x, w, dy, padding=pad,
-                                                     stride=stride, algo=algo, mode=mode)
+      cudnnGetConvolutionBackwardFilterWorkspaceSize(dw, x, w, dy, padding=pad, stride=stride, 
+					             dilation=dilation, algo=algo, mode=mode)
     workspace = workspace_size != 0 ? conv_workspace(workspace_size) : workspace
   else
     workspace_size = length(workspace[])
   end
-  cudnnConvolutionBackwardFilter(dw, x, w, dy, padding=pad, stride=stride, mode=mode,
-                                 alpha=alpha, algo=algo, workspace=workspace,
+  cudnnConvolutionBackwardFilter(dw, x, w, dy, padding=pad, stride=stride, dilation=dilation,
+				 mode=mode, alpha=alpha, algo=algo, workspace=workspace,
                                  workspace_size=workspace_size)
 end
 
 function ∇conv_data!(dx::CuArray{T}, dy::CuArray{T}, x::CuArray{T}, w::CuArray{T};
                      pad=0, stride=1, mode=0, alpha=1, dilation=1,
                      workspace::Union{CuVector, Nothing}=nothing, algo=0) where T<:CUDNNFloat
-  all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
+  if CUDNN_VERSION < 6000
+    all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in cuDNN version < 6")
+  end
   if workspace === nothing
     workspace_size =
-      cudnnGetConvolutionBackwardDataWorkspaceSize(dx, x, w, dy, padding=pad,stride=stride,
-                                                   algo=algo, mode=mode)
+      cudnnGetConvolutionBackwardDataWorkspaceSize(dx, x, w, dy, padding=pad, stride=stride,
+                                                   dilation=dilation, algo=algo, mode=mode)
     workspace = workspace_size != 0 ? conv_workspace(workspace_size) : workspace
   else
     workspace_size = length(workspace[])
   end
-  cudnnConvolutionBackwardData(dx, x, w, dy, padding=pad, stride=stride, mode=mode,
-                               alpha=alpha, algo=algo, workspace=workspace,
+  cudnnConvolutionBackwardData(dx, x, w, dy, padding=pad, stride=stride, dilation=dilation,
+			       mode=mode, alpha=alpha, algo=algo, workspace=workspace,
                                workspace_size=workspace_size)
 end
 

--- a/src/dnn/nnlib.jl
+++ b/src/dnn/nnlib.jl
@@ -75,7 +75,9 @@ end
 function conv!(y::CuArray{T}, x::CuArray{T}, w::CuArray{T};
                pad=0, stride=1, mode=0, alpha=1, dilation=1,
                workspace::Union{CuVector, Nothing}=nothing, algo=0) where T<:CUDNNFloat
-  all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
+  if CUDNN_VERSION < 6000
+    all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in cuDNN version < 6")
+  end
   if workspace === nothing
     workspace_size =
       cudnnGetConvolutionForwardWorkspaceSize(y, x, w, padding=pad, stride=stride,

--- a/test/dnn.jl
+++ b/test/dnn.jl
@@ -11,6 +11,10 @@
   @test testf(∇conv_filter, rand(Float64, 9, 9, 4, 1), rand(Float64, 10, 10, 3, 1), rand(Float64, 2, 2, 3, 4))
   @test testf(CuArrays.CUDNN.∇conv_bias!, cu(rand(Float64, 1, 1, 10, 1)), cu(rand(Float64, 10, 10, 10, 1)))
 
+  @test testf(NNlib.conv, rand(Float64, 10, 10, 3, 1), rand(Float64, 2, 2, 3, 4); dilation=2)
+  @test testf(∇conv_data, rand(Float64, 8, 8, 4, 1), rand(Float64, 10, 10, 3, 1), rand(Float64, 2, 2, 3, 4); dilation=2)
+  @test testf(∇conv_filter, rand(Float64, 8, 8, 4, 1), rand(Float64, 10, 10, 3, 1), rand(Float64, 2, 2, 3, 4); dilation=2)
+
   @test_nowarn NNlib.conv!(cu(zeros(Float64, 9, 9, 3, 1)), cu(rand(Float64, 10, 10, 1, 1)), cu(rand(Float64, 2, 2, 1, 3)), algo=1)
   @test_nowarn NNlib.∇conv_data!(cu(zeros(Float64, 10, 10, 1, 1)), cu(ones(Float64, 9, 9, 3, 1)), cu(rand(Float64, 10, 10, 1, 1)), cu(rand(Float64, 2, 2, 1, 3)), algo=1)
   @test_nowarn NNlib.∇conv_filter!(cu(zeros(Float64, 2, 2, 1, 3)), cu(ones(Float64, 9, 9, 3, 1)), cu(rand(Float64, 10, 10, 1, 1)), cu(rand(Float64, 2, 2, 1, 3)), algo=1)
@@ -18,6 +22,10 @@
   @test testf(NNlib.conv, rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4))
   @test testf(∇conv_data, rand(Float64, 9, 9, 9, 4, 1), rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4))
   @test testf(∇conv_filter, rand(Float64, 9, 9, 9, 4, 1), rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4))
+  
+  @test testf(NNlib.conv, rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4); dilation=2)
+  @test testf(∇conv_data, rand(Float64, 8, 8, 8, 4, 1), rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4); dilation=2)
+  @test testf(∇conv_filter, rand(Float64, 8, 8, 8, 4, 1), rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4); dilation=2)
 
   @test testf(x -> maxpool(x, (2,2)), rand(Float64, 10, 10, 3, 1))
   @test testf(x -> meanpool(x, (2,2)), rand(Float64, 10, 10, 3, 1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ end
 Random.seed!(1)
 CuArrays.allowscalar(false)
 
-testf(f, xs...) = GPUArrays.TestSuite.compare(f, CuArray, xs...)
+testf(f, xs...; kwargs...) = GPUArrays.TestSuite.compare(f, CuArray, xs...; kwargs...)
 
 using GPUArrays
 


### PR DESCRIPTION
Dilation has been added in the latest release of NNlib. Because of that `NNlib.conv!` doesn't run on GPU since those changes have to be reflected here.