### PR TITLE
Workspace support for Convolution

### DIFF
--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -122,7 +122,7 @@ function cudnnSoftmaxBackward(src::CuArray{T,4}, srcDiff::CuArray{T,4}, destDiff
 end
 
 function cudnnConvolutionForward(handle, alpha, xDesc, x, wDesc, w, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, yDesc, y)
-    workSpace == nothing && workSpace = C_NULL
+    workSpace = workSpace == nothing ? C_NULL : workSpace
     @check ccall((:cudnnConvolutionForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}, cudnnFilterDescriptor_t, Ptr{Void}, cudnnConvolutionDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Void}, Cint, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}), handle, alpha, xDesc, x, wDesc, w, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, yDesc, y)
 end
 
@@ -150,7 +150,7 @@ function cudnnGetConvolutionForwardWorkspaceSize(y::CuArray{T,N}, x::CuArray{T,N
 end
 
 function cudnnConvolutionBackwardData(handle, alpha, wDesc, w, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dxDesc, dx)
-    workSpace == nothing && workSpace = C_NULL
+    workSpace = workSpace == nothing ? C_NULL : workSpace
     @check ccall((:cudnnConvolutionBackwardData, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Void}, cudnnFilterDescriptor_t, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdDataAlgo_t, Ptr{Void}, Cint, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}), handle, alpha, wDesc, w, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dxDesc, dx)
 end
 
@@ -178,7 +178,7 @@ function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, x::CuArr
 end
 
 function cudnnConvolutionBackwardFilter(handle, alpha, xDesc, x, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dwDesc, dw)
