### PR TITLE
Cleanup broadcast implementation and printing

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -143,13 +143,9 @@ cuones(T::Type, dims...) = fill!(CuArray{T}(dims...), 1)
 cuzeros(dims...) = cuzeros(Float32, dims...)
 cuones(dims...) = cuones(Float32, dims...)
 
-Base.show(io::IO, x::CuArray) = show(io, collect(x))
-Base.show(io::IO, x::LinearAlgebra.Adjoint{<:Any,<:CuArray}) = show(io, LinearAlgebra.adjoint(collect(x.parent)))
-Base.show(io::IO, x::LinearAlgebra.Transpose{<:Any,<:CuArray}) = show(io, LinearAlgebra.transpose(collect(x.parent)))
-
-Base.show(io::IO, ::MIME"text/plain", x::CuArray) = show(io, MIME"text/plain"(), collect(x))
-Base.show(io::IO, ::MIME"text/plain", x::LinearAlgebra.Adjoint{<:Any,<:CuArray}) = show(io, MIME"text/plain"(), LinearAlgebra.adjoint(collect(x.parent)))
-Base.show(io::IO, ::MIME"text/plain", x::LinearAlgebra.Transpose{<:Any,<:CuArray}) = show(io, MIME"text/plain"(), LinearAlgebra.transpose(collect(x.parent)))
+Base.print_array(io::IO, x::CuArray) = Base.print_array(io, collect(x))
+Base.print_array(io::IO, x::LinearAlgebra.Adjoint{<:Any,<:CuArray}) = Base.print_array(io, LinearAlgebra.adjoint(collect(x.parent)))
+Base.print_array(io::IO, x::LinearAlgebra.Transpose{<:Any,<:CuArray}) = Base.print_array(io, LinearAlgebra.transpose(collect(x.parent)))
 
 import Adapt: adapt, adapt_
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -61,6 +61,9 @@ macro cufunc(ex)
   def[:body] = replace_device(def[:body])
   quote
     $(esc(MacroTools.combinedef(def)))
+    @inline function Base.Broadcast.preprocess(dest::CuArrays.CuArray, bc::Base.Broadcast.Broadcasted{Nothing,<:Any,typeof($(esc(f)))})
+      Base.Broadcast.Broadcasted{Nothing}($(esc(def[:name])), Base.Broadcast.preprocess_args(dest, bc.args), bc.axes)
+    end
     CuArrays.cufunc(::typeof($(esc(f)))) = $(esc(def[:name]))
   end
 end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -29,11 +29,10 @@ libdevice = :[
   fma, sad, dim, mul24, mul64hi, hadd, rhadd, scalbn].args
 
 for f in libdevice
-  # TODO use Broadcast.broadcasted(::ArrayStyle{<:CuArray}, ::typeof(f), args...)
   isdefined(Base, f) || continue
   @eval begin
     cufunc(::typeof(Base.$f)) = CUDAnative.$f
-    @inline preprocess(dest::CuArray, bc::Broadcasted{Nothing,<:Any,typeof(Base.$f)}) = Broadcasted{CuStyle}(CUDAnative.$f, preprocess_args(dest, bc.args), bc.axes)
+    @inline preprocess(dest::CuArray, bc::Broadcasted{Nothing,<:Any,typeof(Base.$f)}) = Broadcasted{Nothing}(CUDAnative.$f, preprocess_args(dest, bc.args), bc.axes)
   end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,6 @@ if Base.JLOptions().check_bounds == 1
 end
 
 using CuArrays, CUDAnative
-using CuArrays: @fix
 using Test
 using Random
 using LinearAlgebra
@@ -117,11 +116,14 @@ using NNlib
 @testset "Broadcast Fix" begin
   @test testf(x -> log.(x), rand(3,3))
   @test testf((x,xs) -> log.(x.+xs), 1, rand(3,3))
-  @test testf(x -> @fix(logσ.(x)), rand(5))
 
-  f(x) = @fix logσ.(x)
-  ds = Dual.(rand(5),1)
-  @test f(ds) ≈ collect(f(CuArray(ds)))
+  if CuArrays.cudnn_available()
+    @test testf(x -> logσ.(x), rand(5))
+
+    f(x) = CuArrays.@fix logσ.(x)
+    ds = Dual.(rand(5),1)
+    @test f(ds) ≈ collect(f(CuArray(ds)))
+  end
 end
 
 @testset "Reduce" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,8 +34,8 @@ end
 
 CuArrays.allowscalar(false)
 
