### PR TITLE
faster mapreducedim kernel

### DIFF
--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -28,6 +28,7 @@ include("array.jl")
 include("utils.jl")
 include("indexing.jl")
 include("broadcast.jl")
+include("mapreduce.jl")
 
 include("blas/CUBLAS.jl")
 include("solver/CUSOLVER.jl")

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -1,0 +1,73 @@
+using CuArrays: @cuindex, cudims
+
+function mapreducedim_kernel_serial(f, op, R, A, range)
+    I = @cuindex R
+    newrange = map((r, i) -> r === nothing ? i : r, range, I)
+    for I′ in CartesianIndices(newrange)
+        @inbounds R[I...] = op(R[I...], f(A[I′]))
+    end
+    return
+end
+
+@inline function reduce_block(arr::CuDeviceArray, op)
+    sync_threads()
+    len = blockDim().x
+    while len != 1
+        sync_threads()
+        skip = (len + 1) >> 1
+        reduce_to = threadIdx().x - skip
+        if 0 < reduce_to <= (len >> 1)
+            arr[reduce_to] = op(arr[reduce_to], arr[threadIdx().x])
+        end
+        len = skip
+    end
+    sync_threads()
+end
+
+function mapreducedim_kernel_parallel(f, op, R::CuDeviceArray{T}, A::CuDeviceArray{T},
+                             CIS, Rlength, Slength) where {T}
+    for Ri_base in 0:(gridDim().x * blockDim().y):(Rlength-1)
+        Ri = Ri_base + (blockIdx().x - 1) * blockDim().y + threadIdx().y
+        Ri > Rlength && return
+        RI = Tuple(CartesianIndices(R)[Ri])
+        S = @cuStaticSharedMem(T, 1024)
+        Si_folded_base = (threadIdx().y - 1) * blockDim().x
+        Si_folded = Si_folded_base + threadIdx().x
+        # serial reduction of A into S by Slength ÷ xthreads
+        for Si_base in 0:blockDim().x:(Slength-1)
+            Si = Si_base + threadIdx().x
+            Si > Slength && break
+            SI = Tuple(CIS[Si])
+            AI = ifelse.(size(R) .== 1, SI, RI)
+            if Si_base == 0
+                S[Si_folded] = f(A[AI...])
+            else
+                S[Si_folded] = op(S[Si_folded], f(A[AI...]))
+            end
+        end
+        # block-parallel reduction of S to S[1] by xthreads
+        reduce_block(view(S, (Si_folded_base + 1):1024), op)
+        # reduce S[1] into R
+        threadIdx().x == 1 && (R[Ri] = op(R[Ri], S[Si_folded]))
+    end
+end
+
+function Base._mapreducedim!(f, op, R::CuArray{T}, A::CuArray{T}) where {T}
+    Rlength = length(R)
+    Ssize = ifelse.(size(R) .== 1, size(A), 1)
+    Slength = prod(Ssize)
+    outer_thr = min(nextpow(2, Rlength ÷ 512 + 1), 1024)
+    inner_thr = min(1024 ÷ outer_thr, Slength)
+    if inner_thr < 8 # we can saturate the GPU with serial reduction
+        range = ifelse.(length.(axes(R)) .== 1, axes(A), nothing)
+        blk, thr = cudims(R)
+        @cuda(blocks=blk, threads=thr,
+              mapreducedim_kernel_serial(f, op, R, A, range))
+    else
+        CIS = CartesianIndices(Ssize)
+        blk, thr = (Rlength - 1) ÷ outer_thr + 1, (inner_thr, outer_thr, 1)
+        @cuda(blocks=blk, threads=thr,
+              mapreducedim_kernel_parallel(f, op, R, A, CIS, Rlength, Slength))
+    end
+    return R
+end


### PR DESCRIPTION
The algorithm here is to distribute 1024 threads/block among the inner
(reduction) and outer (map) dimensions; the remaining outer dimensions
get scheduled as the block grid. If fewer than 8 threads would be
dedicated to the inner dimension (because the outer dimension is much
larger) then we revert to the original kernel (which has the advantage
that it doesn't need to copy data to and from shared memory).

I'm now using static shared memory, so this is potentially portable to
GPUArrays. I don't think I'll get a chance to do that in the next couple
days, so I'd recommend merging it here first.

Benchmarks below (`serial` is the old kernel; `parallel` is the new kernel
with block-parallel reduction; `polyalgo` is the final version that chooses
between them):
```
from (2, 2) to (2, 1):
         CPU:   30.045 ns (0 allocations: 0 bytes)
  serial GPU:   13.876 μs (28 allocations: 864 bytes)
parallel GPU:   15.359 μs (31 allocations: 1.16 KiB)
polyalgo GPU:   14.004 μs (28 allocations: 864 bytes)
from (1024, 1024) to (1024, 1):
         CPU:  268.191 μs (0 allocations: 0 bytes)
  serial GPU:  216.220 μs (28 allocations: 864 bytes)
parallel GPU:   42.415 μs (39 allocations: 1.28 KiB)
polyalgo GPU:   42.238 μs (39 allocations: 1.28 KiB)
from (4096, 4096) to (4096, 1):
         CPU:   12.739 ms (0 allocations: 0 bytes)
  serial GPU:    1.497 ms (28 allocations: 864 bytes)
parallel GPU:  234.669 μs (39 allocations: 1.28 KiB)
polyalgo GPU:  234.497 μs (39 allocations: 1.28 KiB)
from (32768, 32768) to (32768, 1):
         CPU:    1.199  s (0 allocations: 0 bytes)
  serial GPU:   13.838 ms (28 allocations: 864 bytes)
parallel GPU:   13.669 ms (39 allocations: 1.28 KiB)
polyalgo GPU:   13.669 ms (39 allocations: 1.28 KiB)
from (1048576, 1024) to (1048576, 1):
         CPU:    1.200  s (0 allocations: 0 bytes)
  serial GPU:    5.452 ms (29 allocations: 880 bytes)
parallel GPU:   10.320 ms (40 allocations: 1.30 KiB)
polyalgo GPU:    5.451 ms (29 allocations: 880 bytes)
from (1024, 1048576) to (1024, 1):
         CPU:  692.394 ms (0 allocations: 0 bytes)
  serial GPU:  378.194 ms (28 allocations: 864 bytes)
parallel GPU:   12.487 ms (39 allocations: 1.28 KiB)
polyalgo GPU:   12.535 ms (39 allocations: 1.28 KiB)
from (32, 33554432) to (32, 1):
         CPU:  699.446 ms (0 allocations: 0 bytes)
  serial GPU:   11.362  s (28 allocations: 864 bytes)
parallel GPU:   25.778 ms (35 allocations: 1.22 KiB)
polyalgo GPU:   25.776 ms (35 allocations: 1.22 KiB)
from (33554432, 32) to (33554432, 1):
         CPU:    1.825  s (0 allocations: 0 bytes)
  serial GPU:    6.051 ms (29 allocations: 880 bytes)
parallel GPU:   11.234 ms (36 allocations: 1.23 KiB)
polyalgo GPU:    6.052 ms (29 allocations: 880 bytes)
```