-    workSpace == nothing && workSpace = C_NULL
+    workSpace = workSpace == nothing ? C_NULL : workSpace
     @check ccall((:cudnnConvolutionBackwardFilter, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdFilterAlgo_t, Ptr{Void}, Cint, Ptr{Void}, cudnnFilterDescriptor_t, Ptr{Void}), handle, alpha, xDesc, x, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dwDesc, dw)
 end
 

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -144,7 +144,7 @@ function cudnnGetConvolutionForwardWorkspaceSize(y::CuArray{T,N}, x::CuArray{T,N
                                                  handle=libcudnn_handle[], algo=0, padding=0, stride=1,
                                                  upscale=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
-    sizeInBytes = Cint[0]
+    sizeInBytes = Ref{Cint}()
     cudnnGetConvolutionForwardWorkspaceSize(handle, TensorDesc(x), FilterDesc(w), cd, TensorDesc(y), algo, sizeInBytes)
     return Int(sizeInBytes[])
 end
@@ -172,7 +172,7 @@ function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, x::CuArr
                                                       handle=libcudnn_handle[], algo=0, padding=0, stride=1,
                                                       upscale=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
-    sizeInBytes = Cint[0]
+    sizeInBytes = Ref{Cint}()
     cudnnGetConvolutionBackwardDataWorkspaceSize(handle, FilterDesc(w), TensorDesc(dy), cd, TensorDesc(dx), algo, sizeInBytes)
     return Int(sizeInBytes[])
 end
@@ -200,7 +200,7 @@ function cudnnGetConvolutionBackwardFilterWorkspaceSize(dw::CuArray{T,N}, x::CuA
                                                         handle=libcudnn_handle[], algo=0, padding=0, stride=1,
                                                         upscale=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
-    sizeInBytes = Cint[0]
+    sizeInBytes = Ref{Cint}()
     cudnnGetConvolutionBackwardFilterWorkspaceSize(handle, TensorDesc(x), TensorDesc(dy), cd, FilterDesc(dw), algo, sizeInBytes)
     return Int(sizeInBytes[])
 end

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -163,7 +163,7 @@ function cudnnConvolutionBackwardData(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuAr
 end
 
 function cudnnGetConvolutionBackwardDataWorkspaceSize(handle, wDesc, dyDesc, convDesc, dxDesc, algo, sizeInBytes)
-    @check ccall((:cudnnGetConvolutionBackwardDataWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Cint), handle, wDesc, dyDesc, convDesc, dxDesc, algo, sizeInBytes)
+    @check ccall((:cudnnGetConvolutionBackwardDataWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle, wDesc, dyDesc, convDesc, dxDesc, algo, sizeInBytes)
 end
 
 function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
@@ -190,7 +190,7 @@ function cudnnConvolutionBackwardFilter(dw::CuArray{T,N}, x::CuArray{T,N}, w::Cu
 end
 
 function cudnnGetConvolutionBackwardFilterWorkspaceSize(handle, xDesc, dyDesc, convDesc, dwDesc, algo, sizeInBytes)
-    @check ccall((:cudnnGetConvolutionBackwardFilterWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionFwdAlgo_t, Cint), handle, xDesc, dyDesc, convDesc, dwDesc, algo, sizeInBytes)
+    @check ccall((:cudnnGetConvolutionBackwardFilterWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle, xDesc, dyDesc, convDesc, dwDesc, algo, sizeInBytes)
 end
 
 function cudnnGetConvolutionBackwardFilterWorkspaceSize(dw::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -135,6 +135,18 @@ function cudnnConvolutionForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,
     return y
 end
 
+function cudnnGetConvolutionForwardWorkspaceSize(handle, xDesc, wDesc, convDesc, yDesc, algo, sizeInBytes)
+    @check ccall((:cudnnGetConvolutionForwardWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Cint), handle, xDesc, wDesc, convDesc, yDesc, algo, sizeInBytes)
+end
+
+function cudnnGetConvolutionForwardWorkspaceSize(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N};
+                                                 handle=libcudnn_handle[], algo=0, padding=0, stride=1,
+                                                 upscale=1, mode=0, sizeInBytes = 0) where {T,N}
+    cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
+    cudnnGetConvolutionForwardWorkspaceSize(handle, TensorDesc(x), FilterDesc(w), cd, TensorDesc(y), algo, Ref(sizeInBytes))
+    return sizeInBytes
+end
+
 function cudnnConvolutionBackwardData(handle, alpha, wDesc, w, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dxDesc, dx)
     @check ccall((:cudnnConvolutionBackwardData, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Void}, cudnnFilterDescriptor_t, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdDataAlgo_t, Ptr{Void}, Cint, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}), handle, alpha, wDesc, w, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dxDesc, dx)
 end
@@ -149,6 +161,18 @@ function cudnnConvolutionBackwardData(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuAr
     return dx
 end
 
+function cudnnGetConvolutionBackwardDataWorkspaceSize(handle, wDesc, dyDesc, convDesc, dxDesc, algo, sizeInBytes)
+    @check ccall((:cudnnGetConvolutionBackwardDataWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Cint), handle, wDesc, dyDesc, convDesc, dxDesc, algo, sizeInBytes)
+end
+
+function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
+                                                      handle=libcudnn_handle[], algo=0, padding=0, stride=1,
+                                                      upscale=1, mode=0, sizeInBytes = 0) where {T,N}
+    cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
+    cudnnGetConvolutionBackwardDataWorkspaceSize(handle, FilterDesc(w), TensorDesc(dy), cd, TensorDesc(dx), algo, Ref(sizeInBytes))
+    return sizeInBytes
+end
+
 function cudnnConvolutionBackwardFilter(handle, alpha, xDesc, x, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dwDesc, dw)
     @check ccall((:cudnnConvolutionBackwardFilter, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdFilterAlgo_t, Ptr{Void}, Cint, Ptr{Void}, cudnnFilterDescriptor_t, Ptr{Void}), handle, alpha, xDesc, x, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dwDesc, dw)
 end
@@ -161,6 +185,18 @@ function cudnnConvolutionBackwardFilter(dw::CuArray{T,N}, x::CuArray{T,N}, w::Cu
         handle,Ref(T(alpha)),TensorDesc(x),x,TensorDesc(dy),dy,cd,algo,workSpace,
         workSpaceSizeInBytes,Ref(T(beta)),FilterDesc(dw),dw)
     return dw
+end
+
+function cudnnGetConvolutionBackwardFilterWorkspaceSize(handle, xDesc, dyDesc, convDesc, dwDesc, algo, sizeInBytes)
+    @check ccall((:cudnnGetConvolutionBackwardFilterWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionFwdAlgo_t, Cint), handle, xDesc, dyDesc, convDesc, dwDesc, algo, sizeInBytes)
+end
+
+function cudnnGetConvolutionBackwardFilterWorkspaceSize(dw::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
+                                                        handle=libcudnn_handle[], algo=0, padding=0, stride=1,
+                                                        upscale=1, mode=0, sizeInBytes = 0) where {T,N}
+    cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
+    cudnnGetConvolutionBackwardFilterWorkspaceSize(handle, TensorDesc(x), TensorDesc(dy), cd, FilterDesc(dw), algo, Ref(sizeInBytes))
+    return sizeInBytes
 end
 
 function cudnnPoolingForward(handle,poolingDesc,alpha,xDesc,x,beta,yDesc,y)

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -122,6 +122,7 @@ function cudnnSoftmaxBackward(src::CuArray{T,4}, srcDiff::CuArray{T,4}, destDiff
 end
 
 function cudnnConvolutionForward(handle, alpha, xDesc, x, wDesc, w, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, yDesc, y)
+    workSpace == nothing && workSpace = C_NULL
     @check ccall((:cudnnConvolutionForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}, cudnnFilterDescriptor_t, Ptr{Void}, cudnnConvolutionDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Void}, Cint, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}), handle, alpha, xDesc, x, wDesc, w, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, yDesc, y)
 end
 
@@ -149,6 +150,7 @@ function cudnnGetConvolutionForwardWorkspaceSize(y::CuArray{T,N}, x::CuArray{T,N
 end
 
 function cudnnConvolutionBackwardData(handle, alpha, wDesc, w, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dxDesc, dx)
+    workSpace == nothing && workSpace = C_NULL
     @check ccall((:cudnnConvolutionBackwardData, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Void}, cudnnFilterDescriptor_t, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdDataAlgo_t, Ptr{Void}, Cint, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}), handle, alpha, wDesc, w, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dxDesc, dx)
 end
 
@@ -176,6 +178,7 @@ function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, x::CuArr
 end
 
 function cudnnConvolutionBackwardFilter(handle, alpha, xDesc, x, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dwDesc, dw)
+    workSpace == nothing && workSpace = C_NULL
     @check ccall((:cudnnConvolutionBackwardFilter, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}, cudnnTensorDescriptor_t, Ptr{Void}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdFilterAlgo_t, Ptr{Void}, Cint, Ptr{Void}, cudnnFilterDescriptor_t, Ptr{Void}), handle, alpha, xDesc, x, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dwDesc, dw)
 end
 

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -136,15 +136,16 @@ function cudnnConvolutionForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,
 end
 
 function cudnnGetConvolutionForwardWorkspaceSize(handle, xDesc, wDesc, convDesc, yDesc, algo, sizeInBytes)
-    @check ccall((:cudnnGetConvolutionForwardWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Cint), handle, xDesc, wDesc, convDesc, yDesc, algo, sizeInBytes)
+    @check ccall((:cudnnGetConvolutionForwardWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle, xDesc, wDesc, convDesc, yDesc, algo, sizeInBytes)
 end
 
 function cudnnGetConvolutionForwardWorkspaceSize(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N};
                                                  handle=libcudnn_handle[], algo=0, padding=0, stride=1,
-                                                 upscale=1, mode=0, sizeInBytes = 0) where {T,N}
+                                                 upscale=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
-    cudnnGetConvolutionForwardWorkspaceSize(handle, TensorDesc(x), FilterDesc(w), cd, TensorDesc(y), algo, Ref(sizeInBytes))
-    return sizeInBytes
+    sizeInBytes = Cint[0]
+    cudnnGetConvolutionForwardWorkspaceSize(handle, TensorDesc(x), FilterDesc(w), cd, TensorDesc(y), algo, sizeInBytes)
+    return Int(sizeInBytes[])
 end
 
 function cudnnConvolutionBackwardData(handle, alpha, wDesc, w, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dxDesc, dx)
@@ -167,10 +168,11 @@ end
 
 function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
                                                       handle=libcudnn_handle[], algo=0, padding=0, stride=1,
-                                                      upscale=1, mode=0, sizeInBytes = 0) where {T,N}
+                                                      upscale=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
-    cudnnGetConvolutionBackwardDataWorkspaceSize(handle, FilterDesc(w), TensorDesc(dy), cd, TensorDesc(dx), algo, Ref(sizeInBytes))
-    return sizeInBytes
+    sizeInBytes = Cint[0]
+    cudnnGetConvolutionBackwardDataWorkspaceSize(handle, FilterDesc(w), TensorDesc(dy), cd, TensorDesc(dx), algo, sizeInBytes)
+    return Int(sizeInBytes[])
 end
 
 function cudnnConvolutionBackwardFilter(handle, alpha, xDesc, x, dyDesc, dy, convDesc, algo, workSpace, workSpaceSizeInBytes, beta, dwDesc, dw)
@@ -193,10 +195,11 @@ end
 
 function cudnnGetConvolutionBackwardFilterWorkspaceSize(dw::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
                                                         handle=libcudnn_handle[], algo=0, padding=0, stride=1,
-                                                        upscale=1, mode=0, sizeInBytes = 0) where {T,N}
+                                                        upscale=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, upscale, mode)
-    cudnnGetConvolutionBackwardFilterWorkspaceSize(handle, TensorDesc(x), TensorDesc(dy), cd, FilterDesc(dw), algo, Ref(sizeInBytes))
-    return sizeInBytes
+    sizeInBytes = Cint[0]
+    cudnnGetConvolutionBackwardFilterWorkspaceSize(handle, TensorDesc(x), TensorDesc(dy), cd, FilterDesc(dw), algo, sizeInBytes)
+    return Int(sizeInBytes[])
 end
 
 function cudnnPoolingForward(handle,poolingDesc,alpha,xDesc,x,beta,yDesc,y)

