### PR TITLE
Simpler views

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -9,3 +9,7 @@ function _setindex!(xs::CuArray{T}, v::T, i::Integer) where T
   buf = Mem.view(buffer(xs), (i-1)*sizeof(T))
   Mem.upload!(buf, T[v])
 end
+
+function Base.view(xs::CuArray{T}, i::UnitRange) where T
+  CuVector{T}(xs.buf, xs.offset+(i.start-1)*sizeof(T), (i.stop-i.start+1,))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,6 +124,12 @@ end
     y .= 1
     x
   end
+  let
+    x = cu([1, 2, 3, 4, 5])
+    y = reshape(view(x, 1:3), 1, 3)
+    y[1:1] = 6
+    @test x[1:1] == cu([6])
+  end
 end
 
 @testset "$f! with diagonal $d" for (f, f!) in ((triu, triu!), (tril, tril!)),


### PR DESCRIPTION
Avoids the View wrapper when we can just create a new CuArray. Useful in particular for creating shared views that can be reshaped and such.