### PR TITLE
Accurately keep track of library handles

### DIFF
--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -59,6 +59,7 @@ function __init__()
 
         # wipe the active handles
         isdefined(CuArrays, :CUBLAS) && (CUBLAS._handle[] = C_NULL)
+        isdefined(CuArrays, :CURAND) && (CURAND._generator[] = nothing)
         isdefined(CuArrays, :CUDNN)  && (CUDNN._handle[] = C_NULL)
     end
     push!(CUDAnative.device!_listeners, callback)

--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -34,6 +34,10 @@ include("mapreduce.jl")
 
 include("gpuarray_interface.jl")
 
+# many libraries need to be initialized per-device (per-context, really, but we assume users
+# of CuArrays and/or CUDAnative only use a single context), so keep track of the active one.
+const active_context = Ref{CuContext}()
+
 libcublas !== nothing   && include("blas/CUBLAS.jl")
 libcusolver !== nothing && include("solver/CUSOLVER.jl")
 libcufft !== nothing    && include("fft/CUFFT.jl")
@@ -47,6 +51,18 @@ function __init__()
         @warn("CuArrays.jl has not been successfully built, and will not work properly.")
         @warn("Please run Pkg.build(\"CuArrays\") and restart Julia.")
         return
+    end
+
+    # update the active context when we switch devices
+    callback = (::CuDevice, ctx::CuContext) -> begin
+        active_context[] = ctx
+    end
+    push!(CUDAnative.device!_listeners, callback)
+
+    # a device might be active already
+    existing_ctx = CUDAdrv.CuCurrentContext()
+    if existing_ctx !== nothing
+        active_context[] = existing_ctx
     end
 
     __init_memory__()

--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -59,6 +59,7 @@ function __init__()
 
         # wipe the active handles
         isdefined(CuArrays, :CUBLAS) && (CUBLAS._handle[] = C_NULL)
+        isdefined(CuArrays, :CUDNN)  && (CUDNN._handle[] = C_NULL)
     end
     push!(CUDAnative.device!_listeners, callback)
 

--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -59,6 +59,7 @@ function __init__()
 
         # wipe the active handles
         isdefined(CuArrays, :CUBLAS) && (CUBLAS._handle[] = C_NULL)
+        isdefined(CuArrays, :CUSOLVER) && (CUSOLVER._dense_handle[] = C_NULL)
         isdefined(CuArrays, :CURAND) && (CURAND._generator[] = nothing)
         isdefined(CuArrays, :CUDNN)  && (CUDNN._handle[] = C_NULL)
     end

--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -56,6 +56,9 @@ function __init__()
     # update the active context when we switch devices
     callback = (::CuDevice, ctx::CuContext) -> begin
         active_context[] = ctx
+
+        # wipe the active handles
+        isdefined(CuArrays, :CUBLAS) && (CUBLAS._handle[] = C_NULL)
     end
     push!(CUDAnative.device!_listeners, callback)
 

--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -58,10 +58,10 @@ function __init__()
         active_context[] = ctx
 
         # wipe the active handles
-        isdefined(CuArrays, :CUBLAS) && (CUBLAS._handle[] = C_NULL)
+        isdefined(CuArrays, :CUBLAS)   && (CUBLAS._handle[] = C_NULL)
         isdefined(CuArrays, :CUSOLVER) && (CUSOLVER._dense_handle[] = C_NULL)
-        isdefined(CuArrays, :CURAND) && (CURAND._generator[] = nothing)
-        isdefined(CuArrays, :CUDNN)  && (CUDNN._handle[] = C_NULL)
+        isdefined(CuArrays, :CURAND)   && (CURAND._generator[] = nothing)
+        isdefined(CuArrays, :CUDNN)    && (CUDNN._handle[] = C_NULL)
     end
     push!(CUDAnative.device!_listeners, callback)
 

--- a/src/blas/CUBLAS.jl
+++ b/src/blas/CUBLAS.jl
@@ -17,8 +17,9 @@ function handle()
     if _handle[] == C_NULL
         @assert isassigned(active_context) # some other call should have initialized CUDA
         _handle[] = get!(_handles, active_context[]) do
+            context = active_context[]
             handle = cublasCreate_v2()
-            atexit(()->cublasDestroy_v2(handle))
+            atexit(()->CUDAdrv.isvalid(context) && cublasDestroy_v2(handle))
             handle
         end
     end

--- a/src/blas/CUBLAS.jl
+++ b/src/blas/CUBLAS.jl
@@ -1,57 +1,34 @@
 module CUBLAS
 
 using CUDAdrv
-using CUDAnative
+import CUDAdrv: CuStream_t
 
 using LinearAlgebra
 
-using ..CuArrays: CuArray, CuVector, CuMatrix, CuVecOrMat, libcublas, configured
+using ..CuArrays: CuArray, CuVector, CuMatrix, CuVecOrMat,
+                  libcublas, active_context
 
-include("util.jl")
 include("libcublas_types.jl")
-include("error.jl")
 
-# Typedef needed by libcublas
-const cudaStream_t = Ptr{Nothing}
+const _handles = Dict{CuContext,cublasHandle_t}()
+const _handle = Ref{cublasHandle_t}(C_NULL)
 
-include("libcublas.jl")
-
-const libcublas_handles = Dict{CuContext,cublasHandle_t}()
-const libcublas_handle = Ref{cublasHandle_t}(C_NULL)
-
-function __init__()
-    configured || return
-
-    # initialize the library when we switch devices
-    callback = (dev::CuDevice, ctx::CuContext) -> begin
-        libcublas_handle[] = get!(libcublas_handles, ctx) do
-            @debug "Initializing CUBLAS for $dev"
-            handle = Ref{cublasHandle_t}()
-            cublasCreate_v2(handle)
-            handle[]
+function handle()
+    if _handle[] == C_NULL
+        @assert isassigned(active_context) # some other call should have initialized CUDA
+        _handle[] = get!(_handles, active_context[]) do
+            handle = cublasCreate_v2()
+            atexit(()->cublasDestroy_v2(handle))
+            handle
         end
     end
-    push!(CUDAnative.device!_listeners, callback)
 
-    # a device might be active already
-    existing_ctx = CUDAdrv.CuCurrentContext()
-    if existing_ctx !== nothing
-        dev = device(existing_ctx)
-        callback(dev, existing_ctx)
-    end
-
-    # deinitialize when exiting
-    atexit() do
-        libcublas_handle[] = C_NULL
-
-        for (ctx, handle) in libcublas_handles
-            if CUDAdrv.isvalid(ctx)
-                cublasDestroy_v2(handle)
-            end
-        end
-    end
+    return _handle[]
 end
 
+include("error.jl")
+include("util.jl")
+include("libcublas.jl")
 include("wrap.jl")
 include("highlevel.jl")
 

--- a/src/blas/libcublas.jl
+++ b/src/blas/libcublas.jl
@@ -4,770 +4,1911 @@
 
 function cublasCreate_v2()
   handle = Ref{cublasHandle_t}()
-  @check ccall( (:cublasCreate_v2, libcublas), cublasStatus_t, (Ptr{cublasHandle_t},), handle)
+  @check ccall((:cublasCreate_v2, libcublas),
+               cublasStatus_t,
+               (Ptr{cublasHandle_t},),
+               handle)
   handle[]
 end
+
 function cublasDestroy_v2(handle)