--- a/src/dnn/nnlib.jl
+++ b/src/dnn/nnlib.jl
@@ -61,29 +61,29 @@ end
 
 function conv!(y::A, x::A, w::A;
                pad = 0, stride = 1, mode = 0,
-               alpha = 1, dilation = 1, workSpace = C_NULL,
-               workSpaceSizeInBytes = 0) where A<:CuArray{<:CUDNNFloat}
+               alpha = 1, dilation = 1, workspace::Union{CuVector, Nothing} = nothing,
+               workspaceSizeInBytes::Int = 0) where A<:CuArray{<:CUDNNFloat}
   all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
   cudnnConvolutionForward(y, x, w, padding=pad, stride=stride, mode=mode, alpha=alpha,
-                          workSpace=workSpace, workSpaceSizeInBytes=workSpaceSizeInBytes)
+                          workSpace=workspace, workSpaceSizeInBytes=workspaceSizeInBytes)
 end
 
 function ∇conv_filter!(dw::A, dy::A, x::A, w::A;
                        pad = 0, stride = 1, mode = 0,
-                       alpha = 1, dilation = 1, workSpace = C_NULL,
-                       workSpaceSizeInBytes = 0) where A<:CuArray{<:CUDNNFloat}
+                       alpha = 1, dilation = 1, workspace::Union{CuVector, Nothing} = nothing,
+                       workSpacesizeInBytes::Int = 0) where A<:CuArray{<:CUDNNFloat}
   all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
   cudnnConvolutionBackwardFilter(dw, x, w, dy, padding=pad, stride=stride, mode=mode, alpha=alpha,
-                                 workSpace=workSpace, workSpaceSizeInBytes=workSpaceSizeInBytes)
+                                 workSpace=workspace, workSpaceSizeInBytes=workspaceSizeInBytes)
 end
 
 function ∇conv_data!(dx::A, dy::A, x::A, w::A;
                      pad = 0, stride = 1, mode = 0,
-                     alpha = 1, dilation = 1, workSpace = C_NULL,
-                     workSpaceSizeInBytes = 0) where A<:CuArray{<:CUDNNFloat}
+                     alpha = 1, dilation = 1, workspace::Union{CuVector, Nothing} = nothing,
+                     workspaceSizeInBytes = 0) where A<:CuArray{<:CUDNNFloat}
   all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
   cudnnConvolutionBackwardData(dx, x, w, dy, padding=pad, stride=stride, mode=mode, alpha=alpha,
-                               workSpace=workSpace, workSpaceSizeInBytes=workSpaceSizeInBytes)
+                               workSpace=workspace, workSpaceSizeInBytes=workspaceSizeInBytes)
 end
 
 

