### PR TITLE
Allow fast views of contiguous entries

### DIFF
--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -26,6 +26,7 @@ end
 
 include("memory.jl")
 include("array.jl")
+include("subarray.jl")
 include("utils.jl")
 include("indexing.jl")
 include("broadcast.jl")

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -9,7 +9,3 @@ function _setindex!(xs::CuArray{T}, v::T, i::Integer) where T
   buf = Mem.view(buffer(xs), (i-1)*sizeof(T))
   Mem.upload!(buf, T[v])
 end
-
-function Base.view(xs::CuArray{T}, i::UnitRange) where T
-  CuVector{T}(xs.buf, xs.offset+(i.start-1)*sizeof(T), (i.stop-i.start+1,))
-end

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -1,0 +1,34 @@
+import Base: view
+
+using Base: ScalarIndex, ViewIndex, Slice, @_inline_meta, @boundscheck, 
+            to_indices, compute_offset1, unsafe_length
+
+struct Contiguous end
+struct NonContiguous end
+
+# Detect whether the view is contiguous or not
+CuIndexStyle() = Contiguous()
+CuIndexStyle(i1::Colon, I...) = CuIndexStyle(I...)
+CuIndexStyle(i1::AbstractUnitRange, ::ScalarIndex...) = Contiguous()
+CuIndexStyle(I...) = NonContiguous()
+
+cuviewlength() = ()
+cuviewlength(::Real, I...) = (@_inline_meta; cuviewlength(I...)) # skip scalars
+cuviewlength(i1::AbstractUnitRange, I...) = (@_inline_meta; (unsafe_length(i1), cuviewlength(I...)...))
+cuviewlength(i1::AbstractUnitRange, ::ScalarIndex...) = (@_inline_meta; (unsafe_length(i1),))
+
+view(A::CuArray, I::Vararg{Any,N}) where {N} = (@_inline_meta; _cuview(A, I, CuIndexStyle(I...)))
+
+function _cuview(A, I, ::Contiguous)
+    @_inline_meta
+    J = to_indices(A, I)
+    @boundscheck checkbounds(A, J...)
+    _cuview(A, J, cuviewlength(J...))
+end
+
+# for contiguous views just return a new CuArray
+_cuview(A::CuArray{T}, I::NTuple{N,ViewIndex}, dims::NTuple{M,Integer}) where {T,N,M} =
+    CuArray{T,M}(A.buf, A.offset + compute_offset1(A, 1, I) * sizeof(T), dims)
+
+# fallback to SubArray when the view is not contiguous
+_cuview(A, I::NTuple{N,ViewIndex}, ::NonContiguous) where {N} = invoke(view, Tuple{AbstractArray, typeof(I).parameters...}, A, I...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,12 +41,13 @@ macro grab_output(ex)
     end
 end
 
+using GPUArrays
+import GPUArrays: allowscalar, @allowscalar
+
 Random.seed!(1)
-CuArrays.allowscalar(false)
+allowscalar(false)
 
 testf(f, xs...; kwargs...) = GPUArrays.TestSuite.compare(f, CuArray, xs...; kwargs...)
-
-using GPUArrays
 
 @testset "CuArrays" begin
 
@@ -144,9 +145,8 @@ end
     y .= 1
     x
   end
-  let
-    x = cu(rand(Float32, 5, 4, 3))
-    @test collect(view(x, :, 1:4, 3)) == view(x, :, 1:4, 3)
+  @test testf(x->view(x, :, 1:4, 3), rand(Float32, 5, 4, 3))
+  @allowscalar let x = cu(rand(Float32, 5, 4, 3))
     @test_throws BoundsError view(x, :, :, 1:10)
     @test typeof(view(x, :, 1:4, 3)) <: CuMatrix # contiguous view
     @test typeof(view(x, 1, 1:4, 3)) <: SubArray # non-contiguous view

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,10 +145,11 @@ end
     x
   end
   let
-    x = cu([1, 2, 3, 4, 5])
-    y = reshape(view(x, 1:3), 1, 3)
-    y[1:1] = 6
-    @test x[1:1] == cu([6])
+    x = cu(rand(Float32, 5, 4, 3))
+    @test collect(view(x, :, 1:4, 3)) == view(x, :, 1:4, 3)
+    @test_throws BoundsError view(x, :, :, 1:10)
+    @test typeof(view(x, :, 1:4, 3)) <: CuMatrix # contiguous view
+    @test typeof(view(x, 1, 1:4, 3)) <: SubArray # non-contiguous view
   end
 end
 


### PR DESCRIPTION
This improves #157 a bit by returning new `CuArray`s whenever the view is contiguous

```julia
A = cu(rand(Float32, 10, 8, 6))
view(A, :, 3:6, 4) # now returns CuMatrix{Float32}
```

while

```julia
view(A, 3:5, 5:6, 4) # still returns SubArray
```