### PR TITLE
Deprecate old module names.

### DIFF
--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -39,6 +39,8 @@ libcufft !== nothing    && include("fft/CUFFT.jl")
 libcurand !== nothing   && include("rand/CURAND.jl")
 libcudnn !== nothing    && include("dnn/CUDNN.jl")
 
+include("deprecated.jl")
+
 function __init__()
     if !configured
         @warn("CuArrays.jl has not been successfully built, and will not work properly.")

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,6 @@
+# Deprecated functionality
+
+import Base: @deprecate_binding
+
+@deprecate_binding BLAS CUBLAS
+@deprecate_binding FFT CUFFT


### PR DESCRIPTION
Fix #158
Ref #143

```julia
julia> using CuArrays
[ Info: Recompiling stale cache file /home/tbesard/Julia/depot/compiled/v1.0/CuArrays/7YFE0.ji for CuArrays [3a865a2d-5b23-5a0f-bc46-62713ec82fae]

julia> CuArrays.curand(Float32, 1)^C

julia> CuArrays.BLAS.mul!(cu([1]), cu([1]), cu([1]))
WARNING: CuArrays.BLAS is deprecated, use CUBLAS instead.
 in module CuArrays
1-element CuArray{Float32,1}:
 1.0
```