--- a/src/dnn/nnlib.jl
+++ b/src/dnn/nnlib.jl
@@ -68,12 +68,14 @@ getconvworkspace(bytes) =
 
 function conv!(y::A, x::A, w::A;
                pad = 0, stride = 1, mode = 0,
-               alpha = 1, dilation = 1, workspace = nothing,
-               workspaceSizeInBytes = 0, algo = 0) where A<:CuArray{<:CUDNNFloat}
+               alpha = 1, dilation = 1, workspace::Union{CuVector, Nothing} = nothing,
+               algo = 0) where A<:CuArray{<:CUDNNFloat}
   all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
-  if workspace == nothing
+  if workspace === nothing
     workspaceSizeInBytes = cudnnGetConvolutionForwardWorkspaceSize(y, x, w, padding = pad, stride = stride, algo = algo, mode = mode)
     workspace = workspaceSizeInBytes != 0 ? getconvworkspace(workspaceSizeInBytes) : workspace
+  else
+    workspaceSizeInBytes = length(workspace[])
   end
   cudnnConvolutionForward(y, x, w, padding=pad, stride=stride, mode=mode, alpha=alpha, algo = algo,
                           workSpace=workspace, workSpaceSizeInBytes=workspaceSizeInBytes)
@@ -81,12 +83,14 @@ end
 
 function ∇conv_filter!(dw::A, dy::A, x::A, w::A;
                        pad = 0, stride = 1, mode = 0,
-                       alpha = 1, dilation = 1, workspace = nothing,
-                       workSpacesizeInBytes = 0, algo = 0) where A<:CuArray{<:CUDNNFloat}
+                       alpha = 1, dilation = 1, workspace::Union{CuVector, Nothing} = nothing,
+                       algo = 0) where A<:CuArray{<:CUDNNFloat}
   all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