-  @check ccall( (:cublasDestroy_v2, libcublas), cublasStatus_t, (cublasHandle_t,), handle)
-end
-function cublasGetVersion_v2(handle, version)
-  @check ccall( (:cublasGetVersion_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{Cint}), handle, version)
-end
-function cublasGetStream_v2(handle, streamId)
-  @check ccall( (:cublasGetStream_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{CuStream_t}), handle, streamId)
-end
-function cublasSetStream_v2(handle, streamId)
-  @check ccall( (:cublasSetStream_v2, libcublas), cublasStatus_t, (cublasHandle_t, CuStream_t), handle, streamId)
-end
-function cublasGetPointerMode_v2(handle, mode)
-  @check ccall( (:cublasGetPointerMode_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{cublasPointerMode_t}), handle, mode)
-end
-function cublasSetPointerMode_v2(handle, mode)
-  @check ccall( (:cublasSetPointerMode_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasPointerMode_t), handle, mode)
-end
-function cublasGetAtomicsMode(handle, mode)
-  @check ccall( (:cublasGetAtomicsMode, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{cublasAtomicsMode_t}), handle, mode)
-end
-function cublasSetAtomicsMode(handle, mode)
-  @check ccall( (:cublasSetAtomicsMode, libcublas), cublasStatus_t, (cublasHandle_t, cublasAtomicsMode_t), handle, mode)
-end
-function cublasSetVector(n, elemSize, x, incx, devicePtr, incy)
-  @check ccall( (:cublasSetVector, libcublas), cublasStatus_t, (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint), n, elemSize, x, incx, devicePtr, incy)
-end
-function cublasGetVector(n, elemSize, x, incx, y, incy)
-  @check ccall( (:cublasGetVector, libcublas), cublasStatus_t, (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint), n, elemSize, x, incx, y, incy)
-end
-function cublasSetMatrix(rows, cols, elemSize, A, lda, B, ldb)
-  @check ccall( (:cublasSetMatrix, libcublas), cublasStatus_t, (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint), rows, cols, elemSize, A, lda, B, ldb)
-end
-function cublasGetMatrix(rows, cols, elemSize, A, lda, B, ldb)
-  @check ccall( (:cublasGetMatrix, libcublas), cublasStatus_t, (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint), rows, cols, elemSize, A, lda, B, ldb)
-end
-function cublasSetVectorAsync(n, elemSize, hostPtr, incx, devicePtr, incy, stream)
-  @check ccall( (:cublasSetVectorAsync, libcublas), cublasStatus_t, (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t), n, elemSize, hostPtr, incx, devicePtr, incy, stream)
-end
-function cublasGetVectorAsync(n, elemSize, devicePtr, incx, hostPtr, incy, stream)
-  @check ccall( (:cublasGetVectorAsync, libcublas), cublasStatus_t, (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t), n, elemSize, devicePtr, incx, hostPtr, incy, stream)
-end
-function cublasSetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
-  @check ccall( (:cublasSetMatrixAsync, libcublas), cublasStatus_t, (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t), rows, cols, elemSize, A, lda, B, ldb, stream)
-end
-function cublasGetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
-  @check ccall( (:cublasGetMatrixAsync, libcublas), cublasStatus_t, (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t), rows, cols, elemSize, A, lda, B, ldb, stream)
-end
-function cublasXerbla(srName, info)
-  ccall( (:cublasXerbla, libcublas), Nothing, (Ptr{UInt8}, Cint), srName, info)
-end
-function cublasSnrm2_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasSnrm2_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}), handle, n, x, incx, result)
-end
-function cublasDnrm2_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasDnrm2_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}), handle, n, x, incx, result)
-end
-function cublasScnrm2_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasScnrm2_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat}), handle, n, x, incx, result)
-end
-function cublasDznrm2_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasDznrm2_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble}), handle, n, x, incx, result)
-end
-function cublasSdot_v2(handle, n, x, incx, y, incy, result)
-  @check ccall( (:cublasSdot_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}), handle, n, x, incx, y, incy, result)
-end
-function cublasDdot_v2(handle, n, x, incx, y, incy, result)
-  @check ccall( (:cublasDdot_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}), handle, n, x, incx, y, incy, result)
-end
-function cublasCdotu_v2(handle, n, x, incx, y, incy, result)
-  @check ccall( (:cublasCdotu_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}), handle, n, x, incx, y, incy, result)
-end
-function cublasCdotc_v2(handle, n, x, incx, y, incy, result)
-  @check ccall( (:cublasCdotc_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}), handle, n, x, incx, y, incy, result)
-end
-function cublasZdotu_v2(handle, n, x, incx, y, incy, result)
-  @check ccall( (:cublasZdotu_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}), handle, n, x, incx, y, incy, result)
-end
-function cublasZdotc_v2(handle, n, x, incx, y, incy, result)
-  @check ccall( (:cublasZdotc_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}), handle, n, x, incx, y, incy, result)
-end
-function cublasSscal_v2(handle, n, alpha, x, incx)
-  @check ccall( (:cublasSscal_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, n, alpha, x, incx)
-end
-function cublasDscal_v2(handle, n, alpha, x, incx)
-  @check ccall( (:cublasDscal_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, n, alpha, x, incx)
-end
-function cublasCscal_v2(handle, n, alpha, x, incx)
-  @check ccall( (:cublasCscal_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, n, alpha, x, incx)
-end
-function cublasCsscal_v2(handle, n, alpha, x, incx)
-  @check ccall( (:cublasCsscal_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Ptr{cuComplex}, Cint), handle, n, alpha, x, incx)
-end
-function cublasZscal_v2(handle, n, alpha, x, incx)
-  @check ccall( (:cublasZscal_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, n, alpha, x, incx)
-end
-function cublasZdscal_v2(handle, n, alpha, x, incx)
-  @check ccall( (:cublasZdscal_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint), handle, n, alpha, x, incx)
-end
-function cublasSaxpy_v2(handle, n, alpha, x, incx, y, incy)
-  @check ccall( (:cublasSaxpy_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, n, alpha, x, incx, y, incy)
-end
-function cublasDaxpy_v2(handle, n, alpha, x, incx, y, incy)
-  @check ccall( (:cublasDaxpy_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, n, alpha, x, incx, y, incy)
-end
-function cublasCaxpy_v2(handle, n, alpha, x, incx, y, incy)
-  @check ccall( (:cublasCaxpy_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, n, alpha, x, incx, y, incy)
-end
-function cublasZaxpy_v2(handle, n, alpha, x, incx, y, incy)
-  @check ccall( (:cublasZaxpy_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, n, alpha, x, incx, y, incy)
-end
-function cublasScopy_v2(handle, n, x, incx, y, incy)
-  @check ccall( (:cublasScopy_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, n, x, incx, y, incy)
-end
-function cublasDcopy_v2(handle, n, x, incx, y, incy)
-  @check ccall( (:cublasDcopy_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, n, x, incx, y, incy)
-end
-function cublasCcopy_v2(handle, n, x, incx, y, incy)
-  @check ccall( (:cublasCcopy_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, n, x, incx, y, incy)
-end
-function cublasZcopy_v2(handle, n, x, incx, y, incy)
-  @check ccall( (:cublasZcopy_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, n, x, incx, y, incy)
-end
-function cublasSswap_v2(handle, n, x, incx, y, incy)
-  @check ccall( (:cublasSswap_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, n, x, incx, y, incy)
-end
-function cublasDswap_v2(handle, n, x, incx, y, incy)
-  @check ccall( (:cublasDswap_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, n, x, incx, y, incy)
-end
-function cublasCswap_v2(handle, n, x, incx, y, incy)
-  @check ccall( (:cublasCswap_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, n, x, incx, y, incy)
-end
-function cublasZswap_v2(handle, n, x, incx, y, incy)
-  @check ccall( (:cublasZswap_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, n, x, incx, y, incy)
-end
-function cublasIsamax_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasIsamax_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cint}), handle, n, x, incx, result)
-end
-function cublasIdamax_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasIdamax_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cint}), handle, n, x, incx, result)
-end
-function cublasIcamax_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasIcamax_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cint}), handle, n, x, incx, result)
-end
-function cublasIzamax_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasIzamax_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cint}), handle, n, x, incx, result)
-end
-function cublasIsamin_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasIsamin_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cint}), handle, n, x, incx, result)
-end
-function cublasIdamin_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasIdamin_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cint}), handle, n, x, incx, result)
-end
-function cublasIcamin_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasIcamin_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cint}), handle, n, x, incx, result)
-end
-function cublasIzamin_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasIzamin_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cint}), handle, n, x, incx, result)
-end
-function cublasSasum_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasSasum_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}), handle, n, x, incx, result)
-end
-function cublasDasum_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasDasum_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}), handle, n, x, incx, result)
-end
-function cublasScasum_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasScasum_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat}), handle, n, x, incx, result)
-end
-function cublasDzasum_v2(handle, n, x, incx, result)
-  @check ccall( (:cublasDzasum_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble}), handle, n, x, incx, result)
-end
-function cublasSrot_v2(handle, n, x, incx, y, incy, c, s)
-  @check ccall( (:cublasSrot_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}), handle, n, x, incx, y, incy, c, s)
-end
-function cublasDrot_v2(handle, n, x, incx, y, incy, c, s)
-  @check ccall( (:cublasDrot_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}), handle, n, x, incx, y, incy, c, s)
-end
-function cublasCrot_v2(handle, n, x, incx, y, incy, c, s)
-  @check ccall( (:cublasCrot_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat}, Ptr{cuComplex}), handle, n, x, incx, y, incy, c, s)
-end
-function cublasCsrot_v2(handle, n, x, incx, y, incy, c, s)
-  @check ccall( (:cublasCsrot_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat}, Ptr{Cfloat}), handle, n, x, incx, y, incy, c, s)
-end
-function cublasZrot_v2(handle, n, x, incx, y, incy, c, s)
-  @check ccall( (:cublasZrot_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}), handle, n, x, incx, y, incy, c, s)
-end
-function cublasZdrot_v2(handle, n, x, incx, y, incy, c, s)
-  @check ccall( (:cublasZdrot_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble}, Ptr{Cdouble}), handle, n, x, incx, y, incy, c, s)
-end
-function cublasSrotg_v2(handle, a, b, c, s)
-  @check ccall( (:cublasSrotg_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}), handle, a, b, c, s)
-end
-function cublasDrotg_v2(handle, a, b, c, s)
-  @check ccall( (:cublasDrotg_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), handle, a, b, c, s)
-end
-function cublasCrotg_v2(handle, a, b, c, s)
-  @check ccall( (:cublasCrotg_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{cuComplex}, Ptr{cuComplex}, Ptr{Cfloat}, Ptr{cuComplex}), handle, a, b, c, s)
-end
-function cublasZrotg_v2(handle, a, b, c, s)
-  @check ccall( (:cublasZrotg_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Ptr{Cdouble}, Ptr{cuDoubleComplex}), handle, a, b, c, s)
-end
-function cublasSrotm_v2(handle, n, x, incx, y, incy, param)
-  @check ccall( (:cublasSrotm_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}), handle, n, x, incx, y, incy, param)
-end
-function cublasDrotm_v2(handle, n, x, incx, y, incy, param)
-  @check ccall( (:cublasDrotm_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}), handle, n, x, incx, y, incy, param)
-end
-function cublasSrotmg_v2(handle, d1, d2, x1, y1, param)
-  @check ccall( (:cublasSrotmg_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}), handle, d1, d2, x1, y1, param)
-end
-function cublasDrotmg_v2(handle, d1, d2, x1, y1, param)
-  @check ccall( (:cublasDrotmg_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}), handle, d1, d2, x1, y1, param)
-end
-function cublasSgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasSgemv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasDgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasDgemv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasCgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasCgemv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasZgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasZgemv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasSgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasSgbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasDgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasDgbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasCgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasCgbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasZgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasZgbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasStrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-  @check ccall( (:cublasStrmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, uplo, trans, diag, n, A, lda, x, incx)
-end
-function cublasDtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-  @check ccall( (:cublasDtrmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, uplo, trans, diag, n, A, lda, x, incx)
-end
-function cublasCtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-  @check ccall( (:cublasCtrmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, uplo, trans, diag, n, A, lda, x, incx)
-end
-function cublasZtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-  @check ccall( (:cublasZtrmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, diag, n, A, lda, x, incx)
-end
-function cublasStbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-  @check ccall( (:cublasStbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, uplo, trans, diag, n, k, A, lda, x, incx)
-end
-function cublasDtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-  @check ccall( (:cublasDtbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, uplo, trans, diag, n, k, A, lda, x, incx)
-end
-function cublasCtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-  @check ccall( (:cublasCtbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, uplo, trans, diag, n, k, A, lda, x, incx)
-end
-function cublasZtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-  @check ccall( (:cublasZtbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, diag, n, k, A, lda, x, incx)
-end
-function cublasStpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-  @check ccall( (:cublasStpmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, uplo, trans, diag, n, AP, x, incx)
-end
-function cublasDtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-  @check ccall( (:cublasDtpmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, uplo, trans, diag, n, AP, x, incx)
-end
-function cublasCtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-  @check ccall( (:cublasCtpmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, uplo, trans, diag, n, AP, x, incx)
-end
-function cublasZtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-  @check ccall( (:cublasZtpmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, diag, n, AP, x, incx)
-end
-function cublasStrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-  @check ccall( (:cublasStrsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, uplo, trans, diag, n, A, lda, x, incx)
-end
-function cublasDtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-  @check ccall( (:cublasDtrsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, uplo, trans, diag, n, A, lda, x, incx)
-end
-function cublasCtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-  @check ccall( (:cublasCtrsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, uplo, trans, diag, n, A, lda, x, incx)
-end
-function cublasZtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
-  @check ccall( (:cublasZtrsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, diag, n, A, lda, x, incx)
-end
-function cublasStpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-  @check ccall( (:cublasStpsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, uplo, trans, diag, n, AP, x, incx)
-end
-function cublasDtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-  @check ccall( (:cublasDtpsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, uplo, trans, diag, n, AP, x, incx)
-end
-function cublasCtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-  @check ccall( (:cublasCtpsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, uplo, trans, diag, n, AP, x, incx)
-end
-function cublasZtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
-  @check ccall( (:cublasZtpsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, diag, n, AP, x, incx)
-end
-function cublasStbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-  @check ccall( (:cublasStbsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, uplo, trans, diag, n, k, A, lda, x, incx)
-end
-function cublasDtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-  @check ccall( (:cublasDtbsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, uplo, trans, diag, n, k, A, lda, x, incx)
-end
-function cublasCtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-  @check ccall( (:cublasCtbsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, uplo, trans, diag, n, k, A, lda, x, incx)
-end
-function cublasZtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
-  @check ccall( (:cublasZtbsv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, diag, n, k, A, lda, x, incx)
-end
-function cublasSsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasSsymv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasDsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasDsymv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasCsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasCsymv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasZsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasZsymv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasChemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasChemv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasZhemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasZhemv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasSsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasSsbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasDsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasDsbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasChbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasChbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasZhbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-  @check ccall( (:cublasZhbmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
-end
-function cublasSspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-  @check ccall( (:cublasSspmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-end
-function cublasDspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-  @check ccall( (:cublasDspmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-end
-function cublasChpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-  @check ccall( (:cublasChpmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-end
-function cublasZhpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-  @check ccall( (:cublasZhpmv_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
-end
-function cublasSger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasSger_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, m, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasDger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasDger_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, m, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasCgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasCgeru_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, m, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasCgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasCgerc_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, m, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasZgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasZgeru_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, m, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasZgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasZgerc_v2, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, m, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasSsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
-  @check ccall( (:cublasSsyr_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, uplo, n, alpha, x, incx, A, lda)
-end
-function cublasDsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
-  @check ccall( (:cublasDsyr_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, uplo, n, alpha, x, incx, A, lda)
-end
-function cublasCsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
-  @check ccall( (:cublasCsyr_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, uplo, n, alpha, x, incx, A, lda)
-end
-function cublasZsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
-  @check ccall( (:cublasZsyr_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, uplo, n, alpha, x, incx, A, lda)
-end
-function cublasCher_v2(handle, uplo, n, alpha, x, incx, A, lda)
-  @check ccall( (:cublasCher_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, uplo, n, alpha, x, incx, A, lda)
-end
-function cublasZher_v2(handle, uplo, n, alpha, x, incx, A, lda)
-  @check ccall( (:cublasZher_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, uplo, n, alpha, x, incx, A, lda)
-end
-function cublasSspr_v2(handle, uplo, n, alpha, x, incx, AP)
-  @check ccall( (:cublasSspr_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}), handle, uplo, n, alpha, x, incx, AP)
-end
-function cublasDspr_v2(handle, uplo, n, alpha, x, incx, AP)
-  @check ccall( (:cublasDspr_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}), handle, uplo, n, alpha, x, incx, AP)
-end
-function cublasChpr_v2(handle, uplo, n, alpha, x, incx, AP)
-  @check ccall( (:cublasChpr_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{cuComplex}, Cint, Ptr{cuComplex}), handle, uplo, n, alpha, x, incx, AP)
-end
-function cublasZhpr_v2(handle, uplo, n, alpha, x, incx, AP)
-  @check ccall( (:cublasZhpr_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}), handle, uplo, n, alpha, x, incx, AP)
-end
-function cublasSsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasSsyr2_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasDsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasDsyr2_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasCsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasCsyr2_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasZsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasZsyr2_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasCher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasCher2_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasZher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-  @check ccall( (:cublasZher2_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, uplo, n, alpha, x, incx, y, incy, A, lda)
-end
-function cublasSspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
-  @check ccall( (:cublasSspr2_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}), handle, uplo, n, alpha, x, incx, y, incy, AP)
-end
-function cublasDspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
-  @check ccall( (:cublasDspr2_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}), handle, uplo, n, alpha, x, incx, y, incy, AP)
-end
-function cublasChpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
-  @check ccall( (:cublasChpr2_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}), handle, uplo, n, alpha, x, incx, y, incy, AP)
-end
-function cublasZhpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
-  @check ccall( (:cublasZhpr2_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}), handle, uplo, n, alpha, x, incx, y, incy, AP)
-end
-function cublasSgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasSgemm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasDgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasDgemm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasCgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasCgemm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasZgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasZgemm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasSsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-  @check ccall( (:cublasSsyrk_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-end
-function cublasDsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-  @check ccall( (:cublasDsyrk_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-end
-function cublasCsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-  @check ccall( (:cublasCsyrk_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-end
-function cublasZsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-  @check ccall( (:cublasZsyrk_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-end
-function cublasCherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-  @check ccall( (:cublasCherk_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{cuComplex}, Cint, Ptr{Cfloat}, Ptr{cuComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-end
-function cublasZherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-  @check ccall( (:cublasZherk_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
-end
-function cublasSsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasSsyr2k_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasDsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasDsyr2k_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasCsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasCsyr2k_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasZsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasZsyr2k_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasCher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasCher2k_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat}, Ptr{cuComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasZher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasZher2k_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasSsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasSsyrkx, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasDsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasDsyrkx, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasCsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasCsyrkx, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasZsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasZsyrkx, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasCherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasCherkx, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat}, Ptr{cuComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasZherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasZherkx, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint), handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasSsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasSsymm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasDsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasDsymm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasCsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasCsymm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasZsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasZsymm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasChemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasChemm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasZhemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-  @check ccall( (:cublasZhemm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
-end
-function cublasStrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-  @check ccall( (:cublasStrsm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-end
-function cublasDtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-  @check ccall( (:cublasDtrsm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-end
-function cublasCtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-  @check ccall( (:cublasCtrsm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-end
-function cublasZtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-  @check ccall( (:cublasZtrsm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
-end
-function cublasStrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
-  @check ccall( (:cublasStrmm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
-end
-function cublasDtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
-  @check ccall( (:cublasDtrmm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
-end
-function cublasCtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
-  @check ccall( (:cublasCtrmm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
-end
-function cublasZtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
-  @check ccall( (:cublasZtrmm_v2, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
-end
-function cublasSgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
-  @check ccall( (:cublasSgemmBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Ptr{Cfloat}}, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cfloat}, Ptr{Ptr{Cfloat}}, Cint, Cint), handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
-end
-function cublasDgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
-  @check ccall( (:cublasDgemmBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cdouble}, Ptr{Ptr{Cdouble}}, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cdouble}, Ptr{Ptr{Cdouble}}, Cint, Cint), handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
-end
-function cublasCgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
-  @check ccall( (:cublasCgemmBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Ptr{cuComplex}}, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{cuComplex}, Ptr{Ptr{cuComplex}}, Cint, Cint), handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
-end
-function cublasZgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
-  @check ccall( (:cublasZgemmBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{cuDoubleComplex}, Ptr{Ptr{cuDoubleComplex}}, Cint, Cint), handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
-end
-function cublasSgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
-  @check ccall( (:cublasSgeam, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
-end
-function cublasDgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
-  @check ccall( (:cublasDgeam, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
-end
-function cublasCgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
-  @check ccall( (:cublasCgeam, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
-end
-function cublasZgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
-  @check ccall( (:cublasZgeam, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
-end
-function cublasSgetrfBatched(handle, n, A, lda, P, info, batchSize)
-  @check ccall( (:cublasSgetrfBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint), handle, n, A, lda, P, info, batchSize)
-end
-function cublasDgetrfBatched(handle, n, A, lda, P, info, batchSize)
-  @check ccall( (:cublasDgetrfBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint), handle, n, A, lda, P, info, batchSize)
-end
-function cublasCgetrfBatched(handle, n, A, lda, P, info, batchSize)
-  @check ccall( (:cublasCgetrfBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint), handle, n, A, lda, P, info, batchSize)
-end
-function cublasZgetrfBatched(handle, n, A, lda, P, info, batchSize)
-  @check ccall( (:cublasZgetrfBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint), handle, n, A, lda, P, info, batchSize)
-end
-function cublasSgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
-  @check ccall( (:cublasSgetriBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Cint), handle, n, A, lda, P, C, ldc, info, batchSize)
-end
-function cublasDgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
-  @check ccall( (:cublasDgetriBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Cint), handle, n, A, lda, P, C, ldc, info, batchSize)
-end
-function cublasCgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
-  @check ccall( (:cublasCgetriBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Cint), handle, n, A, lda, P, C, ldc, info, batchSize)
-end
-function cublasZgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
-  @check ccall( (:cublasZgetriBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint}, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint}, Cint), handle, n, A, lda, P, C, ldc, info, batchSize)
-end
-function cublasStrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
-  @check ccall( (:cublasStrsmBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{Cfloat}, Ptr{Ptr{Cfloat}}, Cint, Ptr{Ptr{Cfloat}}, Cint, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
-end
-function cublasDtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
-  @check ccall( (:cublasDtrsmBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{Cdouble}, Ptr{Ptr{Cdouble}}, Cint, Ptr{Ptr{Cdouble}}, Cint, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
-end
-function cublasCtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
-  @check ccall( (:cublasCtrsmBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{cuComplex}, Ptr{Ptr{cuComplex}}, Cint, Ptr{Ptr{cuComplex}}, Cint, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
-end
-function cublasZtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
-  @check ccall( (:cublasZtrsmBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Cint), handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
-end
-function cublasSmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-  @check ccall( (:cublasSmatinvBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Cint), handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-end
-function cublasDmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-  @check ccall( (:cublasDmatinvBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Cint), handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-end
-function cublasCmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-  @check ccall( (:cublasCmatinvBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Cint), handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-end
-function cublasZmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-  @check ccall( (:cublasZmatinvBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint}, Cint), handle, n, A, lda, Ainv, lda_inv, info, batchSize)
-end
-function cublasSgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
-  @check ccall( (:cublasSgeqrfBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Ptr{Cfloat}}, Ptr{Cint}, Cint), handle, m, n, Aarray, lda, TauArray, info, batchSize)
-end
-function cublasDgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
-  @check ccall( (:cublasDgeqrfBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Ptr{Cdouble}}, Ptr{Cint}, Cint), handle, m, n, Aarray, lda, TauArray, info, batchSize)
-end
-function cublasCgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
-  @check ccall( (:cublasCgeqrfBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Ptr{cuComplex}}, Ptr{Cint}, Cint), handle, m, n, Aarray, lda, TauArray, info, batchSize)
-end
-function cublasZgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
-  @check ccall( (:cublasZgeqrfBatched, libcublas), cublasStatus_t, (cublasHandle_t, Cint, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Ptr{cuDoubleComplex}}, Ptr{Cint}, Cint), handle, m, n, Aarray, lda, TauArray, info, batchSize)
-end
-function cublasSgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
-  @check ccall( (:cublasSgelsBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint), handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
-end
-function cublasDgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
-  @check ccall( (:cublasDgelsBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint), handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
-end
-function cublasCgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
-  @check ccall( (:cublasCgelsBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint), handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
-end
-function cublasZgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
-  @check ccall( (:cublasZgelsBatched, libcublas), cublasStatus_t, (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint), handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
-end
-function cublasSdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
-  @check ccall( (:cublasSdgmm, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint), handle, mode, m, n, A, lda, x, incx, C, ldc)
-end
-function cublasDdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
-  @check ccall( (:cublasDdgmm, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint), handle, mode, m, n, A, lda, x, incx, C, ldc)
-end
-function cublasCdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
-  @check ccall( (:cublasCdgmm, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint), handle, mode, m, n, A, lda, x, incx, C, ldc)
-end
-function cublasZdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
-  @check ccall( (:cublasZdgmm, libcublas), cublasStatus_t, (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint), handle, mode, m, n, A, lda, x, incx, C, ldc)
-end
-function cublasStpttr(handle, uplo, n, AP, A, lda)
-  @check ccall( (:cublasStpttr, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint), handle, uplo, n, AP, A, lda)
-end
-function cublasDtpttr(handle, uplo, n, AP, A, lda)
-  @check ccall( (:cublasDtpttr, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint), handle, uplo, n, AP, A, lda)
-end
-function cublasCtpttr(handle, uplo, n, AP, A, lda)
-  @check ccall( (:cublasCtpttr, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint), handle, uplo, n, AP, A, lda)
-end
-function cublasZtpttr(handle, uplo, n, AP, A, lda)
-  @check ccall( (:cublasZtpttr, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint), handle, uplo, n, AP, A, lda)
-end
-function cublasStrttp(handle, uplo, n, A, lda, AP)
-  @check ccall( (:cublasStrttp, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}), handle, uplo, n, A, lda, AP)
-end
-function cublasDtrttp(handle, uplo, n, A, lda, AP)
-  @check ccall( (:cublasDtrttp, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}), handle, uplo, n, A, lda, AP)
-end
-function cublasCtrttp(handle, uplo, n, A, lda, AP)
-  @check ccall( (:cublasCtrttp, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}), handle, uplo, n, A, lda, AP)
-end
-function cublasZtrttp(handle, uplo, n, A, lda, AP)
-  @check ccall( (:cublasZtrttp, libcublas), cublasStatus_t, (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}), handle, uplo, n, A, lda, AP)
+  @check ccall((:cublasDestroy_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t,),
+               handle)
 end
 
-if CUDAdrv.version() ≥ v"7.5.0"   #these functions were introduced with CUDA v7.5
+function cublasGetVersion_v2(handle, version)
+  @check ccall((:cublasGetVersion_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Ptr{Cint}),
+               handle, version)
+end
+
+function cublasGetStream_v2(handle, streamId)
+  @check ccall((:cublasGetStream_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Ptr{CuStream_t}),
+               handle, streamId)
+end
+
+function cublasSetStream_v2(handle, streamId)
+  @check ccall((:cublasSetStream_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, CuStream_t),
+               handle, streamId)
+end
+
+function cublasGetPointerMode_v2(handle, mode)
+  @check ccall((:cublasGetPointerMode_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Ptr{cublasPointerMode_t}),
+               handle, mode)
+end
+
+function cublasSetPointerMode_v2(handle, mode)
+  @check ccall((:cublasSetPointerMode_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasPointerMode_t),
+               handle, mode)
+end
+
+function cublasGetAtomicsMode(handle, mode)
+  @check ccall((:cublasGetAtomicsMode, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Ptr{cublasAtomicsMode_t}),
+               handle, mode)
+end
+
+function cublasSetAtomicsMode(handle, mode)
+  @check ccall((:cublasSetAtomicsMode, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasAtomicsMode_t),
+               handle, mode)
+end
+
+function cublasSetVector(n, elemSize, x, incx, devicePtr, incy)
+  @check ccall((:cublasSetVector, libcublas),
+               cublasStatus_t,
+               (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint),
+               n, elemSize, x, incx, devicePtr, incy)
+end
+
+function cublasGetVector(n, elemSize, x, incx, y, incy)
+  @check ccall((:cublasGetVector, libcublas),
+               cublasStatus_t,
+               (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint),
+               n, elemSize, x, incx, y, incy)
+end
+
+function cublasSetMatrix(rows, cols, elemSize, A, lda, B, ldb)
+  @check ccall((:cublasSetMatrix, libcublas),
+               cublasStatus_t,
+               (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint),
+               rows, cols, elemSize, A, lda, B, ldb)
+end
+
+function cublasGetMatrix(rows, cols, elemSize, A, lda, B, ldb)
+  @check ccall((:cublasGetMatrix, libcublas),
+               cublasStatus_t,
+               (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint),
+               rows, cols, elemSize, A, lda, B, ldb)
+end
+
+function cublasSetVectorAsync(n, elemSize, hostPtr, incx, devicePtr, incy, stream)
+  @check ccall((:cublasSetVectorAsync, libcublas),
+               cublasStatus_t,
+               (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t),
+               n, elemSize, hostPtr, incx, devicePtr, incy, stream)
+end
+
+function cublasGetVectorAsync(n, elemSize, devicePtr, incx, hostPtr, incy, stream)
+  @check ccall((:cublasGetVectorAsync, libcublas),
+               cublasStatus_t,
+               (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t),
+               n, elemSize, devicePtr, incx, hostPtr, incy, stream)
+end
+
+function cublasSetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
+  @check ccall((:cublasSetMatrixAsync, libcublas),
+               cublasStatus_t,
+               (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t),
+               rows, cols, elemSize, A, lda, B, ldb, stream)
+end
+
+function cublasGetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
+  @check ccall((:cublasGetMatrixAsync, libcublas),
+               cublasStatus_t,
+               (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t),
+               rows, cols, elemSize, A, lda, B, ldb, stream)
+end
+
+function cublasXerbla(srName, info)
+  ccall((:cublasXerbla, libcublas),
+               Nothing,
+               (Ptr{UInt8}, Cint),
+               srName, info)
+end
+
+function cublasSnrm2_v2(handle, n, x, incx, result)
+  @check ccall((:cublasSnrm2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               handle, n, x, incx, result)
+end
+
+function cublasDnrm2_v2(handle, n, x, incx, result)
+  @check ccall((:cublasDnrm2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}),
+               handle, n, x, incx, result)
+end
+
+function cublasScnrm2_v2(handle, n, x, incx, result)
+  @check ccall((:cublasScnrm2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat}),
+               handle, n, x, incx, result)
+end
+
+function cublasDznrm2_v2(handle, n, x, incx, result)
+  @check ccall((:cublasDznrm2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble}),
+               handle, n, x, incx, result)
+end
+
+function cublasSdot_v2(handle, n, x, incx, y, incy, result)
+  @check ccall((:cublasSdot_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               handle, n, x, incx, y, incy, result)
+end
+
+function cublasDdot_v2(handle, n, x, incx, y, incy, result)
+  @check ccall((:cublasDdot_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}),
+               handle, n, x, incx, y, incy, result)
+end
+
+function cublasCdotu_v2(handle, n, x, incx, y, incy, result)
+  @check ccall((:cublasCdotu_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}),
+               handle, n, x, incx, y, incy, result)
+end
+
+function cublasCdotc_v2(handle, n, x, incx, y, incy, result)
+  @check ccall((:cublasCdotc_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint,
+                Ptr{cuComplex}),
+               handle, n, x, incx, y, incy, result)
+end
+
+function cublasZdotu_v2(handle, n, x, incx, y, incy, result)
+  @check ccall((:cublasZdotu_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}),
+               handle, n, x, incx, y, incy, result)
+end
+
+function cublasZdotc_v2(handle, n, x, incx, y, incy, result)
+  @check ccall((:cublasZdotc_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}),
+               handle, n, x, incx, y, incy, result)
+end
+
+function cublasSscal_v2(handle, n, alpha, x, incx)
+  @check ccall((:cublasSscal_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               handle, n, alpha, x, incx)
+end
+
+function cublasDscal_v2(handle, n, alpha, x, incx)
+  @check ccall((:cublasDscal_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               handle, n, alpha, x, incx)
+end
+
+function cublasCscal_v2(handle, n, alpha, x, incx)
+  @check ccall((:cublasCscal_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               handle, n, alpha, x, incx)
+end
+
+function cublasCsscal_v2(handle, n, alpha, x, incx)
+  @check ccall((:cublasCsscal_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Ptr{cuComplex}, Cint),
+               handle, n, alpha, x, incx)
+end
+
+function cublasZscal_v2(handle, n, alpha, x, incx)
+  @check ccall((:cublasZscal_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, n, alpha, x, incx)
+end
+
+function cublasZdscal_v2(handle, n, alpha, x, incx)
+  @check ccall((:cublasZdscal_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint),
+               handle, n, alpha, x, incx)
+end
+
+function cublasSaxpy_v2(handle, n, alpha, x, incx, y, incy)
+  @check ccall((:cublasSaxpy_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               handle, n, alpha, x, incx, y, incy)
+end
+
+function cublasDaxpy_v2(handle, n, alpha, x, incx, y, incy)
+  @check ccall((:cublasDaxpy_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               handle, n, alpha, x, incx, y, incy)
+end
+
+function cublasCaxpy_v2(handle, n, alpha, x, incx, y, incy)
+  @check ccall((:cublasCaxpy_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint,
+                Ptr{cuComplex}, Cint),
+               handle, n, alpha, x, incx, y, incy)
+end
+
+function cublasZaxpy_v2(handle, n, alpha, x, incx, y, incy)
+  @check ccall((:cublasZaxpy_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint,
+                Ptr{cuDoubleComplex}, Cint),
+               handle, n, alpha, x, incx, y, incy)
+end
+
+function cublasScopy_v2(handle, n, x, incx, y, incy)
+  @check ccall((:cublasScopy_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               handle, n, x, incx, y, incy)
+end
+
+function cublasDcopy_v2(handle, n, x, incx, y, incy)
+  @check ccall((:cublasDcopy_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               handle, n, x, incx, y, incy)
+end
+
+function cublasCcopy_v2(handle, n, x, incx, y, incy)
+  @check ccall((:cublasCcopy_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, n, x, incx, y, incy)
+end
+
+function cublasZcopy_v2(handle, n, x, incx, y, incy)
+  @check ccall((:cublasZcopy_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, n, x, incx, y, incy)
+end
+
+function cublasSswap_v2(handle, n, x, incx, y, incy)
+  @check ccall((:cublasSswap_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               handle, n, x, incx, y, incy)
+end
+
+function cublasDswap_v2(handle, n, x, incx, y, incy)
+  @check ccall((:cublasDswap_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               handle, n, x, incx, y, incy)
+end
+
+function cublasCswap_v2(handle, n, x, incx, y, incy)
+  @check ccall((:cublasCswap_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, n, x, incx, y, incy)
+end
+
+function cublasZswap_v2(handle, n, x, incx, y, incy)
+  @check ccall((:cublasZswap_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, n, x, incx, y, incy)
+end
+
+function cublasIsamax_v2(handle, n, x, incx, result)
+  @check ccall((:cublasIsamax_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cint}),
+               handle, n, x, incx, result)
+end
+
+function cublasIdamax_v2(handle, n, x, incx, result)
+  @check ccall((:cublasIdamax_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cint}),
+               handle, n, x, incx, result)
+end
+
+function cublasIcamax_v2(handle, n, x, incx, result)
+  @check ccall((:cublasIcamax_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cint}),
+               handle, n, x, incx, result)
+end
+
+function cublasIzamax_v2(handle, n, x, incx, result)
+  @check ccall((:cublasIzamax_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cint}),
+               handle, n, x, incx, result)
+end
+
+function cublasIsamin_v2(handle, n, x, incx, result)
+  @check ccall((:cublasIsamin_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cint}),
+               handle, n, x, incx, result)
+end
+
+function cublasIdamin_v2(handle, n, x, incx, result)
+  @check ccall((:cublasIdamin_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cint}),
+               handle, n, x, incx, result)
+end
+
+function cublasIcamin_v2(handle, n, x, incx, result)
+  @check ccall((:cublasIcamin_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cint}),
+               handle, n, x, incx, result)
+end
+
+function cublasIzamin_v2(handle, n, x, incx, result)
+  @check ccall((:cublasIzamin_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cint}),
+               handle, n, x, incx, result)
+end
+
+function cublasSasum_v2(handle, n, x, incx, result)
+  @check ccall((:cublasSasum_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               handle, n, x, incx, result)
+end
+
+function cublasDasum_v2(handle, n, x, incx, result)
+  @check ccall((:cublasDasum_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}),
+               handle, n, x, incx, result)
+end
+
+function cublasScasum_v2(handle, n, x, incx, result)
+  @check ccall((:cublasScasum_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat}),
+               handle, n, x, incx, result)
+end
+
+function cublasDzasum_v2(handle, n, x, incx, result)
+  @check ccall((:cublasDzasum_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble}),
+               handle, n, x, incx, result)
+end
+
+function cublasSrot_v2(handle, n, x, incx, y, incy, c, s)
+  @check ccall((:cublasSrot_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat},
+                Ptr{Cfloat}),
+               handle, n, x, incx, y, incy, c, s)
+end
+
+function cublasDrot_v2(handle, n, x, incx, y, incy, c, s)
+  @check ccall((:cublasDrot_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint,
+                Ptr{Cdouble}, Ptr{Cdouble}),
+               handle, n, x, incx, y, incy, c, s)
+end
+
+function cublasCrot_v2(handle, n, x, incx, y, incy, c, s)
+  @check ccall((:cublasCrot_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint,
+                Ptr{Cfloat}, Ptr{cuComplex}),
+               handle, n, x, incx, y, incy, c, s)
+end
+
+function cublasCsrot_v2(handle, n, x, incx, y, incy, c, s)
+  @check ccall((:cublasCsrot_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint,
+                Ptr{Cfloat}, Ptr{Cfloat}),
+               handle, n, x, incx, y, incy, c, s)
+end
+
+function cublasZrot_v2(handle, n, x, incx, y, incy, c, s)
+  @check ccall((:cublasZrot_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}),
+               handle, n, x, incx, y, incy, c, s)
+end
+
+function cublasZdrot_v2(handle, n, x, incx, y, incy, c, s)
+  @check ccall((:cublasZdrot_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{Cdouble}, Ptr{Cdouble}),
+               handle, n, x, incx, y, incy, c, s)
+end
+
+function cublasSrotg_v2(handle, a, b, c, s)
+  @check ccall((:cublasSrotg_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}),
+               handle, a, b, c, s)
+end
+
+function cublasDrotg_v2(handle, a, b, c, s)
+  @check ccall((:cublasDrotg_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
+               handle, a, b, c, s)
+end
+
+function cublasCrotg_v2(handle, a, b, c, s)
+  @check ccall((:cublasCrotg_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Ptr{cuComplex}, Ptr{cuComplex}, Ptr{Cfloat}, Ptr{cuComplex}),
+               handle, a, b, c, s)
+end
+
+function cublasZrotg_v2(handle, a, b, c, s)
+  @check ccall((:cublasZrotg_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Ptr{Cdouble},
+                Ptr{cuDoubleComplex}),
+               handle, a, b, c, s)
+end
+
+function cublasSrotm_v2(handle, n, x, incx, y, incy, param)
+  @check ccall((:cublasSrotm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               handle, n, x, incx, y, incy, param)
+end
+
+function cublasDrotm_v2(handle, n, x, incx, y, incy, param)
+  @check ccall((:cublasDrotm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint,
+                Ptr{Cdouble}),
+               handle, n, x, incx, y, incy, param)
+end
+
+function cublasSrotmg_v2(handle, d1, d2, x1, y1, param)
+  @check ccall((:cublasSrotmg_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},
+                Ptr{Cfloat}),
+               handle, d1, d2, x1, y1, param)
+end
+
+function cublasDrotmg_v2(handle, d1, d2, x1, y1, param)
+  @check ccall((:cublasDrotmg_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
+                Ptr{Cdouble}),
+               handle, d1, d2, x1, y1, param)
+end
+
+function cublasSgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasSgemv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat},
+                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasDgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasDgemv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble},
+                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasCgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasCgemv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex},
+                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex},
+                Cint),
+               handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasZgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasZgemv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasSgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasSgbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, Ptr{Cfloat},
+                Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasDgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasDgbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, Ptr{Cdouble},
+                Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasCgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasCgbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, Ptr{cuComplex},
+                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex},
+                Cint),
+               handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasZgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasZgbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasStrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
+  @check ccall((:cublasStrmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               handle, uplo, trans, diag, n, A, lda, x, incx)
+end
+
+function cublasDtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
+  @check ccall((:cublasDtrmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               handle, uplo, trans, diag, n, A, lda, x, incx)
+end
+
+function cublasCtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
+  @check ccall((:cublasCtrmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, uplo, trans, diag, n, A, lda, x, incx)
+end
+
+function cublasZtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
+  @check ccall((:cublasZtrmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, diag, n, A, lda, x, incx)
+end
+
+function cublasStbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
+  @check ccall((:cublasStbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               handle, uplo, trans, diag, n, k, A, lda, x, incx)
+end
+
+function cublasDtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
+  @check ccall((:cublasDtbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               handle, uplo, trans, diag, n, k, A, lda, x, incx)
+end
+
+function cublasCtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
+  @check ccall((:cublasCtbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, uplo, trans, diag, n, k, A, lda, x, incx)
+end
+
+function cublasZtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
+  @check ccall((:cublasZtbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, diag, n, k, A, lda, x, incx)
+end
+
+function cublasStpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
+  @check ccall((:cublasStpmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               handle, uplo, trans, diag, n, AP, x, incx)
+end
+
+function cublasDtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
+  @check ccall((:cublasDtpmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               handle, uplo, trans, diag, n, AP, x, incx)
+end
+
+function cublasCtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
+  @check ccall((:cublasCtpmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               handle, uplo, trans, diag, n, AP, x, incx)
+end
+
+function cublasZtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
+  @check ccall((:cublasZtpmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, diag, n, AP, x, incx)
+end
+
+function cublasStrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
+  @check ccall((:cublasStrsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               handle, uplo, trans, diag, n, A, lda, x, incx)
+end
+
+function cublasDtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
+  @check ccall((:cublasDtrsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               handle, uplo, trans, diag, n, A, lda, x, incx)
+end
+
+function cublasCtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
+  @check ccall((:cublasCtrsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, uplo, trans, diag, n, A, lda, x, incx)
+end
+
+function cublasZtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
+  @check ccall((:cublasZtrsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, diag, n, A, lda, x, incx)
+end
+
+function cublasStpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
+  @check ccall((:cublasStpsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               handle, uplo, trans, diag, n, AP, x, incx)
+end
+
+function cublasDtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
+  @check ccall((:cublasDtpsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               handle, uplo, trans, diag, n, AP, x, incx)
+end
+
+function cublasCtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
+  @check ccall((:cublasCtpsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               handle, uplo, trans, diag, n, AP, x, incx)
+end
+
+function cublasZtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
+  @check ccall((:cublasZtpsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, diag, n, AP, x, incx)
+end
+
+function cublasStbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
+  @check ccall((:cublasStbsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               handle, uplo, trans, diag, n, k, A, lda, x, incx)
+end
+
+function cublasDtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
+  @check ccall((:cublasDtbsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               handle, uplo, trans, diag, n, k, A, lda, x, incx)
+end
+
+function cublasCtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
+  @check ccall((:cublasCtbsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, uplo, trans, diag, n, k, A, lda, x, incx)
+end
+
+function cublasZtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
+  @check ccall((:cublasZtbsv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
+                Cint, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, diag, n, k, A, lda, x, incx)
+end
+
+function cublasSsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasSsymv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat},
+                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasDsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasDsymv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
+                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasCsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasCsymv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
+                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasZsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasZsymv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasChemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasChemv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
+                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasZhemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasZhemv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasSsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasSsbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat},
+                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasDsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasDsbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble},
+                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasChbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasChbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{cuComplex},
+                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasZhbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
+  @check ccall((:cublasZhbmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
+end
+
+function cublasSspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
+  @check ccall((:cublasSspmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat},
+                Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
+end
+
+function cublasDspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
+  @check ccall((:cublasDspmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
+                Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
+end
+
+function cublasChpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
+  @check ccall((:cublasChpmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex},
+                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
+end
+
+function cublasZhpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
+  @check ccall((:cublasZhpmv_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
+end
+
+function cublasSger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasSger_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint,
+                Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               handle, m, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasDger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasDger_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint,
+                Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               handle, m, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasCgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasCgeru_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint,
+                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, m, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasCgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasCgerc_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint,
+                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, m, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasZgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasZgeru_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, m, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasZgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasZgerc_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, m, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasSsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
+  @check ccall((:cublasSsyr_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat},
+                Cint, Ptr{Cfloat}, Cint),
+               handle, uplo, n, alpha, x, incx, A, lda)
+end
+
+function cublasDsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
+  @check ccall((:cublasDsyr_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
+                Cint, Ptr{Cdouble}, Cint),
+               handle, uplo, n, alpha, x, incx, A, lda)
+end
+
+function cublasCsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
+  @check ccall((:cublasCsyr_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
+                Cint, Ptr{cuComplex}, Cint),
+               handle, uplo, n, alpha, x, incx, A, lda)
+end
+
+function cublasZsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
+  @check ccall((:cublasZsyr_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, n, alpha, x, incx, A, lda)
+end
+
+function cublasCher_v2(handle, uplo, n, alpha, x, incx, A, lda)
+  @check ccall((:cublasCher_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{cuComplex},
+                Cint, Ptr{cuComplex}, Cint),
+               handle, uplo, n, alpha, x, incx, A, lda)
+end
+
+function cublasZher_v2(handle, uplo, n, alpha, x, incx, A, lda)
+  @check ccall((:cublasZher_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, n, alpha, x, incx, A, lda)
+end
+
+function cublasSspr_v2(handle, uplo, n, alpha, x, incx, AP)
+  @check ccall((:cublasSspr_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat},
+                Cint, Ptr{Cfloat}),
+               handle, uplo, n, alpha, x, incx, AP)
+end
+
+function cublasDspr_v2(handle, uplo, n, alpha, x, incx, AP)
+  @check ccall((:cublasDspr_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
+                Cint, Ptr{Cdouble}),
+               handle, uplo, n, alpha, x, incx, AP)
+end
+
+function cublasChpr_v2(handle, uplo, n, alpha, x, incx, AP)
+  @check ccall((:cublasChpr_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{cuComplex},
+                Cint, Ptr{cuComplex}),
+               handle, uplo, n, alpha, x, incx, AP)
+end
+
+function cublasZhpr_v2(handle, uplo, n, alpha, x, incx, AP)
+  @check ccall((:cublasZhpr_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble},
+                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}),
+               handle, uplo, n, alpha, x, incx, AP)
+end
+
+function cublasSsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasSsyr2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat},
+                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasDsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasDsyr2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
+                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasCsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasCsyr2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
+                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasZsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasZsyr2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint,
+                Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasCher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasCher2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
+                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasZher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+  @check ccall((:cublasZher2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint,
+                Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, n, alpha, x, incx, y, incy, A, lda)
+end
+
+function cublasSspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
+  @check ccall((:cublasSspr2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint,
+                Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               handle, uplo, n, alpha, x, incx, y, incy, AP)
+end
+
+function cublasDspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
+  @check ccall((:cublasDspr2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
+                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}),
+               handle, uplo, n, alpha, x, incx, y, incy, AP)
+end
+
+function cublasChpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
+  @check ccall((:cublasChpr2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
+                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}),
+               handle, uplo, n, alpha, x, incx, y, incy, AP)
+end
+
+function cublasZhpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
+  @check ccall((:cublasZhpr2_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint,
+                Ptr{cuDoubleComplex}),
+               handle, uplo, n, alpha, x, incx, y, incy, AP)
+end
+
+function cublasSgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasSgemm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat},
+                Cint),
+               handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasDgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasDgemm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble},
+                Ptr{Cdouble}, Cint),
+               handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasCgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasCgemm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex},
+                Ptr{cuComplex}, Cint),
+               handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasZgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasZgemm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasSsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+  @check ccall((:cublasSsyrk_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+end
+
+function cublasDsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+  @check ccall((:cublasDsyrk_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+end
+
+function cublasCsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+  @check ccall((:cublasCsyrk_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+end
+
+function cublasZsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+  @check ccall((:cublasZsyrk_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+end
+
+function cublasCherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+  @check ccall((:cublasCherk_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{Cfloat}, Ptr{cuComplex}, Cint, Ptr{Cfloat}, Ptr{cuComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+end
+
+function cublasZherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+  @check ccall((:cublasZherk_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble},
+                Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
+end
+
+function cublasSsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasSsyr2k_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat},
+                Ptr{Cfloat}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasDsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasDsyr2k_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble},
+                Ptr{Cdouble}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasCsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasCsyr2k_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex},
+                Ptr{cuComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasZsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasZsyr2k_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasCher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasCher2k_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat},
+                Ptr{cuComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasZher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasZher2k_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasSsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasSsyrkx, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat},
+                Ptr{Cfloat}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasDsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasDsyrkx, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble},
+                Ptr{Cdouble}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasCsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasCsyrkx, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, 
+                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex},
+                Ptr{cuComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasZsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasZsyrkx, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasCherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasCherkx, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat},
+                Ptr{cuComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasZherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasZherkx, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasSsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasSsymm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
+                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat},
+                Ptr{Cfloat}, Cint),
+               handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasDsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasDsymm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
+                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble},
+                Ptr{Cdouble}, Cint),
+               handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasCsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasCsymm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
+                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex},
+                Ptr{cuComplex}, Cint),
+               handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasZsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasZsymm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasChemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasChemm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
+                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex},
+                Ptr{cuComplex}, Cint),
+               handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasZhemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+  @check ccall((:cublasZhemm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function cublasStrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
+  @check ccall((:cublasStrsm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat},
+                Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
+end
+
+function cublasDtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
+  @check ccall((:cublasDtrsm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint,
+                Ptr{Cdouble}, Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
+end
+
+function cublasCtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
+  @check ccall((:cublasCtrsm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint,
+                Ptr{cuComplex}, Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
+end
+
+function cublasZtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
+  @check ccall((:cublasZtrsm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
+end
+
+function cublasStrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
+  @check ccall((:cublasStrmm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat},
+                Cint, Ptr{Cfloat}, Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
+end
+
+function cublasDtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
+  @check ccall((:cublasDtrmm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint,
+                Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
+end
+
+function cublasCtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
+  @check ccall((:cublasCtrmm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint,
+                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
+end
+
+function cublasZtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
+  @check ccall((:cublasZtrmm_v2, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
+end
+
+function cublasSgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
+  @check ccall((:cublasSgemmBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                Ptr{Cfloat}, Ptr{Ptr{Cfloat}}, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cfloat},
+                Ptr{Ptr{Cfloat}}, Cint, Cint),
+               handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta,
+               Carray, ldc, batchCount)
+end
+
+function cublasDgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
+  @check ccall((:cublasDgemmBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                Ptr{Cdouble}, Ptr{Ptr{Cdouble}}, Cint, Ptr{Ptr{Cdouble}}, Cint,
+                Ptr{Cdouble}, Ptr{Ptr{Cdouble}}, Cint, Cint),
+               handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta,
+               Carray, ldc, batchCount)
+end
+
+function cublasCgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
+  @check ccall((:cublasCgemmBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                Ptr{cuComplex}, Ptr{Ptr{cuComplex}}, Cint, Ptr{Ptr{cuComplex}}, Cint,
+                Ptr{cuComplex}, Ptr{Ptr{cuComplex}}, Cint, Cint),
+               handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta,
+               Carray, ldc, batchCount)
+end
+
+function cublasZgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc, batchCount)
+  @check ccall((:cublasZgemmBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                Ptr{cuDoubleComplex}, Ptr{Ptr{cuDoubleComplex}}, Cint,
+                Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{cuDoubleComplex},
+                Ptr{Ptr{cuDoubleComplex}}, Cint, Cint),
+               handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta,
+               Carray, ldc, batchCount)
+end
+
+function cublasSgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
+  @check ccall((:cublasSgeam, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
+                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat},
+                Cint),
+               handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
+end
+
+function cublasDgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
+  @check ccall((:cublasDgeam, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
+                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint,
+                Ptr{Cdouble}, Cint),
+               handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
+end
+
+function cublasCgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
+  @check ccall((:cublasCgeam, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
+                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex},
+                Cint, Ptr{cuComplex}, Cint),
+               handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
+end
+
+function cublasZgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
+  @check ccall((:cublasZgeam, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
+                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
+end
+
+function cublasSgetrfBatched(handle, n, A, lda, P, info, batchSize)
+  @check ccall((:cublasSgetrfBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               handle, n, A, lda, P, info, batchSize)
+end
+
+function cublasDgetrfBatched(handle, n, A, lda, P, info, batchSize)
+  @check ccall((:cublasDgetrfBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               handle, n, A, lda, P, info, batchSize)
+end
+
+function cublasCgetrfBatched(handle, n, A, lda, P, info, batchSize)
+  @check ccall((:cublasCgetrfBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               handle, n, A, lda, P, info, batchSize)
+end
+
+function cublasZgetrfBatched(handle, n, A, lda, P, info, batchSize)
+  @check ccall((:cublasZgetrfBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               handle, n, A, lda, P, info, batchSize)
+end
+
+function cublasSgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
+  @check ccall((:cublasSgetriBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Cint),
+               handle, n, A, lda, P, C, ldc, info, batchSize)
+end
+
+function cublasDgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
+  @check ccall((:cublasDgetriBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Cint),
+               handle, n, A, lda, P, C, ldc, info, batchSize)
+end
+
+function cublasCgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
+  @check ccall((:cublasCgetriBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Cint),
+               handle, n, A, lda, P, C, ldc, info, batchSize)
+end
+
+function cublasZgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
+  @check ccall((:cublasZgetriBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint},
+                Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint}, Cint),
+               handle, n, A, lda, P, C, ldc, info, batchSize)
+end
+
+function cublasStrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
+  @check ccall((:cublasStrsmBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{Cfloat}, Ptr{Ptr{Cfloat}}, Cint,
+                Ptr{Ptr{Cfloat}}, Cint, Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
+end
+
+function cublasDtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
+  @check ccall((:cublasDtrsmBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{Cdouble}, Ptr{Ptr{Cdouble}}, Cint,
+                Ptr{Ptr{Cdouble}}, Cint, Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
+end
+
+function cublasCtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
+  @check ccall((:cublasCtrsmBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{cuComplex}, Ptr{Ptr{cuComplex}}, Cint,
+                Ptr{Ptr{cuComplex}}, Cint, Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
+end
+
+function cublasZtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
+  @check ccall((:cublasZtrsmBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
+                cublasDiagType_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{Ptr{cuDoubleComplex}},
+                Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Cint),
+               handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
+end
+
+function cublasSmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
+  @check ccall((:cublasSmatinvBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Cint),
+               handle, n, A, lda, Ainv, lda_inv, info, batchSize)
+end
+
+function cublasDmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
+  @check ccall((:cublasDmatinvBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Cint),
+               handle, n, A, lda, Ainv, lda_inv, info, batchSize)
+end
+
+function cublasCmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
+  @check ccall((:cublasCmatinvBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Cint),
+               handle, n, A, lda, Ainv, lda_inv, info, batchSize)
+end
+
+function cublasZmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
+  @check ccall((:cublasZmatinvBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint,
+                Ptr{Ptr{cuDoubleComplex}},
+                Cint, Ptr{Cint}, Cint),
+               handle, n, A, lda, Ainv, lda_inv, info, batchSize)
+end
+
+function cublasSgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
+  @check ccall((:cublasSgeqrfBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Ptr{Cfloat}},
+                Ptr{Cint}, Cint),
+               handle, m, n, Aarray, lda, TauArray, info, batchSize)
+end
+
+function cublasDgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
+  @check ccall((:cublasDgeqrfBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Ptr{Cdouble}},
+                Ptr{Cint}, Cint),
+               handle, m, n, Aarray, lda, TauArray, info, batchSize)
+end
+
+function cublasCgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
+  @check ccall((:cublasCgeqrfBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Ptr{cuComplex}},
+                Ptr{Cint}, Cint),
+               handle, m, n, Aarray, lda, TauArray, info, batchSize)
+end
+
+function cublasZgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
+  @check ccall((:cublasZgeqrfBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint,
+                Ptr{Ptr{cuDoubleComplex}}, Ptr{Cint}, Cint),
+               handle, m, n, Aarray, lda, TauArray, info, batchSize)
+end
+
+function cublasSgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
+  @check ccall((:cublasSgelsBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Ptr{Cfloat}}, Cint,
+                Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
+end
+
+function cublasDgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
+  @check ccall((:cublasDgelsBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Ptr{Cdouble}},
+                Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
+end
+
+function cublasCgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
+  @check ccall((:cublasCgelsBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Ptr{cuComplex}},
+                Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
+end
+
+function cublasZgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
+  @check ccall((:cublasZgelsBatched, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint,
+                Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint},
+                Ptr{Cint}, Cint),
+               handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
+end
+
+function cublasSdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
+  @check ccall((:cublasSdgmm, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{Cfloat}, Cint,
+                Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               handle, mode, m, n, A, lda, x, incx, C, ldc)
+end
+
+function cublasDdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
+  @check ccall((:cublasDdgmm, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{Cdouble}, Cint,
+                Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               handle, mode, m, n, A, lda, x, incx, C, ldc)
+end
+
+function cublasCdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
+  @check ccall((:cublasCdgmm, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{cuComplex}, Cint,
+                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               handle, mode, m, n, A, lda, x, incx, C, ldc)
+end
+
+function cublasZdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
+  @check ccall((:cublasZdgmm, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{cuDoubleComplex}, Cint,
+                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               handle, mode, m, n, A, lda, x, incx, C, ldc)
+end
+
+function cublasStpttr(handle, uplo, n, AP, A, lda)
+  @check ccall((:cublasStpttr, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               handle, uplo, n, AP, A, lda)
+end
+
+function cublasDtpttr(handle, uplo, n, AP, A, lda)
+  @check ccall((:cublasDtpttr, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               handle, uplo, n, AP, A, lda)
+end
+
+function cublasCtpttr(handle, uplo, n, AP, A, lda)
+  @check ccall((:cublasCtpttr, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               handle, uplo, n, AP, A, lda)
+end
+
+function cublasZtpttr(handle, uplo, n, AP, A, lda)
+  @check ccall((:cublasZtpttr, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
+                Ptr{cuDoubleComplex}, Cint),
+               handle, uplo, n, AP, A, lda)
+end
+
+function cublasStrttp(handle, uplo, n, A, lda, AP)
+  @check ccall((:cublasStrttp, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               handle, uplo, n, A, lda, AP)
+end
+
+function cublasDtrttp(handle, uplo, n, A, lda, AP)
+  @check ccall((:cublasDtrttp, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}),
+               handle, uplo, n, A, lda, AP)
+end
+
+function cublasCtrttp(handle, uplo, n, A, lda, AP)
+  @check ccall((:cublasCtrttp, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}),
+               handle, uplo, n, A, lda, AP)
+end
+
+function cublasZtrttp(handle, uplo, n, A, lda, AP)
+  @check ccall((:cublasZtrttp, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
+                Cint, Ptr{cuDoubleComplex}),
+               handle, uplo, n, A, lda, AP)
+end
+
+if CUDAdrv.version() ≥ v"7.5"
     # Wrap extensions of functions (ie. Nrm2Ex, GemmEx, etc) (CUDA 7.5+)
     function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
         @check ccall((:cublasNrm2Ex, libcublas),
-                     cublasStatus_t,
-                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, cudaDataType_t),
+                      cublasStatus_t,
+                      (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint,
+                        Ptr{Nothing}, cudaDataType_t, cudaDataType_t),
                      handle, n, x, xType, incx, result, resultType, executionType)
     end
     function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
         @check ccall((:cublasDotEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, cudaDataType_t),
-                     handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
+                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint,
+                      Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t,
+                      cudaDataType_t),
+                     handle, n, x, xType, incx, y, yType, incy, result, resultType,
+                     executionType)
     end
     function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
         @check ccall((:cublasDotcEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, cudaDataType_t),
+                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint,
+                      Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t,
+                      cudaDataType_t),
                      handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
     end
     function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
         @check ccall((:cublasScalEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Ptr{Nothing}, cudaDataType_t, Cint, cudaDataType_t),
+                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Ptr{Nothing},
+                      cudaDataType_t, Cint, cudaDataType_t),
                      handle, n, alpha, alphaType, x, xType, incx, executionType)
     end
     function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
         @check ccall((:cublasAxpyEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, cudaDataType_t),
+                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Ptr{Nothing},
+                      cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, cudaDataType_t),
                      handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
     end
     function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
         @check ccall((:cublasCgemm3mEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint),
-                     handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                      Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing},
+                      cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t,
+                      Cint),
+                     handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb,
+                     beta, C, Ctype, ldc)
     end
     function cublasSgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
         @check ccall((:cublasSgemmEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint),
-                     handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                      Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing},
+                      cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint),
+                     handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb,
+                     beta, C, Ctype, ldc)
     end
     function cublasGemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
         @check ccall((:cublasGemmEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Nothing}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, Ptr{Nothing}, cudaDataType_t, Cint, cudaDataType_t, cublasGemmAlgo_t),
-                     handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc, computeType, algo)
+                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                      Ptr{Nothing}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing},
+                      cudaDataType_t, Cint, Ptr{Nothing}, Ptr{Nothing}, cudaDataType_t,
+                      Cint, cudaDataType_t, cublasGemmAlgo_t),
+                     handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb,
+                     beta, C, Ctype, ldc, computeType, algo)
     end
     function cublasCgemmEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
         @check ccall((:cublasCgemmEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint),
-                     handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
+                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
+                      Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing},
+                      cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t,
+                      Cint),
+                     handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb,
+                     beta, C, Ctype, ldc)
     end
     function cublasCsyrkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
         @check ccall((:cublasCsyrkEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint),
+                     (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                      Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{cuComplex},
+                      Ptr{Nothing}, cudaDataType_t, Cint),
                      handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     end
     function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
         @check ccall((:cublasCsyrk3mEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint),
+                     (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                      Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{cuComplex},
+                      Ptr{Nothing}, cudaDataType_t, Cint),
                      handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     end
     function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
         @check ccall((:cublasCherkEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint),
+                     (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                      Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Cfloat},
+                      Ptr{Nothing}, cudaDataType_t, Cint),
                      handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     end
     function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
         @check ccall((:cublasCherk3mEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint),
+                     (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
+                      Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Cfloat},
+                      Ptr{Nothing}, cudaDataType_t, Cint),
                      handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     end
     # Wrap FP16 functions (CUDA 7.5+)
     function cublasHgemm(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
         @check ccall((:cublasHgemm, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half}, Ptr{__half}, Cint),
+                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
+                      Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half},
+                      Ptr{__half}, Cint),
                      handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     end
     function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
         @check ccall((:cublasHgemmStridedBatched, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
-                     handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
+                     (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
+                      Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint,
+                      Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
+                     handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb,
+                     strideB, beta, C, ldc, strideC, batchCount)
     end
 end

--- a/src/blas/libcublas.jl
+++ b/src/blas/libcublas.jl
@@ -2,8 +2,10 @@
 # Automatically generated using Clang.jl wrap_c, version v0.0.1
 # Manually copied from ../gen to this directory
 
-function cublasCreate_v2(handle)
+function cublasCreate_v2()
+  handle = Ref{cublasHandle_t}()
   @check ccall( (:cublasCreate_v2, libcublas), cublasStatus_t, (Ptr{cublasHandle_t},), handle)
+  handle[]
 end
 function cublasDestroy_v2(handle)
   @check ccall( (:cublasDestroy_v2, libcublas), cublasStatus_t, (cublasHandle_t,), handle)
@@ -12,10 +14,10 @@ function cublasGetVersion_v2(handle, version)
   @check ccall( (:cublasGetVersion_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{Cint}), handle, version)
 end
 function cublasGetStream_v2(handle, streamId)
-  @check ccall( (:cublasGetStream_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{cudaStream_t}), handle, streamId)
+  @check ccall( (:cublasGetStream_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{CuStream_t}), handle, streamId)
 end
 function cublasSetStream_v2(handle, streamId)
-  @check ccall( (:cublasSetStream_v2, libcublas), cublasStatus_t, (cublasHandle_t, cudaStream_t), handle, streamId)
+  @check ccall( (:cublasSetStream_v2, libcublas), cublasStatus_t, (cublasHandle_t, CuStream_t), handle, streamId)
 end
 function cublasGetPointerMode_v2(handle, mode)
   @check ccall( (:cublasGetPointerMode_v2, libcublas), cublasStatus_t, (cublasHandle_t, Ptr{cublasPointerMode_t}), handle, mode)
@@ -42,16 +44,16 @@ function cublasGetMatrix(rows, cols, elemSize, A, lda, B, ldb)
   @check ccall( (:cublasGetMatrix, libcublas), cublasStatus_t, (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint), rows, cols, elemSize, A, lda, B, ldb)
 end
 function cublasSetVectorAsync(n, elemSize, hostPtr, incx, devicePtr, incy, stream)
-  @check ccall( (:cublasSetVectorAsync, libcublas), cublasStatus_t, (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, cudaStream_t), n, elemSize, hostPtr, incx, devicePtr, incy, stream)
+  @check ccall( (:cublasSetVectorAsync, libcublas), cublasStatus_t, (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t), n, elemSize, hostPtr, incx, devicePtr, incy, stream)
 end
 function cublasGetVectorAsync(n, elemSize, devicePtr, incx, hostPtr, incy, stream)
-  @check ccall( (:cublasGetVectorAsync, libcublas), cublasStatus_t, (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, cudaStream_t), n, elemSize, devicePtr, incx, hostPtr, incy, stream)
+  @check ccall( (:cublasGetVectorAsync, libcublas), cublasStatus_t, (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t), n, elemSize, devicePtr, incx, hostPtr, incy, stream)
 end
 function cublasSetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
-  @check ccall( (:cublasSetMatrixAsync, libcublas), cublasStatus_t, (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, cudaStream_t), rows, cols, elemSize, A, lda, B, ldb, stream)
+  @check ccall( (:cublasSetMatrixAsync, libcublas), cublasStatus_t, (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t), rows, cols, elemSize, A, lda, B, ldb, stream)
 end
 function cublasGetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
-  @check ccall( (:cublasGetMatrixAsync, libcublas), cublasStatus_t, (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, cudaStream_t), rows, cols, elemSize, A, lda, B, ldb, stream)
+  @check ccall( (:cublasGetMatrixAsync, libcublas), cublasStatus_t, (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t), rows, cols, elemSize, A, lda, B, ldb, stream)
 end
 function cublasXerbla(srName, info)
   ccall( (:cublasXerbla, libcublas), Nothing, (Ptr{UInt8}, Cint), srName, info)

--- a/src/blas/wrap.jl
+++ b/src/blas/wrap.jl
@@ -73,7 +73,7 @@ for (fname, elty) in ((:cublasDcopy_v2,:Float64),
               @check ccall(($(string(fname)), libcublas), cublasStatus_t,
                            (cublasHandle_t, Cint, Ptr{$elty}, Cint,
                             Ptr{$elty}, Cint),
-                           libcublas_handle[], n, DX, incx, DY, incy)
+                           handle(), n, DX, incx, DY, incy)
             DY
         end
     end
@@ -93,7 +93,7 @@ for (fname, elty) in ((:cublasDscal_v2,:Float64),
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Ptr{$elty}, Ptr{$elty},
                           Cint),
-                         libcublas_handle[], n, [DA], DX, incx)
+                         handle(), n, [DA], DX, incx)
             DX
         end
     end
@@ -108,11 +108,11 @@ for (fname, elty, celty) in ((:cublasSscal_v2, :Float32, :ComplexF32),
                        DX::CuArray{$celty},
                        incx::Integer)
             #DY = reinterpret($elty,DX,(2*n,))
-            #$(cublascall(fname))(libcublas_handle[],2*n,[DA],DY,incx)
+            #$(cublascall(fname))(handle(),2*n,[DA],DY,incx)
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Ptr{$elty}, Ptr{$celty},
                           Cint),
-                         libcublas_handle[], 2*n, [DA], DX, incx)
+                         handle(), 2*n, [DA], DX, incx)
             DX
         end
     end
@@ -141,7 +141,7 @@ for (jname, fname, elty) in ((:dot,:cublasDdot_v2,:Float64),
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Ptr{$elty}, Cint,
                           Ptr{$elty}, Cint, Ptr{$elty}),
-                         libcublas_handle[], n, DX, incx, DY, incy, result)
+                         handle(), n, DX, incx, DY, incy, result)
             return result[]
         end
     end
@@ -161,7 +161,7 @@ for (fname, elty, ret_type) in ((:cublasDnrm2_v2,:Float64,:Float64),
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Ptr{$elty}, Cint,
                           Ptr{$ret_type}),
-                         libcublas_handle[], n, X, incx, result)
+                         handle(), n, X, incx, result)
             return result[]
         end
     end
@@ -184,7 +184,7 @@ for (fname, elty, ret_type) in ((:cublasDasum_v2,:Float64,:Float64),
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Ptr{$elty}, Cint,
                           Ptr{$ret_type}),
-                         libcublas_handle[], n, X, incx, result)
+                         handle(), n, X, incx, result)
             return result[]
         end
     end
@@ -216,7 +216,7 @@ for (fname, elty) in ((:cublasDaxpy_v2,:Float64),
                          (cublasHandle_t, Cint, Ref{$elty}, Ptr{$elty},
                           Cint, Ptr{$elty},
                           Cint),
-                         libcublas_handle[], n, alpha, dx, incx, dy, incy)
+                         handle(), n, alpha, dx, incx, dy, incy)
             dy
         end
     end
@@ -250,7 +250,7 @@ for (fname, elty) in ((:cublasIdamax_v2,:Float64),
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Ptr{$elty}, Cint,
                           Ptr{Cint}),
-                         libcublas_handle[], n, dx, incx, result)
+                         handle(), n, dx, incx, result)
             return result[]
         end
     end
@@ -271,7 +271,7 @@ for (fname, elty) in ((:cublasIdamin_v2,:Float64),
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Ptr{$elty}, Cint,
                           Ptr{Cint}),
-                         libcublas_handle[], n, dx, incx, result)
+                         handle(), n, dx, incx, result)
             return result[]
         end
     end
@@ -312,7 +312,7 @@ for (fname, elty) in ((:cublasDgemv_v2,:Float64),
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasOperation_t, Cint, Cint,
                          Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty},
-                         Cint, Ptr{$elty}, Ptr{$elty}, Cint), libcublas_handle[],
+                         Cint, Ptr{$elty}, Ptr{$elty}, Cint), handle(),
                          cutrans, m, n, [alpha], A, lda, X, incx, [beta], Y,
                          incy)
             Y
@@ -360,7 +360,7 @@ for (fname, elty) in ((:cublasDgbmv_v2,:Float64),
                          (cublasHandle_t, cublasOperation_t, Cint, Cint,
                           Cint, Cint, Ptr{$elty}, Ptr{$elty}, Cint,
                           Ptr{$elty}, Cint, Ptr{$elty}, Ptr{$elty},
-                          Cint), libcublas_handle[], cutrans, m, n, kl, ku, [alpha], A,
+                          Cint), handle(), cutrans, m, n, kl, ku, [alpha], A,
                          lda, x, incx, [beta], y, incy)
             y
         end
@@ -417,7 +417,7 @@ for (fname, elty) in ((:cublasDsymv_v2,:Float64),
                          Cint,Ptr{$elty}, Ptr{$elty}, Cint,
                          Ptr{$elty}, Cint, Ptr{$elty},
                          Ptr{$elty},Cint),
-                         libcublas_handle[], cuuplo, n, [alpha],
+                         handle(), cuuplo, n, [alpha],
                          A, lda, x, incx, [beta], y, incy)
             y
         end
@@ -459,7 +459,7 @@ for (fname, elty) in ((:cublasZhemv_v2,:ComplexF64),
                          Cint,Ptr{$elty}, Ptr{$elty}, Cint,
                          Ptr{$elty}, Cint, Ptr{$elty},
                          Ptr{$elty},Cint),
-                         libcublas_handle[], cuuplo, n, [alpha],
+                         handle(), cuuplo, n, [alpha],
                          A, lda, x, incx, [beta], y, incy)
             y
         end
@@ -504,7 +504,7 @@ for (fname, elty) in ((:cublasDsbmv_v2,:Float64),
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, Cint, Cint,
                          Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty}, Cint,
-                         Ptr{$elty}, Ptr{$elty}, Cint), libcublas_handle[],
+                         Ptr{$elty}, Ptr{$elty}, Cint), handle(),
                          cuuplo, n, k, [alpha], A, lda, x, incx, [beta], y,
                          incy)
             y
@@ -548,7 +548,7 @@ for (fname, elty) in ((:cublasZhbmv_v2,:ComplexF64),
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, Cint, Cint,
                          Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty}, Cint,
-                         Ptr{$elty}, Ptr{$elty}, Cint), libcublas_handle[],
+                         Ptr{$elty}, Ptr{$elty}, Cint), handle(),
                          cuuplo, n, k, [alpha], A, lda, x, incx, [beta], y,
                          incy)
             y
@@ -594,7 +594,7 @@ for (fname, elty) in ((:cublasStbmv_v2,:Float32),
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, cublasOperation_t,
                          cublasDiagType_t, Cint, Cint, Ptr{$elty}, Cint,
-                         Ptr{$elty}, Cint), libcublas_handle[], cuuplo, cutrans,
+                         Ptr{$elty}, Cint), handle(), cuuplo, cutrans,
                          cudiag, n, k, A, lda, x, incx)
             x
         end
@@ -637,7 +637,7 @@ for (fname, elty) in ((:cublasStbsv_v2,:Float32),
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, cublasOperation_t,
                          cublasDiagType_t, Cint, Cint, Ptr{$elty}, Cint,
-                         Ptr{$elty}, Cint), libcublas_handle[], cuuplo, cutrans,
+                         Ptr{$elty}, Cint), handle(), cuuplo, cutrans,
                          cudiag, n, k, A, lda, x, incx)
             x
         end
@@ -681,7 +681,7 @@ for (fname, elty) in ((:cublasDtrmv_v2,:Float64),
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t,
                           cublasOperation_t, cublasDiagType_t, Cint,
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint), libcublas_handle[],
+                          Ptr{$elty}, Cint, Ptr{$elty}, Cint), handle(),
                          cuuplo, cutrans, cudiag, n, A, lda, x, incx)
             x
         end
@@ -724,7 +724,7 @@ for (fname, elty) in ((:cublasDtrsv_v2,:Float64),
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t,
                           cublasOperation_t, cublasDiagType_t, Cint,
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint), libcublas_handle[],
+                          Ptr{$elty}, Cint, Ptr{$elty}, Cint), handle(),
                          cuuplo, cutrans, cudiag, n, A, lda, x, incx)
             x
         end
@@ -762,7 +762,7 @@ for (fname, elty) in ((:cublasDger_v2,:Float64),
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Cint, Ptr{$elty},
                          Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty},
-                         Cint), libcublas_handle[], m, n, [alpha], x, incx, y,
+                         Cint), handle(), m, n, [alpha], x, incx, y,
                          incy, A, lda)
             A
         end
@@ -793,7 +793,7 @@ for (fname, elty) in ((:cublasDsyr_v2,:Float64),
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, Cint,
                          Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty}, Cint),
-                         libcublas_handle[], cuuplo, n, [alpha], x, incx, A,
+                         handle(), cuuplo, n, [alpha], x, incx, A,
                          lda)
             A
         end
@@ -817,7 +817,7 @@ for (fname, elty) in ((:cublasZher_v2,:ComplexF64),
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, Cint,
                          Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty}, Cint),
-                         libcublas_handle[], cuuplo, n, [alpha], x, incx, A,
+                         handle(), cuuplo, n, [alpha], x, incx, A,
                          lda)
             A
         end
@@ -845,7 +845,7 @@ for (fname, elty) in ((:cublasZher2_v2,:ComplexF64),
                          (cublasHandle_t, cublasFillMode_t, Cint,
                           Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty}, Cint,
                           Ptr{$elty}, Cint),
-                         libcublas_handle[], cuuplo, n, [alpha], x, incx, y, incy, A,
+                         handle(), cuuplo, n, [alpha], x, incx, y, incy, A,
                          lda)
             A
         end
@@ -890,7 +890,7 @@ for (fname, elty) in
                           cublasOperation_t, Cint, Cint, Cint, Ptr{$elty},
                           Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty},
                           Ptr{$elty}, Cint),
-                         libcublas_handle[], cutransA,
+                         handle(), cutransA,
                          cutransB, m, n, k, [alpha], A, lda, B, ldb, [beta],
                          C, ldc)
             C
@@ -967,7 +967,7 @@ for (fname, elty) in
                           cublasOperation_t, Cint, Cint, Cint, Ptr{$elty},
                           Ptr{Ptr{$elty}}, Cint, Ptr{Ptr{$elty}}, Cint, Ptr{$elty},
                           Ptr{Ptr{$elty}}, Cint, Cint),
-                         libcublas_handle[], cutransA,
+                         handle(), cutransA,
                          cutransB, m, n, k, [alpha], Aptrs, lda, Bptrs, ldb, [beta],
                          Cptrs, ldc, length(A))
             C
@@ -1026,7 +1026,7 @@ for (fname, elty) in ((:cublasDsymm_v2,:Float64),
                          cublasFillMode_t, Cint, Cint, Ptr{$elty},
                           Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty},
                           Ptr{$elty}, Cint),
-                         libcublas_handle[], cuside,
+                         handle(), cuside,
                          cuuplo, m, n, [alpha], A, lda, B, ldb, [beta], C,
                          ldc)
             C
@@ -1077,7 +1077,7 @@ for (fname, elty) in ((:cublasDsyrk_v2,:Float64),
                         (cublasHandle_t, cublasFillMode_t,
                          cublasOperation_t, Cint, Cint, Ptr{$elty},
                          Ptr{$elty}, Cint, Ptr{$elty}, Ptr{$elty}, Cint),
-                        libcublas_handle[], cuuplo, cutrans, n, k, [alpha], A,
+                        handle(), cuuplo, cutrans, n, k, [alpha], A,
                         lda, [beta], C, ldc)
             C
         end
@@ -1130,7 +1130,7 @@ for (fname, elty) in ((:cublasZhemm_v2,:ComplexF64),
                         (cublasHandle_t, cublasSideMode_t, cublasFillMode_t,
                         Cint, Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty},
                          Cint, Ptr{$elty}, Ptr{$elty}, Cint),
-                        libcublas_handle[],
+                        handle(),
                         cuside, cuuplo, m, n, [alpha], A, lda, B, ldb, [beta], C, ldc)
            C
        end
@@ -1174,7 +1174,7 @@ for (fname, elty) in ((:cublasZherk_v2,:ComplexF64),
                         (cublasHandle_t, cublasFillMode_t,
                          cublasOperation_t, Cint, Cint, Ptr{$elty},
                          Ptr{$elty}, Cint, Ptr{$elty}, Ptr{$elty}, Cint),
-                        libcublas_handle[], cuuplo, cutrans, n, k, [alpha], A,
+                        handle(), cuuplo, cutrans, n, k, [alpha], A,
                         lda, [beta], C, ldc)
            C
        end
@@ -1228,7 +1228,7 @@ for (fname, elty) in ((:cublasDsyr2k_v2,:Float64),
                          cublasOperation_t, Cint, Cint, Ptr{$elty},
                           Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty},
                           Ptr{$elty}, Cint),
-                         libcublas_handle[], cuuplo,
+                         handle(), cuuplo,
                          cutrans, n, k, [alpha], A, lda, B, ldb, [beta], C,
                          ldc)
             C
@@ -1284,7 +1284,7 @@ for (fname, elty1, elty2) in ((:cublasZher2k_v2,:ComplexF64,:Float64),
                         cublasOperation_t, Cint, Cint, Ptr{$elty1},
                          Ptr{$elty1}, Cint, Ptr{$elty1}, Cint, Ptr{$elty2},
                          Ptr{$elty1}, Cint),
-                        libcublas_handle[], cuuplo, cutrans, n, k,
+                        handle(), cuuplo, cutrans, n, k,
                         [alpha], A, lda, B, ldb, [beta], C, ldc)
            C
        end
@@ -1348,7 +1348,7 @@ for (mmname, smname, elty) in
                           cublasDiagType_t, Cint, Cint, Ptr{$elty},
                           Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty},
                           Cint),
-                         libcublas_handle[], cuside, cuuplo, cutransa,
+                         handle(), cuside, cuuplo, cutransa,
                          cudiag, m, n, [alpha], A, lda, B, ldb, C, ldc)
             C
         end
@@ -1391,7 +1391,7 @@ for (mmname, smname, elty) in
                            cublasFillMode_t, cublasOperation_t,
                            cublasDiagType_t, Cint, Cint, Ptr{$elty},
                            Ptr{$elty}, Cint, Ptr{$elty}, Cint),
-                          libcublas_handle[], cuside, cuuplo, cutransa, cudiag,
+                          handle(), cuside, cuuplo, cutransa, cudiag,
                           m, n, [alpha], A, lda, B, ldb)
             B
         end
@@ -1452,7 +1452,7 @@ for (fname, elty) in
                           cublasOperation_t, cublasDiagType_t, Cint, Cint,
                           Ptr{$elty}, Ptr{Ptr{$elty}}, Cint, Ptr{Ptr{$elty}},
                           Cint, Cint),
-                         libcublas_handle[], cuside, cuuplo,
+                         handle(), cuside, cuuplo,
                          cutransa, cudiag, m, n, [alpha], Aptrs, lda,
                          Bptrs, ldb, length(A))
             B
@@ -1509,7 +1509,7 @@ for (fname, elty) in ((:cublasDgeam,:Float64),
            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                         (cublasHandle_t, cublasOperation_t, cublasOperation_t,
                          Cint, Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty},
-                         Ptr{$elty}, Cint, Ptr{$elty}, Cint), libcublas_handle[],
+                         Ptr{$elty}, Cint, Ptr{$elty}, Cint), handle(),
                         cutransa, cutransb, m, n, [alpha], A, lda, [beta], B, ldb, C, ldc)
            C
        end
@@ -1558,7 +1558,7 @@ for (fname, elty) in
             pivotArray  = Pivot ? CuArray{Int32}((n, length(A))) : C_NULL
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Ptr{Ptr{$elty}}, Cint,
-                          Ptr{Cint}, Ptr{Cint}, Cint), libcublas_handle[], n,
+                          Ptr{Cint}, Ptr{Cint}, Cint), handle(), n,
                          Aptrs, lda, pivotArray, info, length(A))
             if( !Pivot )
                 pivotArray = CuArray(zeros(Cint, (n, length(A))))
@@ -1604,7 +1604,7 @@ for (fname, elty) in
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Ptr{Ptr{$elty}}, Cint,
                           Ptr{Cint}, Ptr{Ptr{$elty}}, Cint, Ptr{Cint}, Cint),
-                         libcublas_handle[], n, Aptrs, lda, pivotArray, Cptrs,
+                         handle(), n, Aptrs, lda, pivotArray, Cptrs,
                          ldc, info, length(A))
             pivotArray, info, C
         end
@@ -1643,7 +1643,7 @@ for (fname, elty) in
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Ptr{Ptr{$elty}}, Cint,
                           Ptr{Ptr{$elty}}, Cint, Ptr{Cint}, Cint),
-                         libcublas_handle[], n, Aptrs, lda, Cptrs,
+                         handle(), n, Aptrs, lda, Cptrs,
                          ldc, info, length(A))
             info, C
         end
@@ -1676,7 +1676,7 @@ for (fname, elty) in
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Cint, Ptr{Ptr{$elty}},
                           Cint, Ptr{Ptr{$elty}}, Ptr{Cint}, Cint),
-                         libcublas_handle[], m, n, Aptrs, lda,
+                         handle(), m, n, Aptrs, lda,
                          Tauptrs, [info], length(A))
             if( info != 0 )
                 throw(ArgumentError,string("Invalid value at ",-info))
@@ -1731,7 +1731,7 @@ for (fname, elty) in
                          (cublasHandle_t, cublasOperation_t, Cint, Cint,
                           Cint, Ptr{Ptr{$elty}}, Cint, Ptr{Ptr{$elty}},
                           Cint, Ptr{Cint}, Ptr{Cint}, Cint),
-                         libcublas_handle[], cutrans, m, n, nrhs, Aptrs, lda,
+                         handle(), cutrans, m, n, nrhs, Aptrs, lda,
                          Cptrs, ldc, [info], infoarray, length(A))
             if( info != 0 )
                 throw(ArgumentError,string("Invalid value at ",-info))
@@ -1775,7 +1775,7 @@ for (fname, elty) in ((:cublasDdgmm,:Float64),
            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                         (cublasHandle_t, cublasSideMode_t, Cint, Cint,
                          Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty}, Cint),
-                        libcublas_handle[], cuside, m, n, A, lda, X, incx, C, ldc)
+                        handle(), cuside, m, n, A, lda, X, incx, C, ldc)
            C
        end
        function dgmm(mode::Char,

--- a/src/dnn/CUDNN.jl
+++ b/src/dnn/CUDNN.jl
@@ -13,8 +13,9 @@ function handle()
     if _handle[] == C_NULL
         @assert isassigned(active_context) # some other call should have initialized CUDA
         _handle[] = get!(_handles, active_context[]) do
+            context = active_context[]
             handle = cudnnCreate()
-            atexit(()->cudnnDestroy(handle))
+            atexit(()->CUDAdrv.isvalid(context) && cudnnDestroy(handle))
             handle
         end
     end

--- a/src/dnn/CUDNN.jl
+++ b/src/dnn/CUDNN.jl
@@ -1,21 +1,36 @@
 module CUDNN
 
-using ..CuArrays: CuArray, libcudnn, configured
+using CUDAdrv
+
+using ..CuArrays: CuArray, libcudnn, configured, active_context
 
 include("libcudnn_types.jl")
+
+const _handles = Dict{CuContext,cudnnHandle_t}()
+const _handle = Ref{cudnnHandle_t}(C_NULL)
+
+function handle()
+    if _handle[] == C_NULL
+        @assert isassigned(active_context) # some other call should have initialized CUDA
+        _handle[] = get!(_handles, active_context[]) do
+            handle = cudnnCreate()
+            atexit(()->cudnnDestroy(handle))
+            handle
+        end
+    end
+
+    return _handle[]
+end
+
 include("error.jl")
 include("helpers.jl")
 include("libcudnn.jl")
 include("nnlib.jl")
 
-const libcudnn_handle = Ref{cudnnHandle_t}()
 function __init__()
     configured || return
 
-    cudnnCreate(libcudnn_handle)
-    atexit(()->cudnnDestroy(libcudnn_handle[]))
-
-    global CUDNN_VERSION = convert(Int, ccall((:cudnnGetVersion,libcudnn),Csize_t,()))
+    global CUDNN_VERSION = convert(Int, ccall((:cudnnGetVersion,libcudnn), Csize_t, ()))
 end
 
 end

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -1,115 +1,192 @@
-function cudnnGetVersion()
-    ccall((:cudnnGetVersion,libcudnn),Cint,())
-end
+cudnnGetVersion() = ccall((:cudnnGetVersion,libcudnn), Cint, ())
 
-function cudnnGetErrorString(status)
-    ccall((:cudnnGetErrorString,libcudnn),Ptr{UInt8},(cudnnStatus_t,),status)
-end
+cudnnGetErrorString(status) = ccall((:cudnnGetErrorString,libcudnn), Ptr{UInt8}, (cudnnStatus_t,), status)
 
 function cudnnCreate()
     handle = Ref{cudnnHandle_t}()
-    @check ccall((:cudnnCreate,libcudnn),cudnnStatus_t,(Ptr{cudnnHandle_t},),handle)
+    @check ccall((:cudnnCreate,libcudnn), cudnnStatus_t, (Ptr{cudnnHandle_t},), handle)
     return handle[]
 end
 
 function cudnnDestroy(handle)
-    @check ccall((:cudnnDestroy,libcudnn),cudnnStatus_t,(cudnnHandle_t,),handle)
+    @check ccall((:cudnnDestroy,libcudnn), cudnnStatus_t, (cudnnHandle_t,), handle)
 end
 
 function cudnnCreateTensorDescriptor(tensorDesc)
-    @check ccall((:cudnnCreateTensorDescriptor,libcudnn),cudnnStatus_t,(Ptr{cudnnTensorDescriptor_t},),tensorDesc)
+    @check ccall((:cudnnCreateTensorDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (Ptr{cudnnTensorDescriptor_t},),
+                 tensorDesc)
 end
 
 function cudnnSetTensorNdDescriptor(tensorDesc,dataType,nbDims,dimA,strideA)
-    @check ccall((:cudnnSetTensorNdDescriptor,libcudnn),cudnnStatus_t,(cudnnTensorDescriptor_t,cudnnDataType_t,Cint,Ptr{Cint},Ptr{Cint}),tensorDesc,dataType,nbDims,dimA,strideA)
+    @check ccall((:cudnnSetTensorNdDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnTensorDescriptor_t,cudnnDataType_t,Cint,Ptr{Cint},Ptr{Cint}),
+                 tensorDesc,dataType,nbDims,dimA,strideA)
 end
 
 function cudnnGetTensorNdDescriptor(tensorDesc,nbDimsRequested,dataType,nbDims,dimA,strideA)
-    @check ccall((:cudnnGetTensorNdDescriptor,libcudnn),cudnnStatus_t,(cudnnTensorDescriptor_t,Cint,Ptr{cudnnDataType_t},Ptr{Cint},Ptr{Cint},Ptr{Cint}),tensorDesc,nbDimsRequested,dataType,nbDims,dimA,strideA)
+    @check ccall((:cudnnGetTensorNdDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnTensorDescriptor_t,Cint,Ptr{cudnnDataType_t},Ptr{Cint},Ptr{Cint},Ptr{Cint}),
+                 tensorDesc,nbDimsRequested,dataType,nbDims,dimA,strideA)
 end
 
 function cudnnDestroyTensorDescriptor(tensorDesc)
-    @check ccall((:cudnnDestroyTensorDescriptor,libcudnn),cudnnStatus_t,(cudnnTensorDescriptor_t,),tensorDesc)
+    @check ccall((:cudnnDestroyTensorDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnTensorDescriptor_t,),
+                 tensorDesc)
 end
 
 function cudnnCreateFilterDescriptor(filterDesc)
-    @check ccall((:cudnnCreateFilterDescriptor,libcudnn),cudnnStatus_t,(Ptr{cudnnFilterDescriptor_t},),filterDesc)
+    @check ccall((:cudnnCreateFilterDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (Ptr{cudnnFilterDescriptor_t},),
+                 filterDesc)
 end
 
 function cudnnSetFilterNdDescriptor(filterDesc,dataType,nbDims,filterDimA)
-    @check ccall((:cudnnSetFilterNdDescriptor,libcudnn),cudnnStatus_t,(cudnnFilterDescriptor_t,cudnnDataType_t,Cint,Ptr{Cint}),filterDesc,dataType,nbDims,filterDimA)
+    @check ccall((:cudnnSetFilterNdDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnFilterDescriptor_t,cudnnDataType_t,Cint,Ptr{Cint}),
+                 filterDesc,dataType,nbDims,filterDimA)
 end
 
 function cudnnSetFilterNdDescriptor(filterDesc,dataType,format,nbDims,filterDimA)
-    @check ccall((:cudnnSetFilterNdDescriptor,libcudnn),cudnnStatus_t,(cudnnFilterDescriptor_t,cudnnDataType_t,cudnnTensorFormat_t,Cint,Ptr{Cint}),filterDesc,dataType,format,nbDims,filterDimA)
+    @check ccall((:cudnnSetFilterNdDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnFilterDescriptor_t,cudnnDataType_t,cudnnTensorFormat_t,Cint,Ptr{Cint}),
+                 filterDesc,dataType,format,nbDims,filterDimA)
 end
 
 function cudnnSetFilterNdDescriptor_v4(filterDesc,dataType,format,nbDims,filterDimA)
-    @check ccall((:cudnnSetFilterNdDescriptor_v4,libcudnn),cudnnStatus_t,(cudnnFilterDescriptor_t,cudnnDataType_t,cudnnTensorFormat_t,Cint,Ptr{Cint}),filterDesc,dataType,format,nbDims,filterDimA)
+    @check ccall((:cudnnSetFilterNdDescriptor_v4,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnFilterDescriptor_t,cudnnDataType_t,cudnnTensorFormat_t,Cint,Ptr{Cint}),
+                 filterDesc,dataType,format,nbDims,filterDimA)
 end
 
 function cudnnGetFilterNdDescriptor(filterDesc,nbDimsRequested,dataType,nbDims,filterDimA)
-    @check ccall((:cudnnGetFilterNdDescriptor,libcudnn),cudnnStatus_t,(cudnnFilterDescriptor_t,Cint,Ptr{cudnnDataType_t},Ptr{Cint},Ptr{Cint}),filterDesc,nbDimsRequested,dataType,nbDims,filterDimA)
+    @check ccall((:cudnnGetFilterNdDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnFilterDescriptor_t,Cint,Ptr{cudnnDataType_t},Ptr{Cint},Ptr{Cint}),
+                 filterDesc,nbDimsRequested,dataType,nbDims,filterDimA)
 end
 
 function cudnnGetFilterNdDescriptor_v4(filterDesc,nbDimsRequested,dataType,format,nbDims,filterDimA)
-    @check ccall((:cudnnGetFilterNdDescriptor_v4,libcudnn),cudnnStatus_t,(cudnnFilterDescriptor_t,Cint,Ptr{cudnnDataType_t},Ptr{cudnnTensorFormat_t},Ptr{Cint},Ptr{Cint}),filterDesc,nbDimsRequested,dataType,format,nbDims,filterDimA)
+    @check ccall((:cudnnGetFilterNdDescriptor_v4,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnFilterDescriptor_t,Cint,Ptr{cudnnDataType_t},Ptr{cudnnTensorFormat_t},Ptr{Cint},Ptr{Cint}),
+                 filterDesc,nbDimsRequested,dataType,format,nbDims,filterDimA)
 end
 
 function cudnnDestroyFilterDescriptor(filterDesc)
-    @check ccall((:cudnnDestroyFilterDescriptor,libcudnn),cudnnStatus_t,(cudnnFilterDescriptor_t,),filterDesc)
+    @check ccall((:cudnnDestroyFilterDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnFilterDescriptor_t,),
+                 filterDesc)
 end
 
 function cudnnCreateConvolutionDescriptor(convDesc)
-    @check ccall((:cudnnCreateConvolutionDescriptor,libcudnn),cudnnStatus_t,(Ptr{cudnnConvolutionDescriptor_t},),convDesc)
+    @check ccall((:cudnnCreateConvolutionDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (Ptr{cudnnConvolutionDescriptor_t},),
+                 convDesc)
 end
 
 function cudnnSetConvolutionNdDescriptor(convDesc,arrayLength,padA,filterStrideA,dilationA,mode,dataType)
-    @check ccall((:cudnnSetConvolutionNdDescriptor,libcudnn),cudnnStatus_t,(cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},cudnnConvolutionMode_t,cudnnDataType_t),convDesc,arrayLength,padA,filterStrideA,dilationA,mode,dataType)
+    @check ccall((:cudnnSetConvolutionNdDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},
+                  cudnnConvolutionMode_t,cudnnDataType_t),
+                 convDesc,arrayLength,padA,filterStrideA,dilationA,mode,dataType)
 end
 
 function cudnnGetConvolutionNdDescriptor(convDesc,arrayLengthRequested,arrayLength,padA,strideA,dilationA,mode,dataType)
-    @check ccall((:cudnnGetConvolutionNdDescriptor,libcudnn),cudnnStatus_t,(cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{cudnnConvolutionMode_t},Ptr{cudnnDataType_t}),convDesc,arrayLengthRequested,arrayLength,padA,strideA,dilationA,mode,dataType)
+    @check ccall((:cudnnGetConvolutionNdDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnConvolutionDescriptor_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},
+                  Ptr{cudnnConvolutionMode_t},Ptr{cudnnDataType_t}),
+                 convDesc,arrayLengthRequested,arrayLength,padA,strideA,dilationA,mode,dataType)
 end
 
 function cudnnDestroyConvolutionDescriptor(convDesc)
-    @check ccall((:cudnnDestroyConvolutionDescriptor,libcudnn),cudnnStatus_t,(cudnnConvolutionDescriptor_t,),convDesc)
+    @check ccall((:cudnnDestroyConvolutionDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnConvolutionDescriptor_t,),
+                 convDesc)
 end
 
 function cudnnCreatePoolingDescriptor(poolingDesc)
-    ccall((:cudnnCreatePoolingDescriptor,libcudnn),cudnnStatus_t,(Ptr{cudnnPoolingDescriptor_t},),poolingDesc)
+    @check ccall((:cudnnCreatePoolingDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (Ptr{cudnnPoolingDescriptor_t},),
+                 poolingDesc)
 end
 
 function cudnnSetPoolingNdDescriptor(poolingDesc,mode,maxpoolingNanOpt,nbDims,windowDimA,paddingA,strideA)
-    ccall((:cudnnSetPoolingNdDescriptor,libcudnn),cudnnStatus_t,(cudnnPoolingDescriptor_t,cudnnPoolingMode_t,cudnnNanPropagation_t,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint}),poolingDesc,mode,maxpoolingNanOpt,nbDims,windowDimA,paddingA,strideA)
+    @check ccall((:cudnnSetPoolingNdDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnPoolingDescriptor_t,cudnnPoolingMode_t,cudnnNanPropagation_t,
+                  Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint}),
+                 poolingDesc,mode,maxpoolingNanOpt,nbDims,windowDimA,paddingA,strideA)
 end
 
 function cudnnGetPoolingNdDescriptor(poolingDesc,nbDimsRequested,mode,maxpoolingNanOpt,nbDims,windowDimA,paddingA,strideA)
-    ccall((:cudnnGetPoolingNdDescriptor,libcudnn),cudnnStatus_t,(cudnnPoolingDescriptor_t,Cint,Ptr{cudnnPoolingMode_t},Ptr{cudnnNanPropagation_t},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),poolingDesc,nbDimsRequested,mode,maxpoolingNanOpt,nbDims,windowDimA,paddingA,strideA)
+    @check ccall((:cudnnGetPoolingNdDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnPoolingDescriptor_t,Cint,Ptr{cudnnPoolingMode_t},
+                  Ptr{cudnnNanPropagation_t},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),
+                 poolingDesc,nbDimsRequested,mode,maxpoolingNanOpt,nbDims,windowDimA,paddingA,strideA)
 end
 
 function cudnnDestroyPoolingDescriptor(poolingDesc)
-    ccall((:cudnnDestroyPoolingDescriptor,libcudnn),cudnnStatus_t,(cudnnPoolingDescriptor_t,),poolingDesc)
+    @check ccall((:cudnnDestroyPoolingDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnPoolingDescriptor_t,),
+                 poolingDesc)
 end
 
 function cudnnSetActivationDescriptor(activationDesc, mode, reluNanOpt, coeff)
-    ccall((:cudnnSetActivationDescriptor,libcudnn),cudnnStatus_t,(cudnnActivationDescriptor_t,cudnnActivationMode_t,cudnnNanPropagation_t,Cdouble),activationDesc,mode,reluNanOpt,coeff)
+    @check ccall((:cudnnSetActivationDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnActivationDescriptor_t,cudnnActivationMode_t,
+                  cudnnNanPropagation_t,Cdouble),
+                 activationDesc,mode,reluNanOpt,coeff)
 end
 
 function cudnnGetActivationDescriptor(activationDesc, mode, reluNanOpt, coeff)
-    ccall((:cudnnGetActivationDescriptor,libcudnn),cudnnStatus_t,(cudnnActivationDescriptor_t,Ptr{cudnnActivationMode_t},Ptr{cudnnNanPropagation_t},Ptr{Cdouble}),activationDesc,mode,reluNanOpt,coeff)
+    @check ccall((:cudnnGetActivationDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnActivationDescriptor_t,Ptr{cudnnActivationMode_t},
+                  Ptr{cudnnNanPropagation_t},Ptr{Cdouble}),
+                 activationDesc,mode,reluNanOpt,coeff)
 end
 
 function cudnnCreateActivationDescriptor(activationDesc)
-    ccall((:cudnnCreateActivationDescriptor,libcudnn),cudnnStatus_t,(Ptr{cudnnActivationDescriptor_t},),activationDesc)
+    @check ccall((:cudnnCreateActivationDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (Ptr{cudnnActivationDescriptor_t},),
+                 activationDesc)
 end
 
 function cudnnDestroyActivationDescriptor(activationDesc)
-    ccall((:cudnnDestroyActivationDescriptor,libcudnn),cudnnStatus_t,(cudnnActivationDescriptor_t,),activationDesc)
+    @check ccall((:cudnnDestroyActivationDescriptor,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnActivationDescriptor_t,),
+                 activationDesc)
 end
 
 function cudnnSoftmaxForward(algo,mode,alpha,xDesc,x,beta,yDesc,y)
-    @check ccall((:cudnnSoftmaxForward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnSoftmaxAlgorithm_t,cudnnSoftmaxMode_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle(),algo,mode,alpha,xDesc,x,beta,yDesc,y)
+    @check ccall((:cudnnSoftmaxForward,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t,cudnnSoftmaxAlgorithm_t,cudnnSoftmaxMode_t,Ptr{Nothing},
+                  cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,
+                  Ptr{Nothing}),
+                 handle(),
+                 algo,mode,alpha,xDesc,x,beta,yDesc,y)
 end
 
 function cudnnSoftmaxForward(src::CuArray{T,4}, dest::CuArray{T,4}=src;
@@ -123,7 +200,13 @@ function cudnnSoftmaxForward(src::CuArray{T,4}, dest::CuArray{T,4}=src;
 end
 
 function cudnnSoftmaxBackward(algo,mode,alpha,yDesc,y,dyDesc,dy,beta,dxDesc,dx)
-    @check ccall((:cudnnSoftmaxBackward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnSoftmaxAlgorithm_t,cudnnSoftmaxMode_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle(),algo,mode,alpha,yDesc,y,dyDesc,dy,beta,dxDesc,dx)
+    @check ccall((:cudnnSoftmaxBackward,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t,cudnnSoftmaxAlgorithm_t,cudnnSoftmaxMode_t,Ptr{Nothing},
+                  cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},
+                  Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),
+                 handle(),
+                 algo,mode,alpha,yDesc,y,dyDesc,dy,beta,dxDesc,dx)
 end
 
 function cudnnSoftmaxBackward(src::CuArray{T,4}, srcDiff::CuArray{T,4}, destDiff::CuArray=srcDiff;
@@ -138,7 +221,15 @@ function cudnnSoftmaxBackward(src::CuArray{T,4}, srcDiff::CuArray{T,4}, destDiff
 end
 
 function cudnnConvolutionBiasActivationForward(alpha1, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, alpha2, biasDesc, bias, activationDesc, yDesc, y)
-    @check ccall((:cudnnConvolutionBiasActivationForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Nothing}, Csize_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), alpha1, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, alpha2, yDesc, y, biasDesc, bias, activationDesc, yDesc, y)
+    @check ccall((:cudnnConvolutionBiasActivationForward, libcudnn),
+                cudnnStatus_t,
+                (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing},
+                 cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t,
+                 cudnnConvolutionFwdAlgo_t, Ptr{Nothing}, Csize_t, Ptr{Nothing},
+                 cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t,
+                 Ptr{Nothing}, cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, Ptr{Nothing}),
+                 handle(), alpha1, xDesc, x, wDesc, w, convDesc, algo, workspace,
+                 workspace_size, alpha2, yDesc, y, biasDesc, bias, activationDesc, yDesc, y)
 end
 
 function cudnnConvolutionBiasActivationForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, bias::CuArray{T,N};
@@ -154,8 +245,15 @@ function cudnnConvolutionBiasActivationForward(y::CuArray{T,N}, x::CuArray{T,N},
 end
 
 function cudnnConvolutionForward(alpha, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, beta, yDesc, y)
-    workspace = workspace == nothing ? C_NULL : workspace
-    @check ccall((:cudnnConvolutionForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), alpha, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, beta, yDesc, y)
+    workspace = something(workspace, C_NULL)
+    @check ccall((:cudnnConvolutionForward, libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing},
+                  cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t,
+                  cudnnConvolutionFwdAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, Ptr{Nothing}),
+                 handle(), alpha, xDesc, x, wDesc, w, convDesc, algo, workspace,
+                 workspace_size, beta, yDesc, y)
 end
 
 function cudnnConvolutionForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N};
@@ -169,7 +267,12 @@ function cudnnConvolutionForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,
 end
 
 function cudnnGetConvolutionForwardWorkspaceSize(xDesc, wDesc, convDesc, yDesc, algo, workspace_size)
-    @check ccall((:cudnnGetConvolutionForwardWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle(), xDesc, wDesc, convDesc, yDesc, algo, workspace_size)
+    @check ccall((:cudnnGetConvolutionForwardWorkspaceSize, libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnFilterDescriptor_t,
+                  cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t,
+                  cudnnConvolutionFwdAlgo_t, Ptr{Cint}),
+                 handle(), xDesc, wDesc, convDesc, yDesc, algo, workspace_size)
 end
 
 function cudnnGetConvolutionForwardWorkspaceSize(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N};
@@ -182,8 +285,15 @@ function cudnnGetConvolutionForwardWorkspaceSize(y::CuArray{T,N}, x::CuArray{T,N
 end
 
 function cudnnConvolutionBackwardData(alpha, wDesc, w, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dxDesc, dx)
-    workspace = workspace == nothing ? C_NULL : workspace
-    @check ccall((:cudnnConvolutionBackwardData, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdDataAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), alpha, wDesc, w, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dxDesc, dx)
+    workspace = something(workspace, C_NULL)
+    @check ccall((:cudnnConvolutionBackwardData, libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t,
+                  cudnnConvolutionBwdDataAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, Ptr{Nothing}),
+                 handle(), alpha, wDesc, w, dyDesc, dy, convDesc, algo, workspace,
+                 workspace_size, beta, dxDesc, dx)
 end
 
 function cudnnConvolutionBackwardData(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
@@ -197,7 +307,12 @@ function cudnnConvolutionBackwardData(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuAr
 end
 
 function cudnnGetConvolutionBackwardDataWorkspaceSize(wDesc, dyDesc, convDesc, dxDesc, algo, workspace_size)
-    @check ccall((:cudnnGetConvolutionBackwardDataWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle(), wDesc, dyDesc, convDesc, dxDesc, algo, workspace_size)
+    @check ccall((:cudnnGetConvolutionBackwardDataWorkspaceSize, libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t,
+                  cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t,
+                  cudnnConvolutionFwdAlgo_t, Ptr{Cint}),
+                 handle(), wDesc, dyDesc, convDesc, dxDesc, algo, workspace_size)
 end
 
 function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
@@ -210,8 +325,15 @@ function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, x::CuArr
 end
 
 function cudnnConvolutionBackwardFilter(alpha, xDesc, x, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dwDesc, dw)
-    workspace = workspace == nothing ? C_NULL : workspace
-    @check ccall((:cudnnConvolutionBackwardFilter, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdFilterAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}), handle(), alpha, xDesc, x, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dwDesc, dw)
+    workspace = something(workspace, C_NULL)
+    @check ccall((:cudnnConvolutionBackwardFilter, libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t,
+                  cudnnConvolutionBwdFilterAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing},
+                  cudnnFilterDescriptor_t, Ptr{Nothing}),
+                 handle(), alpha, xDesc, x, dyDesc, dy, convDesc, algo, workspace,
+                 workspace_size, beta, dwDesc, dw)
 end
 
 function cudnnConvolutionBackwardFilter(dw::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
@@ -225,7 +347,12 @@ function cudnnConvolutionBackwardFilter(dw::CuArray{T,N}, x::CuArray{T,N}, w::Cu
 end
 
 function cudnnGetConvolutionBackwardFilterWorkspaceSize(xDesc, dyDesc, convDesc, dwDesc, algo, workspace_size)
-    @check ccall((:cudnnGetConvolutionBackwardFilterWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle(), xDesc, dyDesc, convDesc, dwDesc, algo, workspace_size)
+    @check ccall((:cudnnGetConvolutionBackwardFilterWorkspaceSize, libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t,
+                  cudnnConvolutionDescriptor_t, cudnnFilterDescriptor_t,
+                  cudnnConvolutionFwdAlgo_t, Ptr{Cint}),
+                 handle(), xDesc, dyDesc, convDesc, dwDesc, algo, workspace_size)
 end
 
 function cudnnGetConvolutionBackwardFilterWorkspaceSize(dw::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
@@ -238,7 +365,11 @@ function cudnnGetConvolutionBackwardFilterWorkspaceSize(dw::CuArray{T,N}, x::CuA
 end
 
 function cudnnConvolutionBackwardBias(alpha, dyDesc, dy, beta, dbDesc, db)
-    @check ccall((:cudnnConvolutionBackwardBias, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), alpha, dyDesc, dy, beta, dbDesc, db)
+    @check ccall((:cudnnConvolutionBackwardBias, libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing},
+                  Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}),
+                 handle(), alpha, dyDesc, dy, beta, dbDesc, db)
 end
 
 function cudnnConvolutionBackwardBias(db::CuArray{T,N}, dy::CuArray{T,N}; alpha=1, beta=0) where {T,N}
@@ -247,11 +378,20 @@ function cudnnConvolutionBackwardBias(db::CuArray{T,N}, dy::CuArray{T,N}; alpha=
 end
 
 function cudnnPoolingForward(poolingDesc,alpha,xDesc,x,beta,yDesc,y)
-    ccall((:cudnnPoolingForward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnPoolingDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle(),poolingDesc,alpha,xDesc,x,beta,yDesc,y)
+    @check ccall((:cudnnPoolingForward,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t,cudnnPoolingDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,
+                  Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),
+                 handle(), poolingDesc,alpha,xDesc,x,beta,yDesc,y)
 end
 
 function cudnnPoolingBackward(poolingDesc,alpha,yDesc,y,dyDesc,dy,xDesc,x,beta,dxDesc,dx)
-    ccall((:cudnnPoolingBackward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnPoolingDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle(),poolingDesc,alpha,yDesc,y,dyDesc,dy,xDesc,x,beta,dxDesc,dx)
+    @check ccall((:cudnnPoolingBackward,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t,cudnnPoolingDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,
+                  Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,
+                  Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),
+                 handle(),poolingDesc,alpha,yDesc,y,dyDesc,dy,xDesc,x,beta,dxDesc,dx)
 end
 
 function cudnnPoolingForward(y::CuArray{T,N}, x::CuArray{T,N}; alpha=1,
@@ -274,7 +414,12 @@ function cudnnPoolingBackward(dx::CuArray{T,N}, dy::CuArray{T,N}, x::CuArray{T,N
 end
 
 function cudnnActivationForward(activationDesc, alpha, xDesc, x, beta, yDesc, y)
-    @check ccall((:cudnnActivationForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), activationDesc, alpha, xDesc, x, beta, yDesc, y)
+    @check ccall((:cudnnActivationForward, libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, Ptr{Nothing}),
+                 handle(), activationDesc, alpha, xDesc, x, beta, yDesc, y)
 end
 
 function cudnnActivationForward(y::CuArray{T,N}, x::CuArray{T,N}; mode=CUDNN_ACTIVATION_RELU, #CUDNN_ACTIVATION_IDENTITY will not work
@@ -285,7 +430,13 @@ function cudnnActivationForward(y::CuArray{T,N}, x::CuArray{T,N}; mode=CUDNN_ACT
 end
 
 function cudnnActivationBackward(activationDesc, alpha, yDesc, y, dyDesc, dy, xDesc, x, beta, dxDesc, dx)
-    @check ccall((:cudnnActivationBackward, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), activationDesc, alpha, yDesc, y, dyDesc, dy, xDesc, x, beta, dxDesc, dx)
+    @check ccall((:cudnnActivationBackward, libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t,
+                  Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, Ptr{Nothing}),
+                 handle(), activationDesc, alpha, yDesc, y, dyDesc, dy, xDesc, x, beta, dxDesc, dx)
 end
 
 function cudnnActivationBackward(dx::CuArray{T,N}, x::CuArray{T,N}, y::CuArray{T,N}, dy::CuArray{T,N};
@@ -297,7 +448,11 @@ function cudnnActivationBackward(dx::CuArray{T,N}, x::CuArray{T,N}, y::CuArray{T
 end
 
 function cudnnAddTensor(alpha, aDesc, A, beta, cDesc, C)
-    @check ccall((:cudnnAddTensor, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), alpha, aDesc, A, beta, cDesc, C)
+    @check ccall((:cudnnAddTensor, libcudnn),
+                 cudnnStatus_t,
+                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing},
+                  Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}),
+                 handle(), alpha, aDesc, A, beta, cDesc, C)
 end
 
 function cudnnAddTensor(A::CuArray{T,N}, C::CuArray{T,N}; alpha=1,

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -6,8 +6,10 @@ function cudnnGetErrorString(status)
     ccall((:cudnnGetErrorString,libcudnn),Ptr{UInt8},(cudnnStatus_t,),status)
 end
 
-function cudnnCreate(handle)
+function cudnnCreate()
+    handle = Ref{cudnnHandle_t}()
     @check ccall((:cudnnCreate,libcudnn),cudnnStatus_t,(Ptr{cudnnHandle_t},),handle)
+    return handle[]
 end
 
 function cudnnDestroy(handle)
@@ -111,7 +113,7 @@ function cudnnSoftmaxForward(handle,algo,mode,alpha,xDesc,x,beta,yDesc,y)
 end
 
 function cudnnSoftmaxForward(src::CuArray{T,4}, dest::CuArray{T,4}=src;
-                             handle=libcudnn_handle[],
+                             handle=handle(),
                              algorithm=CUDNN_SOFTMAX_ACCURATE, # or CUDNN_SOFTMAX_FAST
                              mode=CUDNN_SOFTMAX_MODE_INSTANCE, # or CUDNN_SOFTMAX_MODE_CHANNEL
                              alpha=1.0, beta=0.0) where T
@@ -126,7 +128,7 @@ function cudnnSoftmaxBackward(handle,algo,mode,alpha,yDesc,y,dyDesc,dy,beta,dxDe
 end
 
 function cudnnSoftmaxBackward(src::CuArray{T,4}, srcDiff::CuArray{T,4}, destDiff::CuArray=srcDiff;
-                              handle=libcudnn_handle[],
+                              handle=handle(),
                               algorithm=CUDNN_SOFTMAX_ACCURATE, # or CUDNN_SOFTMAX_FAST
                               mode=CUDNN_SOFTMAX_MODE_INSTANCE, # or CUDNN_SOFTMAX_MODE_CHANNEL
                               alpha=1.0, beta=0.0) where T
@@ -142,7 +144,7 @@ function cudnnConvolutionBiasActivationForward(handle, alpha1, xDesc, x, wDesc, 
 end
 
 function cudnnConvolutionBiasActivationForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, bias::CuArray{T,N};
-                                               handle=libcudnn_handle[], alpha1=1, workspace=C_NULL, workspace_size=0,
+                                               handle=handle(), alpha1=1, workspace=C_NULL, workspace_size=0,
                                                algo=0, alpha2=0, padding=0, stride=1, dilation=1, mode=0,
                                                activationMode=CUDNN_ACTIVATION_IDENTITY, activationCoeff=0.0,
                                                activationReluNanOpt=CUDNN_NOT_PROPAGATE_NAN) where {T,N}
@@ -159,7 +161,7 @@ function cudnnConvolutionForward(handle, alpha, xDesc, x, wDesc, w, convDesc, al
 end
 
 function cudnnConvolutionForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N};
-                                 handle=libcudnn_handle[], algo=0, workspace=C_NULL, workspace_size=0,
+                                 handle=handle(), algo=0, workspace=C_NULL, workspace_size=0,
                                  alpha=1, beta=0, padding=0, stride=1, dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     cudnnConvolutionForward(
@@ -173,7 +175,7 @@ function cudnnGetConvolutionForwardWorkspaceSize(handle, xDesc, wDesc, convDesc,
 end
 
 function cudnnGetConvolutionForwardWorkspaceSize(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N};
-                                                 handle=libcudnn_handle[], algo=0, padding=0, stride=1,
+                                                 handle=handle(), algo=0, padding=0, stride=1,
                                                  dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     workspace_size = Ref{Cint}()
@@ -187,7 +189,7 @@ function cudnnConvolutionBackwardData(handle, alpha, wDesc, w, dyDesc, dy, convD
 end
 
 function cudnnConvolutionBackwardData(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
-                                      handle=libcudnn_handle[], algo=0, workspace=C_NULL, workspace_size=0,
+                                      handle=handle(), algo=0, workspace=C_NULL, workspace_size=0,
                                       alpha=1, beta=0, padding=0, stride=1, dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     cudnnConvolutionBackwardData(
@@ -201,7 +203,7 @@ function cudnnGetConvolutionBackwardDataWorkspaceSize(handle, wDesc, dyDesc, con
 end
 
 function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
-                                                      handle=libcudnn_handle[], algo=0, padding=0, stride=1,
+                                                      handle=handle(), algo=0, padding=0, stride=1,
                                                       dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     workspace_size = Ref{Cint}()
@@ -215,7 +217,7 @@ function cudnnConvolutionBackwardFilter(handle, alpha, xDesc, x, dyDesc, dy, con
 end
 
 function cudnnConvolutionBackwardFilter(dw::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
-                                        handle=libcudnn_handle[], algo=0, workspace=C_NULL, workspace_size=0,
+                                        handle=handle(), algo=0, workspace=C_NULL, workspace_size=0,
                                         alpha=1, beta=0, padding=0, stride=1, dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     cudnnConvolutionBackwardFilter(
@@ -229,7 +231,7 @@ function cudnnGetConvolutionBackwardFilterWorkspaceSize(handle, xDesc, dyDesc, c
 end
 
 function cudnnGetConvolutionBackwardFilterWorkspaceSize(dw::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
-                                                        handle=libcudnn_handle[], algo=0, padding=0, stride=1,
+                                                        handle=handle(), algo=0, padding=0, stride=1,
                                                         dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     workspace_size = Ref{Cint}()
@@ -241,7 +243,7 @@ function cudnnConvolutionBackwardBias(handle, alpha, dyDesc, dy, beta, dbDesc, d
     @check ccall((:cudnnConvolutionBackwardBias, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle, alpha, dyDesc, dy, beta, dbDesc, db)
 end
 
-function cudnnConvolutionBackwardBias(db::CuArray{T,N}, dy::CuArray{T,N}; handle=libcudnn_handle[], alpha=1, beta=0) where {T,N}
+function cudnnConvolutionBackwardBias(db::CuArray{T,N}, dy::CuArray{T,N}; handle=handle(), alpha=1, beta=0) where {T,N}
     cudnnConvolutionBackwardBias(handle, Ref(T(alpha)), TensorDesc(dy), dy, Ref(T(beta)), TensorDesc(db), db)
     return db
 end
@@ -254,7 +256,7 @@ function cudnnPoolingBackward(handle,poolingDesc,alpha,yDesc,y,dyDesc,dy,xDesc,x
     ccall((:cudnnPoolingBackward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnPoolingDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle,poolingDesc,alpha,yDesc,y,dyDesc,dy,xDesc,x,beta,dxDesc,dx)
 end
 
-function cudnnPoolingForward(y::CuArray{T,N}, x::CuArray{T,N}; handle=libcudnn_handle[], alpha=1,
+function cudnnPoolingForward(y::CuArray{T,N}, x::CuArray{T,N}; handle=handle(), alpha=1,
                                 window=2, padding=0, stride=window, mode=0) where {T,N}
     beta = 0
     pd = PoolDesc(N-2, window, padding, stride, mode)
@@ -263,7 +265,7 @@ function cudnnPoolingForward(y::CuArray{T,N}, x::CuArray{T,N}; handle=libcudnn_h
 end
 
 function cudnnPoolingBackward(dx::CuArray{T,N}, dy::CuArray{T,N}, x::CuArray{T,N}, y::CuArray{T,N};
-                                 handle=libcudnn_handle[], alpha=1,
+                                 handle=handle(), alpha=1,
                                  window=2, padding=0, stride=window, mode=0) where {T,N}
     if alpha!=1 && mode==0; error("Gradient of pool(alpha!=1,mode=0) broken in CUDNN"); end
     beta = 0
@@ -277,7 +279,7 @@ function cudnnActivationForward(handle, activationDesc, alpha, xDesc, x, beta, y
     @check ccall((:cudnnActivationForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle, activationDesc, alpha, xDesc, x, beta, yDesc, y)
 end
 
-function cudnnActivationForward(y::CuArray{T,N}, x::CuArray{T,N}; handle=libcudnn_handle[],
+function cudnnActivationForward(y::CuArray{T,N}, x::CuArray{T,N}; handle=handle(),
                                 mode=CUDNN_ACTIVATION_RELU, #CUDNN_ACTIVATION_IDENTITY will not work
                                 coeff=0.0, reluNanOpt=CUDNN_NOT_PROPAGATE_NAN, alpha=1, beta=0) where {T,N}
     ad = ActivationDesc(mode, T(coeff), reluNanOpt)
@@ -290,7 +292,7 @@ function cudnnActivationBackward(handle, activationDesc, alpha, yDesc, y, dyDesc
 end
 
 function cudnnActivationBackward(dx::CuArray{T,N}, x::CuArray{T,N}, y::CuArray{T,N}, dy::CuArray{T,N};
-                                 handle=libcudnn_handle[], mode=CUDNN_ACTIVATION_RELU, #CUDNN_ACTIVATION_IDENTITY will not work
+                                 handle=handle(), mode=CUDNN_ACTIVATION_RELU, #CUDNN_ACTIVATION_IDENTITY will not work
                                  coeff=0.0, reluNanOpt=CUDNN_NOT_PROPAGATE_NAN, alpha=1, beta=0) where {T,N}
     ad = ActivationDesc(mode, T(coeff), reluNanOpt)
     cudnnActivationBackward(handle, ad, Ref(T(alpha)), TensorDesc(y), y, TensorDesc(dy), dy, TensorDesc(x), x, Ref(T(beta)), TensorDesc(dx), dx)
@@ -301,7 +303,7 @@ function cudnnAddTensor(handle, alpha, aDesc, A, beta, cDesc, C)
     @check ccall((:cudnnAddTensor, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle, alpha, aDesc, A, beta, cDesc, C)
 end
 
-function cudnnAddTensor(A::CuArray{T,N}, C::CuArray{T,N}; handle=libcudnn_handle[], alpha=1,
+function cudnnAddTensor(A::CuArray{T,N}, C::CuArray{T,N}; handle=handle(), alpha=1,
                         beta=1) where {T,N}
     aDesc = TensorDesc(A)
     cDesc = TensorDesc(C)

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -108,205 +108,202 @@ function cudnnDestroyActivationDescriptor(activationDesc)
     ccall((:cudnnDestroyActivationDescriptor,libcudnn),cudnnStatus_t,(cudnnActivationDescriptor_t,),activationDesc)
 end
 
-function cudnnSoftmaxForward(handle,algo,mode,alpha,xDesc,x,beta,yDesc,y)
-    @check ccall((:cudnnSoftmaxForward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnSoftmaxAlgorithm_t,cudnnSoftmaxMode_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle,algo,mode,alpha,xDesc,x,beta,yDesc,y)
+function cudnnSoftmaxForward(algo,mode,alpha,xDesc,x,beta,yDesc,y)
+    @check ccall((:cudnnSoftmaxForward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnSoftmaxAlgorithm_t,cudnnSoftmaxMode_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle(),algo,mode,alpha,xDesc,x,beta,yDesc,y)
 end
 
 function cudnnSoftmaxForward(src::CuArray{T,4}, dest::CuArray{T,4}=src;
-                             handle=handle(),
                              algorithm=CUDNN_SOFTMAX_ACCURATE, # or CUDNN_SOFTMAX_FAST
                              mode=CUDNN_SOFTMAX_MODE_INSTANCE, # or CUDNN_SOFTMAX_MODE_CHANNEL
                              alpha=1.0, beta=0.0) where T
-    cudnnSoftmaxForward(handle, algorithm, mode,
+    cudnnSoftmaxForward(algorithm, mode,
                         cptr(alpha, src), TensorDesc(src), src,
                         cptr(beta, dest), TensorDesc(dest), dest)
     return dest
 end
 
-function cudnnSoftmaxBackward(handle,algo,mode,alpha,yDesc,y,dyDesc,dy,beta,dxDesc,dx)
-    @check ccall((:cudnnSoftmaxBackward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnSoftmaxAlgorithm_t,cudnnSoftmaxMode_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle,algo,mode,alpha,yDesc,y,dyDesc,dy,beta,dxDesc,dx)
+function cudnnSoftmaxBackward(algo,mode,alpha,yDesc,y,dyDesc,dy,beta,dxDesc,dx)
+    @check ccall((:cudnnSoftmaxBackward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnSoftmaxAlgorithm_t,cudnnSoftmaxMode_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle(),algo,mode,alpha,yDesc,y,dyDesc,dy,beta,dxDesc,dx)
 end
 
 function cudnnSoftmaxBackward(src::CuArray{T,4}, srcDiff::CuArray{T,4}, destDiff::CuArray=srcDiff;
-                              handle=handle(),
                               algorithm=CUDNN_SOFTMAX_ACCURATE, # or CUDNN_SOFTMAX_FAST
                               mode=CUDNN_SOFTMAX_MODE_INSTANCE, # or CUDNN_SOFTMAX_MODE_CHANNEL
                               alpha=1.0, beta=0.0) where T
-    cudnnSoftmaxBackward(handle, algorithm, mode,
+    cudnnSoftmaxBackward(algorithm, mode,
                          cptr(alpha, src), TensorDesc(src), src,
                          TensorDesc(srcDiff), srcDiff,
                          cptr(beta, destDiff), TensorDesc(destDiff), destDiff)
     return destDiff
 end
 
-function cudnnConvolutionBiasActivationForward(handle, alpha1, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, alpha2, biasDesc, bias, activationDesc, yDesc, y)
-    @check ccall((:cudnnConvolutionBiasActivationForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Nothing}, Csize_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, Ptr{Nothing}), handle, alpha1, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, alpha2, yDesc, y, biasDesc, bias, activationDesc, yDesc, y)
+function cudnnConvolutionBiasActivationForward(alpha1, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, alpha2, biasDesc, bias, activationDesc, yDesc, y)
+    @check ccall((:cudnnConvolutionBiasActivationForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Nothing}, Csize_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), alpha1, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, alpha2, yDesc, y, biasDesc, bias, activationDesc, yDesc, y)
 end
 
 function cudnnConvolutionBiasActivationForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, bias::CuArray{T,N};
-                                               handle=handle(), alpha1=1, workspace=C_NULL, workspace_size=0,
+                                               alpha1=1, workspace=C_NULL, workspace_size=0,
                                                algo=0, alpha2=0, padding=0, stride=1, dilation=1, mode=0,
                                                activationMode=CUDNN_ACTIVATION_IDENTITY, activationCoeff=0.0,
                                                activationReluNanOpt=CUDNN_NOT_PROPAGATE_NAN) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     ad = ActivationDesc(activationMode, T(activationCoeff), activationReluNanOpt)
-    cudnnConvolutionBiasActivationForward(handle,Ref(T(alpha1)),TensorDesc(x),x,FilterDesc(w),w,cd,algo,workspace,
+    cudnnConvolutionBiasActivationForward(Ref(T(alpha1)),TensorDesc(x),x,FilterDesc(w),w,cd,algo,workspace,
         workspace_size,Ref(T(alpha2)),TensorDesc(bias),bias,ad,TensorDesc(y),y)
     return y
 end
 
-function cudnnConvolutionForward(handle, alpha, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, beta, yDesc, y)
+function cudnnConvolutionForward(alpha, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, beta, yDesc, y)
     workspace = workspace == nothing ? C_NULL : workspace
-    @check ccall((:cudnnConvolutionForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle, alpha, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, beta, yDesc, y)
+    @check ccall((:cudnnConvolutionForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), alpha, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, beta, yDesc, y)
 end
 
 function cudnnConvolutionForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N};
-                                 handle=handle(), algo=0, workspace=C_NULL, workspace_size=0,
+                                 algo=0, workspace=C_NULL, workspace_size=0,
                                  alpha=1, beta=0, padding=0, stride=1, dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     cudnnConvolutionForward(
-      handle,Ref(T(alpha)),TensorDesc(x),x,FilterDesc(w),w,cd,algo,workspace,
+      Ref(T(alpha)),TensorDesc(x),x,FilterDesc(w),w,cd,algo,workspace,
       workspace_size,Ref(T(beta)),TensorDesc(y),y)
     return y
 end
 
-function cudnnGetConvolutionForwardWorkspaceSize(handle, xDesc, wDesc, convDesc, yDesc, algo, workspace_size)
-    @check ccall((:cudnnGetConvolutionForwardWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle, xDesc, wDesc, convDesc, yDesc, algo, workspace_size)
+function cudnnGetConvolutionForwardWorkspaceSize(xDesc, wDesc, convDesc, yDesc, algo, workspace_size)
+    @check ccall((:cudnnGetConvolutionForwardWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle(), xDesc, wDesc, convDesc, yDesc, algo, workspace_size)
 end
 
 function cudnnGetConvolutionForwardWorkspaceSize(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N};
-                                                 handle=handle(), algo=0, padding=0, stride=1,
+                                                 algo=0, padding=0, stride=1,
                                                  dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     workspace_size = Ref{Cint}()
-    cudnnGetConvolutionForwardWorkspaceSize(handle, TensorDesc(x), FilterDesc(w), cd, TensorDesc(y), algo, workspace_size)
+    cudnnGetConvolutionForwardWorkspaceSize(TensorDesc(x), FilterDesc(w), cd, TensorDesc(y), algo, workspace_size)
     return Int(workspace_size[])
 end
 
-function cudnnConvolutionBackwardData(handle, alpha, wDesc, w, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dxDesc, dx)
+function cudnnConvolutionBackwardData(alpha, wDesc, w, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dxDesc, dx)
     workspace = workspace == nothing ? C_NULL : workspace
-    @check ccall((:cudnnConvolutionBackwardData, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdDataAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle, alpha, wDesc, w, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dxDesc, dx)
+    @check ccall((:cudnnConvolutionBackwardData, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdDataAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), alpha, wDesc, w, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dxDesc, dx)
 end
 
 function cudnnConvolutionBackwardData(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
-                                      handle=handle(), algo=0, workspace=C_NULL, workspace_size=0,
+                                      algo=0, workspace=C_NULL, workspace_size=0,
                                       alpha=1, beta=0, padding=0, stride=1, dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     cudnnConvolutionBackwardData(
-        handle,Ref(T(alpha)),FilterDesc(w),w,TensorDesc(dy),dy,cd,algo,workspace,
+        Ref(T(alpha)),FilterDesc(w),w,TensorDesc(dy),dy,cd,algo,workspace,
         workspace_size,Ref(T(beta)),TensorDesc(dx),dx)
     return dx
 end
 
-function cudnnGetConvolutionBackwardDataWorkspaceSize(handle, wDesc, dyDesc, convDesc, dxDesc, algo, workspace_size)
-    @check ccall((:cudnnGetConvolutionBackwardDataWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle, wDesc, dyDesc, convDesc, dxDesc, algo, workspace_size)
+function cudnnGetConvolutionBackwardDataWorkspaceSize(wDesc, dyDesc, convDesc, dxDesc, algo, workspace_size)
+    @check ccall((:cudnnGetConvolutionBackwardDataWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnFilterDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle(), wDesc, dyDesc, convDesc, dxDesc, algo, workspace_size)
 end
 
 function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
-                                                      handle=handle(), algo=0, padding=0, stride=1,
+                                                      algo=0, padding=0, stride=1,
                                                       dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     workspace_size = Ref{Cint}()
-    cudnnGetConvolutionBackwardDataWorkspaceSize(handle, FilterDesc(w), TensorDesc(dy), cd, TensorDesc(dx), algo, workspace_size)
+    cudnnGetConvolutionBackwardDataWorkspaceSize(FilterDesc(w), TensorDesc(dy), cd, TensorDesc(dx), algo, workspace_size)
     return Int(workspace_size[])
 end
 
-function cudnnConvolutionBackwardFilter(handle, alpha, xDesc, x, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dwDesc, dw)
+function cudnnConvolutionBackwardFilter(alpha, xDesc, x, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dwDesc, dw)
     workspace = workspace == nothing ? C_NULL : workspace
-    @check ccall((:cudnnConvolutionBackwardFilter, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdFilterAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}), handle, alpha, xDesc, x, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dwDesc, dw)
+    @check ccall((:cudnnConvolutionBackwardFilter, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t, cudnnConvolutionBwdFilterAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing}), handle(), alpha, xDesc, x, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dwDesc, dw)
 end
 
 function cudnnConvolutionBackwardFilter(dw::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
-                                        handle=handle(), algo=0, workspace=C_NULL, workspace_size=0,
+                                        algo=0, workspace=C_NULL, workspace_size=0,
                                         alpha=1, beta=0, padding=0, stride=1, dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     cudnnConvolutionBackwardFilter(
-        handle,Ref(T(alpha)),TensorDesc(x),x,TensorDesc(dy),dy,cd,algo,workspace,
+        Ref(T(alpha)),TensorDesc(x),x,TensorDesc(dy),dy,cd,algo,workspace,
         workspace_size,Ref(T(beta)),FilterDesc(dw),dw)
     return dw
 end
 
-function cudnnGetConvolutionBackwardFilterWorkspaceSize(handle, xDesc, dyDesc, convDesc, dwDesc, algo, workspace_size)
-    @check ccall((:cudnnGetConvolutionBackwardFilterWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle, xDesc, dyDesc, convDesc, dwDesc, algo, workspace_size)
+function cudnnGetConvolutionBackwardFilterWorkspaceSize(xDesc, dyDesc, convDesc, dwDesc, algo, workspace_size)
+    @check ccall((:cudnnGetConvolutionBackwardFilterWorkspaceSize, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnTensorDescriptor_t, cudnnTensorDescriptor_t, cudnnConvolutionDescriptor_t, cudnnFilterDescriptor_t, cudnnConvolutionFwdAlgo_t, Ptr{Cint}), handle(), xDesc, dyDesc, convDesc, dwDesc, algo, workspace_size)
 end
 
 function cudnnGetConvolutionBackwardFilterWorkspaceSize(dw::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
-                                                        handle=handle(), algo=0, padding=0, stride=1,
+                                                        algo=0, padding=0, stride=1,
                                                         dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     workspace_size = Ref{Cint}()
-    cudnnGetConvolutionBackwardFilterWorkspaceSize(handle, TensorDesc(x), TensorDesc(dy), cd, FilterDesc(dw), algo, workspace_size)
+    cudnnGetConvolutionBackwardFilterWorkspaceSize(TensorDesc(x), TensorDesc(dy), cd, FilterDesc(dw), algo, workspace_size)
     return Int(workspace_size[])
 end
 
-function cudnnConvolutionBackwardBias(handle, alpha, dyDesc, dy, beta, dbDesc, db)
-    @check ccall((:cudnnConvolutionBackwardBias, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle, alpha, dyDesc, dy, beta, dbDesc, db)
+function cudnnConvolutionBackwardBias(alpha, dyDesc, dy, beta, dbDesc, db)
+    @check ccall((:cudnnConvolutionBackwardBias, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), alpha, dyDesc, dy, beta, dbDesc, db)
 end
 
-function cudnnConvolutionBackwardBias(db::CuArray{T,N}, dy::CuArray{T,N}; handle=handle(), alpha=1, beta=0) where {T,N}
-    cudnnConvolutionBackwardBias(handle, Ref(T(alpha)), TensorDesc(dy), dy, Ref(T(beta)), TensorDesc(db), db)
+function cudnnConvolutionBackwardBias(db::CuArray{T,N}, dy::CuArray{T,N}; alpha=1, beta=0) where {T,N}
+    cudnnConvolutionBackwardBias(Ref(T(alpha)), TensorDesc(dy), dy, Ref(T(beta)), TensorDesc(db), db)
     return db
 end
 
-function cudnnPoolingForward(handle,poolingDesc,alpha,xDesc,x,beta,yDesc,y)
-    ccall((:cudnnPoolingForward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnPoolingDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle,poolingDesc,alpha,xDesc,x,beta,yDesc,y)
+function cudnnPoolingForward(poolingDesc,alpha,xDesc,x,beta,yDesc,y)
+    ccall((:cudnnPoolingForward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnPoolingDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle(),poolingDesc,alpha,xDesc,x,beta,yDesc,y)
 end
 
-function cudnnPoolingBackward(handle,poolingDesc,alpha,yDesc,y,dyDesc,dy,xDesc,x,beta,dxDesc,dx)
-    ccall((:cudnnPoolingBackward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnPoolingDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle,poolingDesc,alpha,yDesc,y,dyDesc,dy,xDesc,x,beta,dxDesc,dx)
+function cudnnPoolingBackward(poolingDesc,alpha,yDesc,y,dyDesc,dy,xDesc,x,beta,dxDesc,dx)
+    ccall((:cudnnPoolingBackward,libcudnn),cudnnStatus_t,(cudnnHandle_t,cudnnPoolingDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),handle(),poolingDesc,alpha,yDesc,y,dyDesc,dy,xDesc,x,beta,dxDesc,dx)
 end
 
-function cudnnPoolingForward(y::CuArray{T,N}, x::CuArray{T,N}; handle=handle(), alpha=1,
+function cudnnPoolingForward(y::CuArray{T,N}, x::CuArray{T,N}; alpha=1,
                                 window=2, padding=0, stride=window, mode=0) where {T,N}
     beta = 0
     pd = PoolDesc(N-2, window, padding, stride, mode)
-    cudnnPoolingForward(handle, pd, Ref(T(alpha)), TensorDesc(x), x, Ref(T(beta)), TensorDesc(y), y)
+    cudnnPoolingForward(pd, Ref(T(alpha)), TensorDesc(x), x, Ref(T(beta)), TensorDesc(y), y)
     return y
 end
 
 function cudnnPoolingBackward(dx::CuArray{T,N}, dy::CuArray{T,N}, x::CuArray{T,N}, y::CuArray{T,N};
-                                 handle=handle(), alpha=1,
+                                 alpha=1,
                                  window=2, padding=0, stride=window, mode=0) where {T,N}
     if alpha!=1 && mode==0; error("Gradient of pool(alpha!=1,mode=0) broken in CUDNN"); end
     beta = 0
     pd = PoolDesc(N-2, window, padding, stride, mode)
-    cudnnPoolingBackward(handle, pd, Ref(T(alpha)), TensorDesc(y), y,
+    cudnnPoolingBackward(pd, Ref(T(alpha)), TensorDesc(y), y,
                          TensorDesc(dy), dy, TensorDesc(x), x, Ref(T(beta)), TensorDesc(dx), dx)
     return dx
 end
 
-function cudnnActivationForward(handle, activationDesc, alpha, xDesc, x, beta, yDesc, y)
-    @check ccall((:cudnnActivationForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle, activationDesc, alpha, xDesc, x, beta, yDesc, y)
+function cudnnActivationForward(activationDesc, alpha, xDesc, x, beta, yDesc, y)
+    @check ccall((:cudnnActivationForward, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), activationDesc, alpha, xDesc, x, beta, yDesc, y)
 end
 
-function cudnnActivationForward(y::CuArray{T,N}, x::CuArray{T,N}; handle=handle(),
-                                mode=CUDNN_ACTIVATION_RELU, #CUDNN_ACTIVATION_IDENTITY will not work
+function cudnnActivationForward(y::CuArray{T,N}, x::CuArray{T,N}; mode=CUDNN_ACTIVATION_RELU, #CUDNN_ACTIVATION_IDENTITY will not work
                                 coeff=0.0, reluNanOpt=CUDNN_NOT_PROPAGATE_NAN, alpha=1, beta=0) where {T,N}
     ad = ActivationDesc(mode, T(coeff), reluNanOpt)
-    cudnnActivationForward(handle, ad, Ref(T(alpha)), TensorDesc(x), x, Ref(T(beta)), TensorDesc(y), y)
+    cudnnActivationForward(ad, Ref(T(alpha)), TensorDesc(x), x, Ref(T(beta)), TensorDesc(y), y)
     return y
 end
 
-function cudnnActivationBackward(handle, activationDesc, alpha, yDesc, y, dyDesc, dy, xDesc, x, beta, dxDesc, dx)
-    @check ccall((:cudnnActivationBackward, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle, activationDesc, alpha, yDesc, y, dyDesc, dy, xDesc, x, beta, dxDesc, dx)
+function cudnnActivationBackward(activationDesc, alpha, yDesc, y, dyDesc, dy, xDesc, x, beta, dxDesc, dx)
+    @check ccall((:cudnnActivationBackward, libcudnn), cudnnStatus_t, (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), activationDesc, alpha, yDesc, y, dyDesc, dy, xDesc, x, beta, dxDesc, dx)
 end
 
 function cudnnActivationBackward(dx::CuArray{T,N}, x::CuArray{T,N}, y::CuArray{T,N}, dy::CuArray{T,N};
-                                 handle=handle(), mode=CUDNN_ACTIVATION_RELU, #CUDNN_ACTIVATION_IDENTITY will not work
+                                 mode=CUDNN_ACTIVATION_RELU, #CUDNN_ACTIVATION_IDENTITY will not work
                                  coeff=0.0, reluNanOpt=CUDNN_NOT_PROPAGATE_NAN, alpha=1, beta=0) where {T,N}
     ad = ActivationDesc(mode, T(coeff), reluNanOpt)
-    cudnnActivationBackward(handle, ad, Ref(T(alpha)), TensorDesc(y), y, TensorDesc(dy), dy, TensorDesc(x), x, Ref(T(beta)), TensorDesc(dx), dx)
+    cudnnActivationBackward(ad, Ref(T(alpha)), TensorDesc(y), y, TensorDesc(dy), dy, TensorDesc(x), x, Ref(T(beta)), TensorDesc(dx), dx)
     return dx
 end
 
-function cudnnAddTensor(handle, alpha, aDesc, A, beta, cDesc, C)
-    @check ccall((:cudnnAddTensor, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle, alpha, aDesc, A, beta, cDesc, C)
+function cudnnAddTensor(alpha, aDesc, A, beta, cDesc, C)
+    @check ccall((:cudnnAddTensor, libcudnn), cudnnStatus_t, (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}), handle(), alpha, aDesc, A, beta, cDesc, C)
 end
 
-function cudnnAddTensor(A::CuArray{T,N}, C::CuArray{T,N}; handle=handle(), alpha=1,
+function cudnnAddTensor(A::CuArray{T,N}, C::CuArray{T,N}; alpha=1,
                         beta=1) where {T,N}
     aDesc = TensorDesc(A)
     cDesc = TensorDesc(C)
-    cudnnAddTensor(handle, Ref(T(alpha)), aDesc, A, Ref(T(beta)), cDesc, C)
+    cudnnAddTensor(Ref(T(alpha)), aDesc, A, Ref(T(beta)), cDesc, C)
     return C
 end

--- a/src/rand/CURAND.jl
+++ b/src/rand/CURAND.jl
@@ -1,9 +1,11 @@
 module CURAND
 
-using ..GPUArrays
-using ..CuArrays: CuArray, libcurand
+using CUDAdrv
 
 using Random
+
+using ..GPUArrays
+using ..CuArrays: CuArray, libcurand, active_context
 
 export curand,
        curandn,
@@ -11,6 +13,23 @@ export curand,
        curand_poisson, rand_poisson!
 
 include("libcurand_defs.jl")
+
+const _generators = Dict{CuContext,RNG}()
+const _generator = Ref{Union{Nothing,RNG}}(nothing)
+
+function generator()
+    if _generator[] == nothing
+        @assert isassigned(active_context) # some other call should have initialized CUDA
+        _generator[] = get!(_generators, active_context[]) do
+            generator = create_generator()
+            atexit(()->destroy_generator(generator))
+            generator
+        end
+    end
+
+    return _generator[]::RNG
+end
+
 include("error.jl")
 include("libcurand.jl")
 include("highlevel.jl")

--- a/src/rand/CURAND.jl
+++ b/src/rand/CURAND.jl
@@ -21,8 +21,10 @@ function generator()
     if _generator[] == nothing
         @assert isassigned(active_context) # some other call should have initialized CUDA
         _generator[] = get!(_generators, active_context[]) do
+            context = active_context[]
             generator = create_generator()
-            atexit(()->destroy_generator(generator))
+            # FIXME: crashes
+            #atexit(()->CUDAdrv.isvalid(context) && destroy_generator(generator))
             generator
         end
     end

--- a/src/rand/highlevel.jl
+++ b/src/rand/highlevel.jl
@@ -6,19 +6,10 @@
 # - functions that take an array will dispatch to either CURAND or GPUArrays
 # - `cu`-prefixed functions are provided for constructing GPU arrays from only an eltype
 
-const GLOBAL_RNG = Ref{RNG}()
-function global_rng()
-    # create the CURAND generator lazily, because it consumes quite a bit of GPU memory
-    if !isassigned(GLOBAL_RNG)
-        GLOBAL_RNG[] = create_generator()
-    end
-    GLOBAL_RNG[]
-end
-
 
 ## seeding
 
-seed!(rng::RNG=global_rng()) = generate_seeds(rng)
+seed!(rng::RNG=generator()) = generate_seeds(rng)
 
 
 ## in-place
@@ -63,18 +54,18 @@ rand_poisson(rng::RNG, ::Type{X}, dim1::Integer, dims::Integer...; kwargs...) wh
 
 ## functions that dispatch to either CURAND or GPUArrays
 
-uniform_rng(::CuArray{<:Union{Float32,Float64}}) = global_rng()
+uniform_rng(::CuArray{<:Union{Float32,Float64}}) = generator()
 uniform_rng(A::CuArray) = GPUArrays.global_rng(A)
 
-normal_rng(::CuArray{<:Union{Float32,Float64}}) = global_rng()
+normal_rng(::CuArray{<:Union{Float32,Float64}}) = generator()
 normal_rng(::CuArray{T}) where {T} =
     error("CuArrays does not support generating normally distributed numbers of type $T")
 
-logn_rng(::CuArray{<:Union{Float32,Float64}}) = global_rng()
+logn_rng(::CuArray{<:Union{Float32,Float64}}) = generator()
 logn_rng(::CuArray{T}) where {T} =
     error("CuArrays does not support generating lognormally distributed numbers of type $T")
 
-poisson_rng(::CuArray{Cuint}) = global_rng()
+poisson_rng(::CuArray{Cuint}) = generator()
 poisson_rng(::CuArray{T}) where {T} =
     error("CuArrays does not support generating Poisson distributed numbers of type $T")
 

--- a/src/rand/libcurand.jl
+++ b/src/rand/libcurand.jl
@@ -1,7 +1,8 @@
 function create_generator(typ::Int=CURAND_RNG_PSEUDO_DEFAULT)
     ptr = Ref{curandGenerator_t}()
     @check ccall((:curandCreateGenerator, libcurand),
-                 curandStatus_t, (Ptr{curandGenerator_t}, Cint), ptr, typ)
+                 curandStatus_t,
+                 (Ptr{curandGenerator_t}, Cint), ptr, typ)
     r = RNG(ptr[], typ)
     finalizer(destroy_generator, r)
     return r
@@ -9,13 +10,15 @@ end
 
 function destroy_generator(rng::RNG)
     @check ccall((:curandDestroyGenerator, libcurand),
-                 curandStatus_t, (curandGenerator_t,), rng)
+                 curandStatus_t,
+                 (curandGenerator_t,), rng)
 end
 
 function get_version()
     ver = Ref{Cint}()
     @check ccall((:curandGetVersion, libcurand),
-                 curandStatus_t, (Ref{Cint},), ver)
+                 curandStatus_t,
+                 (Ref{Cint},), ver)
     return ver[]
 end
 
@@ -23,22 +26,26 @@ end
 
 function set_pseudo_random_generator_seed(rng::RNG, seed::Int64)
     @check ccall((:curandSetPseudoRandomGeneratorSeed, libcurand),
-                 curandStatus_t, (curandGenerator_t, Clonglong), rng, seed)
+                 curandStatus_t,
+                 (curandGenerator_t, Clonglong), rng, seed)
 end
 
 function set_generator_offset(rng::RNG, offset::Int64)
     @check ccall((:curandSetGeneratorOffset, libcurand),
-                 curandStatus_t, (curandGenerator_t, Clonglong), rng, offset)
+                 curandStatus_t,
+                 (curandGenerator_t, Clonglong), rng, offset)
 end
 
 function set_generator_ordering(rng::RNG, order::Int)
     @check ccall((:curandSetGeneratorOrdering, libcurand),
-                 curandStatus_t, (curandGenerator_t, Cint), rng, order)
+                 curandStatus_t,
+                 (curandGenerator_t, Cint), rng, order)
 end
 
 function set_quasi_random_generator_dimensions(rng::RNG, num_dimensions::UInt)
     @check ccall((:curandSetQuasiRandomGeneratorDimensions, libcurand),
-                 curandStatus_t, (curandGenerator_t, Cuint),
+                 curandStatus_t,
+                 (curandGenerator_t, Cuint),
                  rng, num_dimensions)
 end
 
@@ -48,7 +55,8 @@ Generate 64-bit quasirandom numbers.
 """
 function generate(rng::RNG, arr::CuArray, n::UInt)
     @check ccall((:curandGenerate, libcurand),
-                 curandStatus_t, (curandGenerator_t, Ptr{UInt32}, Csize_t),
+                 curandStatus_t,
+                 (curandGenerator_t, Ptr{UInt32}, Csize_t),
                  rng, arr, length(arr))
     return arr
 end
@@ -63,7 +71,8 @@ Valid RNG types are:
 """
 function generate_long_long(rng::RNG, arr::CuArray)
     @check ccall((:curandGenerateLongLong, libcurand),
-                 curandStatus_t, (curandGenerator_t, Ptr{Culonglong}, Csize_t),
+                 curandStatus_t,
+                 (curandGenerator_t, Ptr{Culonglong}, Csize_t),
                  rng, arr, length(arr))
     return arr
 end
@@ -71,14 +80,16 @@ end
 # uniform
 function generate_uniform(rng::RNG, arr::CuArray)
     @check ccall((:curandGenerateUniform, libcurand),
-                 curandStatus_t, (curandGenerator_t, Ptr{Float32}, Csize_t),
+                 curandStatus_t,
+                 (curandGenerator_t, Ptr{Float32}, Csize_t),
                  rng, arr, length(arr))
     return arr
 end
 
 function generate_uniform_double(rng::RNG, arr::CuArray)
     @check ccall((:curandGenerateUniformDouble, libcurand),
-                 curandStatus_t, (curandGenerator_t, Ptr{Float64}, Csize_t),
+                 curandStatus_t,
+                 (curandGenerator_t, Ptr{Float64}, Csize_t),
                  rng, arr, length(arr))
     return arr
 end
@@ -152,7 +163,8 @@ end
 """Generate the starting state of the generator. """
 function generate_seeds(rng::RNG)
     @check ccall((:curandGenerateSeeds, libcurand),
-                 curandStatus_t, (curandGenerator_t,), rng)
+                 curandStatus_t,
+                 (curandGenerator_t,), rng)
 end
 
 # TODO: curandGetDirectionVectors32

--- a/src/rand/libcurand.jl
+++ b/src/rand/libcurand.jl
@@ -9,7 +9,7 @@ end
 
 function destroy_generator(rng::RNG)
     @check ccall((:curandDestroyGenerator, libcurand),
-                 curandStatus_t, (curandGenerator_t,), rng.ptr)
+                 curandStatus_t, (curandGenerator_t,), rng)
 end
 
 function get_version()

--- a/src/rand/libcurand_defs.jl
+++ b/src/rand/libcurand_defs.jl
@@ -1,7 +1,7 @@
 const curandGenerator_t = Ptr{Cvoid}
 
 mutable struct RNG <: Random.AbstractRNG
-    ptr::Ptr{Nothing}
+    ptr::curandGenerator_t
     typ::Int
 end
 

--- a/src/solver/CUSOLVER.jl
+++ b/src/solver/CUSOLVER.jl
@@ -5,7 +5,7 @@ using CUDAdrv: CuContext, CuDevice
 using CUDAnative
 
 using ..CuArrays
-const cudaStream_t = Ptr{Nothing}
+const CuStream_t = Ptr{Nothing}
 
 using ..CuArrays: libcusolver, configured, _getindex
 

--- a/src/solver/CUSOLVER.jl
+++ b/src/solver/CUSOLVER.jl
@@ -23,8 +23,9 @@ function dense_handle()
     if _dense_handle[] == C_NULL
         @assert isassigned(active_context) # some other call should have initialized CUDA
         _dense_handle[] = get!(_dense_handles, active_context[]) do
+            context = active_context[]
             handle = cusolverDnCreate()
-            atexit(()->cusolverDnDestroy(handle))
+            atexit(()->CUDAdrv.isvalid(context) && cusolverDnDestroy(handle))
             handle
         end
     end

--- a/src/solver/dense.jl
+++ b/src/solver/dense.jl
@@ -17,14 +17,14 @@ for (bname, fname,elty) in ((:cusolverDnSpotrf_bufferSize, :cusolverDnSpotrf, :F
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasFillMode_t, Cint,
                           Ptr{$elty}, Cint, Ref{Cint}),
-                         libcusolver_handle_dense[], cuuplo, n, A, lda, bufSize)
+                         dense_handle(), cuuplo, n, A, lda, bufSize)
 
             buffer  = CuArray{$elty}(bufSize[])
             devinfo = CuArray{Cint}(1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasFillMode_t, Cint,
                           Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{Cint}),
-                         libcusolver_handle_dense[], cuuplo, n, A, lda, buffer,
+                         dense_handle(), cuuplo, n, A, lda, buffer,
                          bufSize[], devinfo)
             info = BlasInt(_getindex(devinfo, 1))
             chkargsok(info)
@@ -55,7 +55,7 @@ for (fname,elty) in ((:cusolverDnSpotrs, :Float32),
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint,
                           Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{Cint}),
-                         libcusolver_handle_dense[], cuuplo, n, nrhs, A, lda, B,
+                         dense_handle(), cuuplo, n, nrhs, A, lda, B,
                          ldb, devinfo)
             info = _getindex(devinfo, 1)
             chkargsok(BlasInt(info))
@@ -76,7 +76,7 @@ for (bname, fname,elty) in ((:cusolverDnSgetrf_bufferSize, :cusolverDnSgetrf, :F
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Ptr{$elty}, Cint,
-                          Ref{Cint}), libcusolver_handle_dense[], m, n, A, lda,
+                          Ref{Cint}), dense_handle(), m, n, A, lda,
                          bufSize)
 
             buffer  = CuArray{$elty}(bufSize[])
@@ -85,7 +85,7 @@ for (bname, fname,elty) in ((:cusolverDnSgetrf_bufferSize, :cusolverDnSgetrf, :F
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Ptr{$elty},
                           Cint, Ptr{$elty}, Ptr{Cint}, Ptr{Cint}),
-                         libcusolver_handle_dense[], m, n, A, lda, buffer,
+                         dense_handle(), m, n, A, lda, buffer,
                          devipiv, devinfo)
             info = _getindex(devinfo, 1)
             if info < 0
@@ -110,7 +110,7 @@ for (bname, fname,elty) in ((:cusolverDnSgeqrf_bufferSize, :cusolverDnSgeqrf, :F
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)),libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Ptr{$elty}, Cint,
-                          Ref{Cint}), libcusolver_handle_dense[], m, n, A,
+                          Ref{Cint}), dense_handle(), m, n, A,
                          lda, bufSize)
             buffer  = CuArray{$elty}(bufSize[])
             tau  = CuArray{$elty}(min(m, n))
@@ -118,7 +118,7 @@ for (bname, fname,elty) in ((:cusolverDnSgeqrf_bufferSize, :cusolverDnSgeqrf, :F
             @check ccall(($(string(fname)),libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Ptr{$elty},
                           Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{Cint}),
-                         libcusolver_handle_dense[], m, n, A, lda, tau, buffer,
+                         dense_handle(), m, n, A, lda, tau, buffer,
                          bufSize[], devinfo)
             info = _getindex(devinfo, 1)
             if info < 0
@@ -146,7 +146,7 @@ for (bname, fname,elty) in ((:cusolverDnSsytrf_bufferSize, :cusolverDnSsytrf, :F
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)),libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Ptr{$elty}, Cint,
-                          Ref{Cint}), libcusolver_handle_dense[], n, A, lda,
+                          Ref{Cint}), dense_handle(), n, A, lda,
                          bufSize)
 
             buffer  = CuArray{$elty}(bufSize[])
@@ -155,7 +155,7 @@ for (bname, fname,elty) in ((:cusolverDnSsytrf_bufferSize, :cusolverDnSsytrf, :F
             @check ccall(($(string(fname)),libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasFillMode_t, Cint,
                           Ptr{$elty}, Cint, Ptr{Cint}, Ptr{$elty}, Cint,
-                          Ptr{Cint}), libcusolver_handle_dense[], cuuplo, n, A,
+                          Ptr{Cint}), dense_handle(), cuuplo, n, A,
                          lda, devipiv, buffer, bufSize[], devinfo)
             info = _getindex(devinfo, 1)
             if info < 0
@@ -194,7 +194,7 @@ for (fname,elty) in ((:cusolverDnSgetrs, :Float32),
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasOperation_t, Cint, Cint,
                           Ptr{$elty}, Cint, Ptr{Cint}, Ptr{$elty}, Cint,
-                          Ptr{Cint}), libcusolver_handle_dense[], cutrans, n, nrhs,
+                          Ptr{Cint}), dense_handle(), cutrans, n, nrhs,
                          A, lda, ipiv, B, ldb, devinfo)
             info = _getindex(devinfo, 1)
             if info < 0
@@ -239,7 +239,7 @@ for (bname, fname, elty) in ((:cusolverDnSormqr_bufferSize, :cusolverDnSormqr, :
                           (cusolverDnHandle_t, cublasSideMode_t,
                            cublasOperation_t, Cint, Cint, Cint, Ptr{$elty}, 
                            Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ref{Cint}),
-                          libcusolver_handle_dense[], cuside,
+                          dense_handle(), cuside,
                           cutrans, m, n, k, A,
                           lda, tau, C, ldc, bufSize)
             buffer  = CuArray{$elty}(bufSize[])
@@ -249,7 +249,7 @@ for (bname, fname, elty) in ((:cusolverDnSormqr_bufferSize, :cusolverDnSormqr, :
                           cublasOperation_t, Cint, Cint, Cint, Ptr{$elty},
                           Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty},
                           Cint, Ptr{Cint}),
-                         libcusolver_handle_dense[], cuside,
+                         dense_handle(), cuside,
                          cutrans, m, n, k, A, lda, tau, C, ldc, buffer,
                          bufSize[], devinfo)
             info = _getindex(devinfo, 1)
@@ -276,13 +276,13 @@ for (bname, fname, elty) in ((:cusolverDnSorgqr_bufferSize, :cusolverDnSorgqr, :
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
                           (cusolverDnHandle_t, Cint, Cint, Cint, Ptr{$elty}, Cint,
                            Ptr{$elty}, Ref{Cint}),
-                          libcusolver_handle_dense[], m, n, k, A, lda, tau, bufSize)
+                          dense_handle(), m, n, k, A, lda, tau, bufSize)
             buffer  = CuArray{$elty}(bufSize[])
             devinfo = CuArray{Cint}(1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Cint, Ptr{$elty},
                           Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{Cint}),
-                         libcusolver_handle_dense[], m, n, k, A,
+                         dense_handle(), m, n, k, A,
                          lda, tau, buffer, bufSize[], devinfo)
             info = _getindex(devinfo, 1)
             if info < 0
@@ -309,7 +309,7 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgebrd_bufferSize, :cusolverDnSg
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Ref{Cint}),
-                        libcusolver_handle_dense[], m, n, bufSize)
+                        dense_handle(), m, n, bufSize)
             buffer  = CuArray{$elty}(bufSize[])
             devinfo = CuArray{Cint}(1)
             k       = min(m, n)
@@ -321,7 +321,7 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgebrd_bufferSize, :cusolverDnSg
                          (cusolverDnHandle_t, Cint, Cint, Ptr{$elty},
                           Cint, Ptr{$relty}, Ptr{$relty}, Ptr{$elty},
                           Ptr{$elty}, Ptr{$elty}, Cint, Ptr{Cint}),
-                         libcusolver_handle_dense[], m, n, A, lda, D, E, TAUQ,
+                         dense_handle(), m, n, A, lda, D, E, TAUQ,
                          TAUP, buffer, bufSize[], devinfo)
             info = _getindex(devinfo, 1)
             if info < 0
@@ -345,7 +345,7 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgesvd_bufferSize, :cusolverDnSg
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Ref{Cint}),
-                        libcusolver_handle_dense[], m, n, bufSize)
+                        dense_handle(), m, n, bufSize)
 
             buffer  = CuArray{$elty}(bufSize[])
             rbuffer = CuArray{$relty}(5 * min(m, n))
@@ -359,7 +359,7 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgesvd_bufferSize, :cusolverDnSg
                          (cusolverDnHandle_t, Cuchar, Cuchar, Cint,
                           Cint, Ptr{$elty}, Cint, Ptr{$relty}, Ptr{$elty},
                           Cint, Ptr{$elty}, Cint, Ptr{$elty}, Cint,
-                          Ptr{$relty}, Ptr{Cint}), libcusolver_handle_dense[],
+                          Ptr{$relty}, Ptr{Cint}), dense_handle(),
                          jobu, jobvt, m, n, A, lda, S, U, ldu, Vt, ldvt,
                          buffer, bufSize[], rbuffer, devinfo)
             info = _getindex(devinfo, 1)

--- a/src/solver/libcusolver.jl
+++ b/src/solver/libcusolver.jl
@@ -3,45 +3,87 @@
 #helper functions
 function cusolverDnCreate()
   handle = Ref{cusolverDnHandle_t}()
-  @check ccall( (:cusolverDnCreate, libcusolver), cusolverStatus_t, (Ptr{cusolverDnHandle_t},), handle)
+  @check ccall((:cusolverDnCreate, libcusolver),
+               cusolverStatus_t,
+               (Ptr{cusolverDnHandle_t},),
+               handle)
   return handle[]
 end
 function cusolverDnDestroy(handle)
-  @check ccall( (:cusolverDnDestroy, libcusolver), cusolverStatus_t, (cusolverDnHandle_t,), handle)
+  @check ccall((:cusolverDnDestroy, libcusolver),
+               cusolverStatus_t,
+               (cusolverDnHandle_t,),
+               handle)
 end
 function cusolverDnSetStream(handle, streamId)
-  @check ccall( (:cusolverDnSetStream, libcusolver), cusolverStatus_t, (cusolverDnHandle_t, CuStream_t), handle, streamId)
+  @check ccall((:cusolverDnSetStream, libcusolver),
+               cusolverStatus_t,
+               (cusolverDnHandle_t, CuStream_t),
+               handle, streamId)
 end
 function cusolverDnGetStream(handle, streamId)
-  @check ccall( (:cusolverDnGetStream, libcusolver), cusolverStatus_t, (cusolverDnHandle_t, Ptr{CuStream_t}), handle, streamId)
+  @check ccall((:cusolverDnGetStream, libcusolver),
+               cusolverStatus_t,
+               (cusolverDnHandle_t, Ptr{CuStream_t}),
+               handle, streamId)
 end
 function cusolverSpCreate(handle)
-  @check ccall( (:cusolverSpCreate, libcusolver), cusolverStatus_t, (Ptr{cusolverSpHandle_t},), handle)
+  @check ccall((:cusolverSpCreate, libcusolver),
+               cusolverStatus_t,
+               (Ptr{cusolverSpHandle_t},),
+               handle)
 end
 function cusolverSpDestroy(handle)
-  @check ccall( (:cusolverSpDestroy, libcusolver), cusolverStatus_t, (cusolverSpHandle_t,), handle)
+  @check ccall((:cusolverSpDestroy, libcusolver),
+               cusolverStatus_t,
+               (cusolverSpHandle_t,),
+               handle)
 end
 function cusolverSpSetStream(handle, streamId)
-  @check ccall( (:cusolverSpSetStream, libcusolver), cusolverStatus_t, (cusolverSpHandle_t, CuStream_t), handle, streamId)
+  @check ccall((:cusolverSpSetStream, libcusolver),
+               cusolverStatus_t,
+               (cusolverSpHandle_t, CuStream_t),
+               handle, streamId)
 end
 function cusolverSpGetStream(handle, streamId)
-  @check ccall( (:cusolverSpGetStream, libcusolver), cusolverStatus_t, (cusolverSpHandle_t, Ptr{CuStream_t}), handle, streamId)
+  @check ccall((:cusolverSpGetStream, libcusolver),
+               cusolverStatus_t,
+               (cusolverSpHandle_t, Ptr{CuStream_t}),
+               handle, streamId)
 end
 function cusolverSpCreateCsrqrInfo(info)
-  @check ccall( (:cusolverSpCreateCsrqrInfo, libcusolver), cusolverStatus_t, (Ptr{csrqrInfo_t},), info)
+  @check ccall((:cusolverSpCreateCsrqrInfo, libcusolver),
+               cusolverStatus_t,
+               (Ptr{csrqrInfo_t},),
+               info)
 end
 function cusolverSpDestroyCsrqrInfo(info)
-  @check ccall( (:cusolverDestroyCsrqrInfo, libcusolver), cusolverStatus_t, (csrqrInfo_t,), info)
+  @check ccall((:cusolverDestroyCsrqrInfo, libcusolver),
+               cusolverStatus_t,
+               (csrqrInfo_t,),
+               info)
 end
 function cusolverRfCreate(handle)
-  @check ccall( (:cusolverRfCreate, libcusolver), cusolverStatus_t, (Ptr{cusolverRfHandle_t},), handle)
+  @check ccall((:cusolverRfCreate, libcusolver),
+               cusolverStatus_t,
+               (Ptr{cusolverRfHandle_t},),
+               handle)
 end
 function cusolverRfDestroy(handle)
-  @check ccall( (:cusolverRfDestroy, libcusolver), cusolverStatus_t, (cusolverRfHandle_t,), handle)
+  @check ccall((:cusolverRfDestroy, libcusolver),
+               cusolverStatus_t,
+               (cusolverRfHandle_t,),
+               handle)
 end
 function cusolverRfSetStream(handle, streamId)
-  @check ccall( (:cusolverRfSetStream, libcusolver), cusolverStatus_t, (cusolverRfHandle_t, CuStream_t), handle, streamId)
+  @check ccall((:cusolverRfSetStream, libcusolver),
+               cusolverStatus_t,
+               (cusolverRfHandle_t, CuStream_t),
+               handle, streamId)
 end
 function cusolverRfGetStream(handle, streamId)
-  @check ccall( (:cusolverRfGetStream, libcusolver), cusolverStatus_t, (cusolverRfHandle_t, Ptr{CuStream_t}), handle, streamId)
+  @check ccall((:cusolverRfGetStream, libcusolver),
+               cusolverStatus_t,
+               (cusolverRfHandle_t, Ptr{CuStream_t}),
+               handle, streamId)
 end

--- a/src/solver/libcusolver.jl
+++ b/src/solver/libcusolver.jl
@@ -2,7 +2,9 @@
 
 #helper functions
 function cusolverDnCreate(handle)
+  handle = Ref{cusolverDnHandle_t}()
   @check ccall( (:cusolverDnCreate, libcusolver), cusolverStatus_t, (Ptr{cusolverDnHandle_t},), handle)
+  return handle[]
 end
 function cusolverDnDestroy(handle)
   @check ccall( (:cusolverDnDestroy, libcusolver), cusolverStatus_t, (cusolverDnHandle_t,), handle)

--- a/src/solver/libcusolver.jl
+++ b/src/solver/libcusolver.jl
@@ -8,10 +8,10 @@ function cusolverDnDestroy(handle)
   @check ccall( (:cusolverDnDestroy, libcusolver), cusolverStatus_t, (cusolverDnHandle_t,), handle)
 end
 function cusolverDnSetStream(handle, streamId)
-  @check ccall( (:cusolverDnSetStream, libcusolver), cusolverStatus_t, (cusolverDnHandle_t, cudaStream_t), handle, streamId)
+  @check ccall( (:cusolverDnSetStream, libcusolver), cusolverStatus_t, (cusolverDnHandle_t, CuStream_t), handle, streamId)
 end
 function cusolverDnGetStream(handle, streamId)
-  @check ccall( (:cusolverDnGetStream, libcusolver), cusolverStatus_t, (cusolverDnHandle_t, Ptr{cudaStream_t}), handle, streamId)
+  @check ccall( (:cusolverDnGetStream, libcusolver), cusolverStatus_t, (cusolverDnHandle_t, Ptr{CuStream_t}), handle, streamId)
 end
 function cusolverSpCreate(handle)
   @check ccall( (:cusolverSpCreate, libcusolver), cusolverStatus_t, (Ptr{cusolverSpHandle_t},), handle)
@@ -20,10 +20,10 @@ function cusolverSpDestroy(handle)
   @check ccall( (:cusolverSpDestroy, libcusolver), cusolverStatus_t, (cusolverSpHandle_t,), handle)
 end
 function cusolverSpSetStream(handle, streamId)
-  @check ccall( (:cusolverSpSetStream, libcusolver), cusolverStatus_t, (cusolverSpHandle_t, cudaStream_t), handle, streamId)
+  @check ccall( (:cusolverSpSetStream, libcusolver), cusolverStatus_t, (cusolverSpHandle_t, CuStream_t), handle, streamId)
 end
 function cusolverSpGetStream(handle, streamId)
-  @check ccall( (:cusolverSpGetStream, libcusolver), cusolverStatus_t, (cusolverSpHandle_t, Ptr{cudaStream_t}), handle, streamId)
+  @check ccall( (:cusolverSpGetStream, libcusolver), cusolverStatus_t, (cusolverSpHandle_t, Ptr{CuStream_t}), handle, streamId)
 end
 function cusolverSpCreateCsrqrInfo(info)
   @check ccall( (:cusolverSpCreateCsrqrInfo, libcusolver), cusolverStatus_t, (Ptr{csrqrInfo_t},), info)
@@ -38,8 +38,8 @@ function cusolverRfDestroy(handle)
   @check ccall( (:cusolverRfDestroy, libcusolver), cusolverStatus_t, (cusolverRfHandle_t,), handle)
 end
 function cusolverRfSetStream(handle, streamId)
-  @check ccall( (:cusolverRfSetStream, libcusolver), cusolverStatus_t, (cusolverRfHandle_t, cudaStream_t), handle, streamId)
+  @check ccall( (:cusolverRfSetStream, libcusolver), cusolverStatus_t, (cusolverRfHandle_t, CuStream_t), handle, streamId)
 end
 function cusolverRfGetStream(handle, streamId)
-  @check ccall( (:cusolverRfGetStream, libcusolver), cusolverStatus_t, (cusolverRfHandle_t, Ptr{cudaStream_t}), handle, streamId)
+  @check ccall( (:cusolverRfGetStream, libcusolver), cusolverStatus_t, (cusolverRfHandle_t, Ptr{CuStream_t}), handle, streamId)
 end

--- a/src/solver/libcusolver.jl
+++ b/src/solver/libcusolver.jl
@@ -1,7 +1,7 @@
 # Julia wrapper for header: /usr/local/cuda/include/cusolver.h
 
 #helper functions
-function cusolverDnCreate(handle)
+function cusolverDnCreate()
   handle = Ref{cusolverDnHandle_t}()
   @check ccall( (:cusolverDnCreate, libcusolver), cusolverStatus_t, (Ptr{cusolverDnHandle_t},), handle)
   return handle[]


### PR DESCRIPTION
Two goals: 1) multi-device means multiple handles, 2) eagerly instantiating handles consumes a lot of memory (I've seen 200MB per CUDNN handle).

Didn't rework CUFFT because the code is a bit of a mess and it looks like the plans are not instantiated eagerly/globally?

Finally, destroying the CURAND handle crashes, so I've disabled it. Maybe it's not worth to ever call these methods since we're exiting the process anyway...

```
signal (11): Segmentation fault
in expression starting at no file:0
curandDestroyGenerator at /home/tbesard/CUDA/toolkit/current/lib64/libcurand.so (unknown line)
macro expansion at /home/tbesard/Julia/CuArrays/src/rand/error.jl:49 [inlined]
destroy_generator at /home/tbesard/Julia/CuArrays/src/rand/libcurand.jl:11
unknown function (ip: 0x7f746cee6040)
jl_fptr_trampoline at /buildworker/worker/package_linux64/build/src/gf.c:1831
jl_apply_generic at /buildworker/worker/package_linux64/build/src/gf.c:2184
jl_apply at /buildworker/worker/package_linux64/build/src/julia.h:1537 [inlined]
run_finalizer at /buildworker/worker/package_linux64/build/src/gc.c:115
jl_gc_run_finalizers_in_list at /buildworker/worker/package_linux64/build/src/gc.c:210
jl_gc_run_all_finalizers at /buildworker/worker/package_linux64/build/src/gc.c:245
jl_atexit_hook at /buildworker/worker/package_linux64/build/src/init.c:260
main at /buildworker/worker/package_linux64/build/ui/repl.c:234
__libc_start_main at /usr/lib/libc.so.6 (unknown line)
_start at /home/tbesard/Julia/julia-1.0/build/binary/bin/julia (unknown line)
Allocations: 547321220 (Pool: 547216498; Big: 104722); GC: 1286
```
