### PR TITLE
Use `broadcasted` instead of `preprocess`

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -10,7 +10,7 @@ end
 # to variants that are valid on the GPU, as an example we need to convert CuArray to CuDeviceArray
 cudaconvert(bc::Broadcasted{Style}) where Style = Broadcasted{Style}(bc.f, map(cudaconvert, bc.args), bc.axes)
 cudaconvert(ex::Extruded) = Extruded(cudaconvert(ex.x), ex.keeps, ex.defaults)
-cudaconvert(x::LinearAlgebra.Transpose{<:Any,<:CuArray}) = LinearAlgebra.Transpose(cudaconvert(x.vec))
+cudaconvert(x::LinearAlgebra.Transpose{<:Any,<:CuArray}) = LinearAlgebra.Transpose(cudaconvert(x.parent))
 
 # Ref{CuArray} is invalid for GPU codegen
 # see https://github.com/JuliaGPU/CUDAnative.jl/issues/223

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,4 +1,4 @@
-import Base.Broadcast: Broadcasted, Extruded, BroadcastStyle, ArrayStyle, preprocess, preprocess_args
+import Base.Broadcast: Broadcasted, Extruded, BroadcastStyle, ArrayStyle
 
 BroadcastStyle(::Type{<:CuArray}) = ArrayStyle{CuArray}()
 
@@ -25,8 +25,8 @@ cudaconvert(r::Ref) = CuRefValue(cudaconvert(r[]))
 
 cufunc(f) = f
 
-@inline preprocess(dest::CuArray, bc::Broadcasted{Nothing}) =
-  Broadcasted{Nothing}(cufunc(bc.f), preprocess_args(dest, bc.args), bc.axes)
+Broadcast.broadcasted(::ArrayStyle{CuArray}, f, args...) =
+  Broadcasted{ArrayStyle{CuArray}}(cufunc(f), args, nothing)
 
 libdevice = :[
   cos, cospi, sin, sinpi, tan, acos, asin, atan,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ end
   @test testf((x)       -> fill!(x, 1),  rand(3,3))
   @test testf((x, y)    -> map(+, x, y), rand(2, 3), rand(2, 3))
   @test testf((x)       -> sin.(x),      rand(2, 3))
+  @test testf((x)       -> log.(x) .+ 1, rand(2, 3))
   @test testf((x)       -> 2x,           rand(2, 3))
   @test testf((x, y)    -> x .+ y,       rand(2, 3), rand(1, 3))
   @test testf((z, x, y) -> z .= x .+ y,  rand(2, 3), rand(2, 3), rand(2))


### PR DESCRIPTION
I'm not sure what the motivation for using `preprocess` was, but the current implementation does not actually work (e.g. `log.(xs) .+ 1`). Aside from that it means that the fix is not compatible with `Broadcast.flatten`, which is useful for many things.