-  if workspace == nothing
+  if workspace === nothing
     workspaceSizeInBytes = cudnnGetConvolutionBackwardFilterWorkspaceSize(dw, x, w, dy, padding = pad, stride = stride, algo = algo, mode = mode)
     workspace = workspaceSizeInBytes != 0 ? getconvworkspace(workspaceSizeInBytes) : workspace
+  else
+    workspaceSizeInBytes = length(workspace[])
   end
   cudnnConvolutionBackwardFilter(dw, x, w, dy, padding=pad, stride=stride, mode=mode, alpha=alpha, algo = algo,
                                  workSpace=workspace, workSpaceSizeInBytes=workspaceSizeInBytes)
@@ -94,12 +98,14 @@ end
 
 function ∇conv_data!(dx::A, dy::A, x::A, w::A;
                      pad = 0, stride = 1, mode = 0,
-                     alpha = 1, dilation = 1, workspace = nothing,
-                     workspaceSizeInBytes = 0, algo = 0) where A<:CuArray{<:CUDNNFloat}
+                     alpha = 1, dilation = 1, workspace::Union{CuVector, Nothing} = nothing,
+                     algo = 0) where A<:CuArray{<:CUDNNFloat}
   all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
-  if workspace == nothing
+  if workspace === nothing
     workspaceSizeInBytes = cudnnGetConvolutionBackwardDataWorkspaceSize(dx, x, w, dy, padding = pad, stride = stride, algo = algo, mode = mode)
     workspace = workspaceSizeInBytes != 0 ? getconvworkspace(workspaceSizeInBytes) : workspace
+  else
+    workspaceSizeInBytes = length(workspace[])
   end
   cudnnConvolutionBackwardData(dx, x, w, dy, padding=pad, stride=stride, mode=mode, alpha=alpha, algo = algo,
                                workSpace=workspace, workSpaceSizeInBytes=workspaceSizeInBytes)

--- a/src/dnn/nnlib.jl
+++ b/src/dnn/nnlib.jl
@@ -61,23 +61,29 @@ end
 
 function conv!(y::A, x::A, w::A;
                pad = 0, stride = 1, mode = 0,
-               alpha = 1, dilation = 1) where A<:CuArray{<:CUDNNFloat}
+               alpha = 1, dilation = 1, workSpace = C_NULL,
+               workSpaceSizeInBytes = 0) where A<:CuArray{<:CUDNNFloat}
   all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
