### PR TITLE
Allocate new array copies when slicing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/array.jl
+++ b/src/array.jl
@@ -161,9 +161,8 @@ cu(xs) = adapt(CuArray{Float32}, xs)
 
 Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
 
+
 # Generic linear algebra routines
-
-
 
 function LinearAlgebra.tril!(A::CuMatrix{T}, d::Integer = 0) where T
     function kernel!(_A, _d)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,7 +1,5 @@
 import GPUArrays: allowscalar, @allowscalar
 
-Base.IndexStyle(::Type{<:CuArray}) = IndexLinear()
-
 function _getindex(xs::CuArray{T}, i::Integer) where T
   buf = Mem.view(buffer(xs), (i-1)*sizeof(T))
   return Mem.download(T, buf)[1]

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -5,10 +5,6 @@ function _getindex(xs::CuArray{T}, i::Integer) where T
   return Mem.download(T, buf)[1]
 end
 
-function Base.getindex(xs::CuArray{T}, i::UnitRange) where T
-  CuVector{T}(xs.buf, xs.offset+(i.start-1)*sizeof(T), (i.stop-i.start+1,))
-end
-
 function _setindex!(xs::CuArray{T}, v::T, i::Integer) where T
   buf = Mem.view(buffer(xs), (i-1)*sizeof(T))
   Mem.upload!(buf, T[v])

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -92,7 +92,7 @@ mutable struct PoolStats
 end
 const pool_stats = PoolStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 Base.copy(stats::PoolStats) =
-  PoolStats((getfield(stats, field) for field in fieldnames(stats))...)
+  PoolStats((getfield(stats, field) for field in fieldnames(PoolStats))...)
 
 function __init_memory__()
   create_pools(30) # up to 512 MiB

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,22 +28,11 @@ CuArrays.allowscalar(false)
 
 testf(f, xs...) = GPUArrays.TestSuite.compare(f, CuArray, xs...)
 
-using GPUArrays, GPUArrays.TestSuite
+using GPUArrays
 
 @testset "CuArrays" begin
 @testset "GPUArray Testsuite" begin
-    TestSuite.test_construction(CuArray)
-    TestSuite.test_gpuinterface(CuArray)
-    TestSuite.test_indexing(CuArray)
-    TestSuite.test_io(CuArray)
-    TestSuite.test_base(CuArray)
-    #TestSuite.test_vectors(CuArray)
-    TestSuite.test_mapreduce(CuArray)
-    TestSuite.test_broadcasting(CuArray)
-    TestSuite.test_linalg(CuArray)
-    TestSuite.test_fft(CuArray)
-    TestSuite.test_blas(CuArray)
-    TestSuite.test_random(CuArray)
+  GPUArrays.test(CuArray)
 end
 
 @testset "Memory" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,14 +119,16 @@ end
 end
 
 @testset "Slices" begin
-  x = cu([1:10;])
-  y = x[6:10]
-  @test x.buf == y.buf
-  @test collect(y) == [6, 7, 8, 9, 10]
-  CuArrays._setindex!(y, -1f0, 3)
-  @test collect(y) == [6, 7, -1, 9, 10]
-  @test collect(x) == [1, 2, 3, 4, 5, 6, 7, -1, 9, 10]
-  @test collect(CuMatrix{eltype(y)}(I, 5, 5)*y) == collect(y)
+  @test testf(rand(5)) do x
+    y = x[2:4]
+    y .= 1
+    x
+  end
+  @test testf(rand(5)) do x
+    y = view(x, 2:4)
+    y .= 1
+    x
+  end
 end
 
 @testset "$f! with diagonal $d" for (f, f!) in ((triu, triu!), (tril, tril!)),


### PR DESCRIPTION
Also adds some convenience macros to inspect the allocated memory:

```julia
julia> CuArrays.@time CuArray{Int,1}(1000000);
  0.000373 seconds (17 CPU allocations: 336 bytes) (1 GPU allocation: 7.629 MiB, 95.43% gc time of which 100.00% spent allocating)

julia> CuArrays.@time CuArray{Int,1}(1000000);
  0.000015 seconds (9 CPU allocations: 192 bytes) (1 GPU allocation: 7.629 MiB)

julia> CuArrays.@allocated CuArray{Int,1}(1)
8
```

Fixes https://github.com/JuliaGPU/CuArrays.jl/issues/127