-function testf(f, xs...; ref=f)
-  collect(f(cu.(xs)...)) ≈ collect(ref(xs...))
+function testf(f, xs...)
+  collect(f(cu.(xs)...)) ≈ collect(f(xs...))
 end
 
 using GPUArrays, GPUArrays.TestSuite
@@ -97,13 +97,12 @@ end
 end
 
 @testset "Broadcast" begin
-  @test testf((x)       -> fill!(x, 1),       rand(3,3))
-  @test testf((x, y)    -> map(+, x, y),      rand(2, 3), rand(2, 3))
-  @test testf((x)      -> CUDAnative.sin.(x), rand(2, 3);
-              ref=(x)  -> sin.(x))
-  @test testf((x)       -> 2x,                rand(2, 3))
-  @test testf((x, y)    -> x .+ y,            rand(2, 3), rand(1, 3))
-  @test testf((z, x, y) -> z .= x .+ y,       rand(2, 3), rand(2, 3), rand(2))
+  @test testf((x)       -> fill!(x, 1),  rand(3,3))
+  @test testf((x, y)    -> map(+, x, y), rand(2, 3), rand(2, 3))
+  @test testf((x)       -> sin.(x),      rand(2, 3))
+  @test testf((x)       -> 2x,      rand(2, 3))
+  @test testf((x, y)    -> x .+ y,       rand(2, 3), rand(1, 3))
+  @test testf((z, x, y) -> z .= x .+ y,  rand(2, 3), rand(2, 3), rand(2))
 end
 
 # https://github.com/JuliaGPU/CUDAnative.jl/issues/223
@@ -116,10 +115,8 @@ using ForwardDiff: Dual
 using NNlib
 
 @testset "Broadcast Fix" begin
-  @test testf(x -> CUDAnative.log.(x), rand(3,3);
-              ref=x -> log.(x))
-  @test testf((x,xs) -> CUDAnative.log.(x.+xs), 1, rand(3,3);
-              ref=(x,xs) -> log.(x.+xs))
+  @test testf(x -> log.(x), rand(3,3))
+  @test testf((x,xs) -> log.(x.+xs), 1, rand(3,3))
   @test testf(x -> @fix(logσ.(x)), rand(5))
 
   f(x) = @fix logσ.(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,12 @@ end
   @test testf((z, x, y) -> z .= x .+ y,       rand(2, 3), rand(2, 3), rand(2))
 end
 
+# https://github.com/JuliaGPU/CUDAnative.jl/issues/223
+@testset "Ref Broadcast" begin
+  foobar(idx, A) = A[idx]
+  @test CuArray([42]) == foobar.(CuArray([1]), Base.RefValue(CuArray([42])))
+end
+
 using ForwardDiff: Dual
 using NNlib
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,7 +38,6 @@ function testf(f, xs...; ref=f)
   collect(f(cu.(xs)...)) ≈ collect(ref(xs...))
 end
 
-
 using GPUArrays, GPUArrays.TestSuite
 
 @testset "CuArrays" begin
@@ -53,6 +52,19 @@ using GPUArrays, GPUArrays.TestSuite
     CuArrays.allowscalar(true)
     TestSuite.test_indexing(CuArray)
     CuArrays.allowscalar(false)
+end
+
+@testset "Showing" begin
+  io = IOBuffer()
+  A = CuArray([1])
+
+  show(io, MIME("text/plain"), A)
+  seekstart(io)
+  @test String(take!(io)) == "1-element CuArray{Int64,1}:\n 1"
+
+  show(io, MIME("text/plain"), A')
+  seekstart(io)
+  @test String(take!(io)) == "1×1 Adjoint{Int64,CuArray{Int64,1}}:\n 1"
 end
 
 @testset "Array" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CUDAnative.jl/issues/223

- By using `print_array` instead of `show` we get the smarts of the base implementation.
- Fixes the `RefValue` handling by introducing an immutable wrapper
- fixes the `preprocess` hack by using style `Nothing` 