### PR TITLE
do a late second cufunc pass for broadcast

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -8,7 +8,7 @@ end
 
 # GPUArrays.jl defines broadcast for us and we only need to ensure that Broadcast/Extruded gets converted
 # to variants that are valid on the GPU, as an example we need to convert CuArray to CuDeviceArray
-cudaconvert_ctor(f) = f
+cudaconvert_ctor(f) = cufunc(f)
 cudaconvert_ctor(::Type{T}) where T = (x...) -> T(x...)
 cudaconvert(bc::Broadcasted{Style}) where Style =
   Broadcasted{Style}(cudaconvert_ctor(bc.f), map(cudaconvert, bc.args), bc.axes)


### PR DESCRIPTION
In https://github.com/JuliaParallel/DistributedArrays.jl/pull/164 we don't have the opportunity to do early translation of `f` to `cufunc(f)` so let's do a second pass during the `cudaconvert`.