### PR TITLE
Don't pool large arrays

### DIFF
--- a/src/memory.jl
+++ b/src/memory.jl
@@ -208,6 +208,7 @@ function reclaim(full::Bool=false)
   end
 end
 
+const MAX_POOL = 100*1024^2 # 100 MiB
 
 ## interface
 
@@ -219,6 +220,8 @@ function alloc(bytes)
   pool_stats.req_nalloc += 1
   pool_stats.req_alloc += bytes
   pool_stats.total_time += Base.@elapsed begin
+    bytes > MAX_POOL && return Mem.alloc(bytes)
+
     pid = poolidx(bytes)
     create_pools(pid)
 


### PR DESCRIPTION
The pooling allocator is designed for small arrays, and doesn't really make any sense for one that take up a significant amount of GPU memory. This fixes the immediate issue by just not pooling at all for large arrays.

In future, we could extend this by just using a different pooling strategy for arrays of this size. For example, in this regime linear lookups are much less of a big deal (at most we can allocate ~100 arrays of this size anyway) so allocating exact sizes and searching for the smallest buffer to reuse would be sensible.