### PR TITLE
Remove redundant getindex and setindex! methods covered by GPUArrays methods

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -7,10 +7,6 @@ function _getindex(xs::CuArray{T}, i::Integer) where T
   return Mem.download(T, buf)[1]
 end
 
-function Base.getindex(xs::CuArray{T}, i::Integer) where T
-  _getindex(xs, i)
-end
-
 function Base.getindex(xs::CuArray{T}, i::UnitRange) where T
   CuVector{T}(xs.buf, xs.offset+(i.start-1)*sizeof(T), (i.stop-i.start+1,))
 end
@@ -19,9 +15,3 @@ function _setindex!(xs::CuArray{T}, v::T, i::Integer) where T
   buf = Mem.view(buffer(xs), (i-1)*sizeof(T))
   Mem.upload!(buf, T[v])
 end
-
-function Base.setindex!(xs::CuArray{T}, v::T, i::Integer) where T
-  _setindex!(xs, v, i)
-end
-
-Base.setindex!(xs::CuArray, v, i::Integer) = xs[i] = convert(eltype(xs), v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,9 @@ end
   @test collect(cu[1, 2, 3]) == [1, 2, 3]
   @test collect(cu([1, 2, 3])) == [1, 2, 3]
   @test testf(vec, rand(5,3))
+  # Check that allowscalar works
+  @test_throws ErrorException xs[1]
+  @test_throws ErrorException xs[1] = 1
 end
 
 @testset "Broadcast" begin


### PR DESCRIPTION
Fixes an issue with `allowscalar` not having an effect for `CuArrays`.