-  cudnnConvolutionForward(y, x, w, padding=pad, stride=stride, mode=mode, alpha=alpha)
+  cudnnConvolutionForward(y, x, w, padding=pad, stride=stride, mode=mode, alpha=alpha,
+                          workSpace=workSpace, workSpaceSizeInBytes=workSpaceSizeInBytes)
 end
 
 function ∇conv_filter!(dw::A, dy::A, x::A, w::A;
                        pad = 0, stride = 1, mode = 0,
-                       alpha = 1, dilation = 1) where A<:CuArray{<:CUDNNFloat}
+                       alpha = 1, dilation = 1, workSpace = C_NULL,
+                       workSpaceSizeInBytes = 0) where A<:CuArray{<:CUDNNFloat}
   all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
-  cudnnConvolutionBackwardFilter(dw, x, w, dy, padding=pad, stride=stride, mode=mode, alpha=alpha)
+  cudnnConvolutionBackwardFilter(dw, x, w, dy, padding=pad, stride=stride, mode=mode, alpha=alpha,
+                                 workSpace=workSpace, workSpaceSizeInBytes=workSpaceSizeInBytes)
 end
 
 function ∇conv_data!(dx::A, dy::A, x::A, w::A;
                      pad = 0, stride = 1, mode = 0,
-                     alpha = 1, dilation = 1) where A<:CuArray{<:CUDNNFloat}
+                     alpha = 1, dilation = 1, workSpace = C_NULL,
+                     workSpaceSizeInBytes = 0) where A<:CuArray{<:CUDNNFloat}
   all(x -> x == 1, dilation) || error("Only dilation = 1 is supported in CuArrays")
-  cudnnConvolutionBackwardData(dx, x, w, dy, padding=pad, stride=stride, mode=mode, alpha=alpha)
+  cudnnConvolutionBackwardData(dx, x, w, dy, padding=pad, stride=stride, mode=mode, alpha=alpha,
+                               workSpace=workSpace, workSpaceSizeInBytes=workSpaceSizeInBytes)
 end
 
 

--- a/test/nnlib.jl
+++ b/test/nnlib.jl
@@ -24,6 +24,15 @@ info("Testing CuArrays/CUDNN")
   @test testf((x, dy) -> ∇maxpool(dy, maxpool(x, (2,2,2)), x, (2,2,2)), rand(10, 10, 10, 3, 1), rand(5, 5, 5, 3, 1))
   @test testf((x, dy) -> ∇meanpool(dy, meanpool(x, (2,2,2)), x, (2,2,2)), rand(10, 10, 10, 3, 1), rand(5, 5, 5, 3, 1))
 
+  @testset "Convolution WorkSpace Size" begin
+    x = cu(rand(10, 10, 3, 1));
+    y = cu(rand(9, 9, 4, 1));
+    w = cu(rand(2, 2, 3, 4));
+    @test CuArrays.CUDNN.cudnnGetConvolutionForwardWorkspaceSize(y, x, w, algo = 1) == 492
+    @test CuArrays.CUDNN.cudnnGetConvolutionBackwardFilterWorkspaceSize(w, x, w, y, algo = 1) == 2452
+    @test CuArrays.CUDNN.cudnnGetConvolutionBackwardDataWorkspaceSize(x, x, w, y, algo = 1) == 2784
+  end
+
   for dims in [(5,5), (5,)]
     @test testf(softmax, rand(dims))
     @test testf(∇softmax, rand(dims), rand(dims))


### PR DESCRIPTION
Adds wrappers for getting Workspace Size for Convolutions.
Example code:
```julia
using CuArrays
x = cu(rand(224,224,3,1))
y = cu(rand(224,224,10,1))
w = cu(rand(3,3,3,10))
CuArrays.CUDNN.cudnnGetConvolutionForwardWorkspaceSize(y, x, w, padding = 1, algo = 5) # 292864
CuArrays.CUDNN.cudnnGetConvolutionBackwardDataWorkspaceSize(x, x, w, y, padding = 1, algo = 5) # 93933792
CuArrays.CUDNN.cudnnGetConvolutionBackwardFilterWorkspaceSize(w, x, w, y, padding = 1, algo = 5) # 5874912
```