### PR TITLE
Simplify array constructors.

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -2,29 +2,98 @@ import CUDAnative: DevicePtr
 
 mutable struct CuArray{T,N} <: GPUArray{T,N}
   buf::Mem.Buffer
+  dims::Dims{N}
   offset::Int
-  dims::NTuple{N,Int}
 
-  function CuArray{T,N}(buf::Mem.Buffer, offset::Integer, dims::NTuple{N,Integer}) where {T,N}
-    xs = new{T,N}(buf, offset, dims)
+  function CuArray{T,N}(buf::Mem.Buffer, dims::Dims{N}, offset::Integer=0) where {T,N}
+    xs = new{T,N}(buf, dims, offset)
     Mem.retain(buf)
     finalizer(unsafe_free!, xs)
     return xs
   end
 end
 
-CuArray{T,N}(buf::Mem.Buffer, dims::NTuple{N,Integer}) where {T,N} = CuArray{T,N}(buf, 0, dims)
-
 CuVector{T} = CuArray{T,1}
 CuMatrix{T} = CuArray{T,2}
 CuVecOrMat{T} = Union{CuVector{T},CuMatrix{T}}
-
-Base.elsize(::CuArray{T}) where T = sizeof(T)
 
 function unsafe_free!(xs::CuArray)
   Mem.release(xs.buf) && dealloc(xs.buf, prod(xs.dims)*sizeof(eltype(xs)))
   return
 end
+
+
+## construction
+
+# type and dimensionality specified, accepting dims as tuples of Ints
+CuArray{T,N}(::UndefInitializer, dims::Dims{N}) where {T,N} =
+  CuArray{T,N}(alloc(prod(dims)*sizeof(T)), dims)
+
+# type and dimensionality specified, accepting dims as series of Ints
+CuArray{T,N}(::UndefInitializer, dims::Integer...) where {T,N} = CuArray{T,N}(undef, dims)
+
+# type but not dimensionality specified
+CuArray{T}(::UndefInitializer, dims::Dims{N}) where {T,N} = CuArray{T,N}(undef, dims)
+CuArray{T}(::UndefInitializer, dims::Integer...) where {T} =
+  CuArray{T}(undef, convert(Tuple{Vararg{Int}}, dims))
+
+# empty vector constructor
+CuArray{T,1}() where {T} = CuArray{T,1}(undef, 0)
+
+
+Base.similar(a::CuArray{T,N}) where {T,N} = CuArray{T,N}(undef, size(a))
+Base.similar(a::CuArray{T}, dims::Base.Dims{N}) where {T,N} = CuArray{T,N}(undef, dims)
+Base.similar(a::CuArray, ::Type{T}, dims::Base.Dims{N}) where {T,N} = CuArray{T,N}(undef, dims)
+
+
+## array interface
+
+Base.elsize(::Type{<:CuArray{T}}) where {T} = sizeof(T)
+
+Base.size(x::CuArray) = x.dims
+Base.sizeof(x::CuArray) = Base.elsize(x) * length(x)
+
+
+## interop with other arrays
+
+# type and dimensionality specified
+CuArray{T,N}(x::AbstractArray{S,N}) where {T,N,S} = convert(CuArray{T,N}, x)
+
+# type but not dimensionality specified
+CuArray{T}(A::AbstractArray{S,N}) where {T,N,S} = CuArray{T,N}(A)
+
+# dimensionality but not type specified
+(::Type{CuArray{T,N} where T})(x::AbstractArray{S,N}) where {S,N} = CuArray{S,N}(x)
+
+# nothing specified
+CuArray(A::AbstractArray{T,N}) where {T,N} = CuArray{T,N}(A)
+
+
+Base.convert(::Type{CuArray{T,N}}, xs::Array{T,N}) where {T,N} =
+  copyto!(CuArray{T,N}(undef, size(xs)), xs)
+
+Base.convert(::Type{CuArray{T}}, xs::Array{T,N}) where {T,N} =
+  copyto!(CuArray{T}(undef, size(xs)), xs)
+
+Base.convert(::Type{CuArray}, xs::Array{T,N}) where {T,N} =
+  convert(CuArray{T,N}, xs)
+
+
+Base.convert(::Type{CuArray{T,N}}, xs::AbstractArray{T,N}) where {T,N} =
+  isbits(xs) ?
+    (CuArray{T,N}(undef, size(xs)) .= xs) :
+    convert(CuArray{T,N}, collect(xs))
+
+Base.convert(::Type{CuArray{T,N}}, xs::AbstractArray{S,N}) where {S,T,N} =
+  convert(CuArray{T,N}, (x -> T(x)).(xs))
+
+Base.convert(::Type{CuArray{T}}, xs::AbstractArray) where T =
+  convert(CuArray{T,ndims(xs)}, xs)
+
+Base.convert(::Type{CuArray}, xs::AbstractArray) = convert(CuArray{eltype(xs)}, xs)
+
+
+## interop with C libraries
 
 """
   buffer(array::CuArray [, index])
@@ -42,32 +111,24 @@ end
 Base.cconvert(::Type{Ptr{T}}, x::CuArray{T}) where T = buffer(x)
 Base.cconvert(::Type{Ptr{Nothing}}, x::CuArray) = buffer(x)
 
-CuArray{T,N}(dims::NTuple{N,Integer}) where {T,N} =
-  CuArray{T,N}(alloc(prod(dims)*sizeof(T)), dims)
-# This constructor is to avoid ambiguity with constructor in GPUArrays
-CuArray{T,0}(::Tuple{}) where T = CuArray{T,0}(alloc(sizeof(T)), ())
 
-CuArray{T}(dims::NTuple{N,Integer}) where {T,N} =
-  CuArray{T,N}(dims)
-# This constructor is to avoid ambiguity with constructor in GPUArrays
-CuArray{T}(::Tuple{}) where T = CuArray{T,0}()
+## interop with CUDAnative
 
-CuArray(dims::NTuple{N,Integer}) where N = CuArray{Float32,N}(dims)
+function Base.convert(::Type{CuDeviceArray{T,N,AS.Global}}, a::CuArray{T,N}) where {T,N}
+    ptr = Base.unsafe_convert(Ptr{T}, a.buf)
+    CuDeviceArray{T,N,AS.Global}(a.dims, DevicePtr{T,AS.Global}(ptr+a.offset))
+end
 
-(T::Type{<:CuArray})(dims::Integer...) = T(dims)
+Adapt.adapt_storage(::CUDAnative.Adaptor, xs::CuArray{T,N}) where {T,N} =
+  convert(CuDeviceArray{T,N,AS.Global}, xs)
 
-Base.similar(a::CuArray{T,N}) where {T,N} = CuArray{T,N}(size(a))
-Base.similar(a::CuArray{T}, dims::Base.Dims{N}) where {T,N} = CuArray{T,N}(dims)
-Base.similar(a::CuArray, ::Type{T}, dims::Base.Dims{N}) where {T,N} =
-  CuArray{T,N}(dims)
 
-Base.size(x::CuArray) = x.dims
-Base.sizeof(x::CuArray) = Base.elsize(x) * length(x)
+## other
 
 function Base._reshape(parent::CuArray, dims::Dims)
   n = length(parent)
   prod(dims) == n || throw(DimensionMismatch("parent has $n elements, which is incompatible with size $dims"))
-  return CuArray{eltype(parent),length(dims)}(parent.buf, parent.offset, dims)
+  return CuArray{eltype(parent),length(dims)}(parent.buf, dims, parent.offset)
 end
 
 # Interop with CPU array
@@ -96,29 +157,7 @@ end
 
 Base.convert(::Type{T}, x::T) where T <: CuArray = x
 
-Base.convert(::Type{CuArray{T,N}}, xs::Array{T,N}) where {T,N} =
-  copyto!(CuArray{T,N}(size(xs)), xs)
-
-Base.convert(::Type{CuArray{T}}, xs::Array{T,N}) where {T,N} =
-  copyto!(CuArray{T}(size(xs)), xs)
-
-Base.convert(::Type{CuArray}, xs::Array{T,N}) where {T,N} =
-  convert(CuArray{T,N}, xs)
-
 # Generic methods
-
-Base.convert(::Type{CuArray{T,N}}, xs::AbstractArray{T,N}) where {T,N} =
-  isbits(xs) ?
-    (CuArray{T,N}(size(xs)) .= xs) :
-    convert(CuArray{T,N}, collect(xs))
-
-Base.convert(::Type{CuArray{T,N}}, xs::AbstractArray{S,N}) where {S,T,N} =
-  convert(CuArray{T,N}, (x -> T(x)).(xs))
-
-Base.convert(::Type{CuArray{T}}, xs::AbstractArray) where T =
-  convert(CuArray{T,ndims(xs)},xs)
-
-Base.convert(::Type{CuArray}, xs::AbstractArray) = convert(CuArray{eltype(xs)}, xs)
 
 # Work around GPUArrays ambiguity
 Base.convert(AT::Type{CuArray{T1,N}}, A::DenseArray{T2, N}) where {T1, T2, N} =
@@ -127,21 +166,11 @@ Base.convert(AT::Type{CuArray{T1,N}}, A::DenseArray{T2, N}) where {T1, T2, N} =
 Base.convert(AT::Type{CuArray{T1}}, A::DenseArray{T2, N}) where {T1, T2, N} =
   invoke(convert, Tuple{Type{CuArray{T1}},AbstractArray{T2,N}}, AT, A)
 
-# Interop with CUDAnative device array
-
-function Base.convert(::Type{CuDeviceArray{T,N,AS.Global}}, a::CuArray{T,N}) where {T,N}
-    ptr = Base.unsafe_convert(Ptr{T}, a.buf)
-    CuDeviceArray{T,N,AS.Global}(a.dims, DevicePtr{T,AS.Global}(ptr+a.offset))
-end
-
-Adapt.adapt_storage(::CUDAnative.Adaptor, xs::CuArray{T,N}) where {T,N} =
-  convert(CuDeviceArray{T,N,AS.Global}, xs)
-
 
 # Utils
 
-cuzeros(T::Type, dims...) = fill!(CuArray{T}(dims...), 0)
-cuones(T::Type, dims...) = fill!(CuArray{T}(dims...), 1)
+cuzeros(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 0)
+cuones(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 1)
 cuzeros(dims...) = cuzeros(Float32, dims...)
 cuones(dims...) = cuones(Float32, dims...)
 
@@ -149,9 +178,9 @@ Base.print_array(io::IO, x::CuArray) = Base.print_array(io, collect(x))
 Base.print_array(io::IO, x::LinearAlgebra.Adjoint{<:Any,<:CuArray}) = Base.print_array(io, LinearAlgebra.adjoint(collect(x.parent)))
 Base.print_array(io::IO, x::LinearAlgebra.Transpose{<:Any,<:CuArray}) = Base.print_array(io, LinearAlgebra.transpose(collect(x.parent)))
 
-Adapt.adapt_storage(::CuArray, xs::AbstractArray) = convert(CuArray, xs)
-Adapt.adapt_storage(::CuArray{T}, xs::AbstractArray{<:Real}) where T <: AbstractFloat = convert(CuArray{T}, xs)
-cu(xs) = adapt(CuArray{Float32}(), xs)
+Adapt.adapt_storage(::Type{<:CuArray}, xs::AbstractArray) = convert(CuArray, xs)
+Adapt.adapt_storage(::Type{<:CuArray{T}}, xs::AbstractArray{<:Real}) where T <: AbstractFloat = convert(CuArray{T}, xs)
+cu(xs) = adapt(CuArray{Float32}, xs)
 
 
 Base.getindex(::typeof(cu), xs...) = CuArray([xs...])

--- a/src/blas/wrap.jl
+++ b/src/blas/wrap.jl
@@ -1554,8 +1554,8 @@ for (fname, elty) in
             m,n = size(A[1])
             lda = max(1,stride(A[1],2))
             Aptrs = device_batch(A)
-            info  = CuArray{Cint}(length(A))
-            pivotArray  = Pivot ? CuArray{Int32}((n, length(A))) : C_NULL
+            info  = CuArray{Cint}(undef, length(A))
+            pivotArray  = Pivot ? CuArray{Int32}(undef, (n, length(A))) : C_NULL
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, Cint, Ptr{Ptr{$elty}}, Cint,
                           Ptr{Cint}, Ptr{Cint}, Cint), handle(), n,

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -3,7 +3,7 @@ import Base.Broadcast: Broadcasted, Extruded, BroadcastStyle, ArrayStyle
 BroadcastStyle(::Type{<:CuArray}) = ArrayStyle{CuArray}()
 
 function Base.similar(bc::Broadcasted{ArrayStyle{CuArray}}, ::Type{T}) where T
-    similar(CuArray, T, axes(bc))
+    similar(CuArray{T}, axes(bc))
 end
 
 

--- a/src/dnn/nnlib.jl
+++ b/src/dnn/nnlib.jl
@@ -68,7 +68,7 @@ function conv_workspace(bytes)
   if isassigned(_conv_workspace) && bytes <= length(_conv_workspace[])
     _conv_workspace[]
   else
-    _conv_workspace[] = CuVector{UInt8}(bytes)
+    _conv_workspace[] = CuVector{UInt8}(undef, bytes)
   end
 end
 

--- a/src/fft/CUFFT.jl
+++ b/src/fft/CUFFT.jl
@@ -426,7 +426,7 @@ end
 # Perhaps use FakeArray types to avoid this.
 
 function plan_inv(p::cCuFFTPlan{T,CUFFT_FORWARD,inplace,N}) where {T,N,inplace}
-    X = CuArray{T}(p.sz)
+    X = CuArray{T}(undef, p.sz)
     pp = _mkplan(p.xtype, p.sz, p.region)
     ScaledPlan(cCuFFTPlan{T,CUFFT_INVERSE,inplace,N}(pp, X, p.sz, p.region,
                                                      p.xtype),
@@ -434,7 +434,7 @@ function plan_inv(p::cCuFFTPlan{T,CUFFT_FORWARD,inplace,N}) where {T,N,inplace}
 end
 
 function plan_inv(p::cCuFFTPlan{T,CUFFT_INVERSE,inplace,N}) where {T,N,inplace}
-    X = CuArray{T}(p.sz)
+    X = CuArray{T}(undef, p.sz)
     pp = _mkplan(p.xtype, p.sz, p.region)
     ScaledPlan(cCuFFTPlan{T,CUFFT_FORWARD,inplace,N}(pp, X, p.sz, p.region,
                                                      p.xtype),
@@ -443,8 +443,8 @@ end
 
 function plan_inv(p::rCuFFTPlan{T,CUFFT_INVERSE,inplace,N}
                   ) where {T<:cufftComplexes,N,inplace}
-    X = CuArray{real(T)}(p.osz)
-    Y = CuArray{T}(p.sz)
+    X = CuArray{real(T)}(undef, p.osz)
+    Y = CuArray{T}(undef, p.sz)
     xtype = p.xtype == CUFFT_C2R ? CUFFT_R2C : CUFFT_D2Z
     pp = _mkplan(xtype, p.osz, p.region)
     ScaledPlan(rCuFFTPlan{real(T),CUFFT_FORWARD,inplace,N}(pp, X, p.sz, p.region,
@@ -454,8 +454,8 @@ end
 
 function plan_inv(p::rCuFFTPlan{T,CUFFT_FORWARD,inplace,N}
                   ) where {T<:cufftReals,N,inplace}
-    X = CuArray{complex(T)}(p.osz)
-    Y = CuArray{T}(p.sz)
+    X = CuArray{complex(T)}(undef, p.osz)
+    Y = CuArray{T}(undef, p.sz)
     xtype = p.xtype == CUFFT_R2C ? CUFFT_C2R : CUFFT_Z2D
     pp = _mkplan(xtype, p.sz, p.region)
     ScaledPlan(rCuFFTPlan{complex(T),CUFFT_INVERSE,inplace,N}(pp, X, p.sz,
@@ -484,7 +484,7 @@ end
 function *(p::rCuFFTPlan{T,CUFFT_FORWARD,false,N}, x::CuArray{T,N}
            ) where {T<:cufftReals,N}
     @assert p.xtype ∈ [CUFFT_R2C,CUFFT_D2Z]
-    y = CuArray{complex(T),N}(p.osz)
+    y = CuArray{complex(T),N}(undef, p.osz)
     mul!(y,p,x)
     y
 end
@@ -492,13 +492,13 @@ end
 function *(p::rCuFFTPlan{T,CUFFT_INVERSE,false,N}, x::CuArray{T,N}
            ) where {T<:cufftComplexes,N}
     @assert p.xtype ∈ [CUFFT_C2R,CUFFT_Z2D]
-    y = CuArray{real(T),N}(p.osz)
+    y = CuArray{real(T),N}(undef, p.osz)
     mul!(y,p,x)
     y
 end
 
 function *(p::cCuFFTPlan{T,K,false,N}, x::CuArray{T,N}) where {T,K,N}
-    y = CuArray{T,N}(p.osz)
+    y = CuArray{T,N}(undef, p.osz)
     mul!(y,p,x)
     y
 end

--- a/src/fft/genericfft.jl
+++ b/src/fft/genericfft.jl
@@ -14,7 +14,7 @@ complexfloat(x::CuArray{T}) where {T<:Real} = copy1(typeof(complex(cufftfloat(ze
 realfloat(x::CuArray{T}) where {T<:Real} = copy1(typeof(cufftfloat(zero(T))), x)
 
 function copy1(::Type{T}, x) where T
-    y = CuArray{T}(map(length, axes(x)))
+    y = CuArray{T}(undef, map(length, axes(x)))
     #copy!(y, x)
     y .= broadcast(xi->convert(T,xi),x)
 end

--- a/src/gpuarray_interface.jl
+++ b/src/gpuarray_interface.jl
@@ -3,9 +3,6 @@ import GPUArrays
 struct CuArrayBackend <: GPUArrays.GPUBackend end
 GPUArrays.backend(::Type{<:CuArray}) = CuArrayBackend()
 
-Base.similar(::Type{<:CuArray}, ::Type{T}, size::Base.Dims{N}) where {T, N} = CuArray{T, N}(size)
-# This constructor is to avoid ambiguity with constructor in GPUArrays
-Base.similar(::Type{<:CuArray}, ::Type{T}, ::Tuple{}) where {T} = CuArray{T,0}()
 
 #Abstract GPU interface
 struct CuKernelState end

--- a/src/rand/highlevel.jl
+++ b/src/rand/highlevel.jl
@@ -32,10 +32,10 @@ rand_poisson!(rng::RNG, A::CuArray{Cuint}; lambda=1) = generate_poisson(rng, A, 
 
 ## out of place
 
-Random.rand(rng::RNG, ::Type{X}, dims::Dims) where {X} = rand!(rng, CuArray{X}(dims))
-Random.randn(rng::RNG, ::Type{X}, dims::Dims; kwargs...) where {X} = randn!(rng, CuArray{X}(dims); kwargs...)
-rand_logn(rng::RNG, ::Type{X}, dims::Dims; kwargs...) where {X} = rand_logn!(rng, CuArray{X}(dims); kwargs...)
-rand_poisson(rng::RNG, ::Type{X}, dims::Dims; kwargs...) where {X} = rand_poisson!(rng, CuArray{X}(dims); kwargs...)
+Random.rand(rng::RNG, ::Type{X}, dims::Dims) where {X} = rand!(rng, CuArray{X}(undef, dims))
+Random.randn(rng::RNG, ::Type{X}, dims::Dims; kwargs...) where {X} = randn!(rng, CuArray{X}(undef, dims); kwargs...)
+rand_logn(rng::RNG, ::Type{X}, dims::Dims; kwargs...) where {X} = rand_logn!(rng, CuArray{X}(undef, dims); kwargs...)
+rand_poisson(rng::RNG, ::Type{X}, dims::Dims; kwargs...) where {X} = rand_poisson!(rng, CuArray{X}(undef, dims); kwargs...)
 
 # specify default types
 Random.rand(rng::RNG, dims::Integer...; kwargs...) = rand(rng, Float32, dims...; kwargs...)
@@ -78,10 +78,10 @@ rand_poisson!(A::CuArray; kwargs...) = rand_poisson!(poisson_rng(A), A; kwargs..
 
 # need to prefix with `cu` to disambiguate from Random functions that return an Array
 # TODO: `@gpu rand` with Cassette
-curand(::Type{X}, args...; kwargs...) where {X} = rand!(CuArray{X}(args...); kwargs...)
-curandn(::Type{X}, args...; kwargs...) where {X} = randn!(CuArray{X}(args...); kwargs...)
-curand_logn(::Type{X}, args...; kwargs...) where {X} = rand_logn!(CuArray{X}(args...); kwargs...)
-curand_poisson(::Type{X}, args...; kwargs...) where {X} = rand_poisson!(CuArray{X}(args...); kwargs...)
+curand(::Type{X}, args...; kwargs...) where {X} = rand!(CuArray{X}(undef, args...); kwargs...)
+curandn(::Type{X}, args...; kwargs...) where {X} = randn!(CuArray{X}(undef, args...); kwargs...)
+curand_logn(::Type{X}, args...; kwargs...) where {X} = rand_logn!(CuArray{X}(undef, args...); kwargs...)
+curand_poisson(::Type{X}, args...; kwargs...) where {X} = rand_poisson!(CuArray{X}(undef, args...); kwargs...)
 
 # specify default types
 curand(args...; kwargs...) where {X} = curand(Float32, args...; kwargs...)

--- a/src/solver/dense.jl
+++ b/src/solver/dense.jl
@@ -19,8 +19,8 @@ for (bname, fname,elty) in ((:cusolverDnSpotrf_bufferSize, :cusolverDnSpotrf, :F
                           Ptr{$elty}, Cint, Ref{Cint}),
                          dense_handle(), cuuplo, n, A, lda, bufSize)
 
-            buffer  = CuArray{$elty}(bufSize[])
-            devinfo = CuArray{Cint}(1)
+            buffer  = CuArray{$elty}(undef, bufSize[])
+            devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasFillMode_t, Cint,
                           Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{Cint}),
@@ -51,7 +51,7 @@ for (fname,elty) in ((:cusolverDnSpotrs, :Float32),
             lda  = max(1, stride(A, 2))
             ldb  = max(1, stride(B, 2))
 
-            devinfo = CuArray{Cint}(1)
+            devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint,
                           Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{Cint}),
@@ -79,9 +79,9 @@ for (bname, fname,elty) in ((:cusolverDnSgetrf_bufferSize, :cusolverDnSgetrf, :F
                           Ref{Cint}), dense_handle(), m, n, A, lda,
                          bufSize)
 
-            buffer  = CuArray{$elty}(bufSize[])
-            devipiv = CuArray{Cint}(min(m,n))
-            devinfo = CuArray{Cint}(1)
+            buffer  = CuArray{$elty}(undef, bufSize[])
+            devipiv = CuArray{Cint}(undef, min(m,n))
+            devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Ptr{$elty},
                           Cint, Ptr{$elty}, Ptr{Cint}, Ptr{Cint}),
@@ -112,9 +112,9 @@ for (bname, fname,elty) in ((:cusolverDnSgeqrf_bufferSize, :cusolverDnSgeqrf, :F
                          (cusolverDnHandle_t, Cint, Cint, Ptr{$elty}, Cint,
                           Ref{Cint}), dense_handle(), m, n, A,
                          lda, bufSize)
-            buffer  = CuArray{$elty}(bufSize[])
-            tau  = CuArray{$elty}(min(m, n))
-            devinfo = CuArray{Cint}(1)
+            buffer  = CuArray{$elty}(undef, bufSize[])
+            tau  = CuArray{$elty}(undef, min(m, n))
+            devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)),libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Ptr{$elty},
                           Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{Cint}),
@@ -149,9 +149,9 @@ for (bname, fname,elty) in ((:cusolverDnSsytrf_bufferSize, :cusolverDnSsytrf, :F
                           Ref{Cint}), dense_handle(), n, A, lda,
                          bufSize)
 
-            buffer  = CuArray{$elty}(bufSize[])
-            devipiv = CuArray{Cint}(n)
-            devinfo = CuArray{Cint}(1)
+            buffer  = CuArray{$elty}(undef, bufSize[])
+            devipiv = CuArray{Cint}(undef, n)
+            devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)),libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasFillMode_t, Cint,
                           Ptr{$elty}, Cint, Ptr{Cint}, Ptr{$elty}, Cint,
@@ -190,7 +190,7 @@ for (fname,elty) in ((:cusolverDnSgetrs, :Float32),
             lda  = max(1, stride(A, 2))
             ldb  = max(1, stride(B, 2))
 
-            devinfo = CuArray{Cint}(1)
+            devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasOperation_t, Cint, Cint,
                           Ptr{$elty}, Cint, Ptr{Cint}, Ptr{$elty}, Cint,
@@ -222,7 +222,7 @@ for (bname, fname, elty) in ((:cusolverDnSormqr_bufferSize, :cusolverDnSormqr, :
                 ldc = size(C, 1)
                 n   = size(C, 2)
                 if m > ldc
-                    Ctemp = CuArray{$elty}(m - ldc, n) .= 0
+                    Ctemp = CuArray{$elty}(undef, m - ldc, n) .= 0
                     C = [C; Ctemp]
                     ldc = m
                 end
@@ -242,8 +242,8 @@ for (bname, fname, elty) in ((:cusolverDnSormqr_bufferSize, :cusolverDnSormqr, :
                           dense_handle(), cuside,
                           cutrans, m, n, k, A,
                           lda, tau, C, ldc, bufSize)
-            buffer  = CuArray{$elty}(bufSize[])
-            devinfo = CuArray{Cint}(1)
+            buffer  = CuArray{$elty}(undef, bufSize[])
+            devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)),libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasSideMode_t,
                           cublasOperation_t, Cint, Cint, Cint, Ptr{$elty},
@@ -277,8 +277,8 @@ for (bname, fname, elty) in ((:cusolverDnSorgqr_bufferSize, :cusolverDnSorgqr, :
                           (cusolverDnHandle_t, Cint, Cint, Cint, Ptr{$elty}, Cint,
                            Ptr{$elty}, Ref{Cint}),
                           dense_handle(), m, n, k, A, lda, tau, bufSize)
-            buffer  = CuArray{$elty}(bufSize[])
-            devinfo = CuArray{Cint}(1)
+            buffer  = CuArray{$elty}(undef, bufSize[])
+            devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Cint, Ptr{$elty},
                           Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{Cint}),
@@ -310,13 +310,13 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgebrd_bufferSize, :cusolverDnSg
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Ref{Cint}),
                         dense_handle(), m, n, bufSize)
-            buffer  = CuArray{$elty}(bufSize[])
-            devinfo = CuArray{Cint}(1)
+            buffer  = CuArray{$elty}(undef, bufSize[])
+            devinfo = CuArray{Cint}(undef, 1)
             k       = min(m, n)
-            D       = CuArray{$relty}(k)
-            E       = CuArray{$relty}(k) .= 0
-            TAUQ    = CuArray{$elty}(k)
-            TAUP    = CuArray{$elty}(k)
+            D       = CuArray{$relty}(undef, k)
+            E       = CuArray{$relty}(undef, k) .= 0
+            TAUQ    = CuArray{$elty}(undef, k)
+            TAUP    = CuArray{$elty}(undef, k)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cint, Cint, Ptr{$elty},
                           Cint, Ptr{$relty}, Ptr{$relty}, Ptr{$elty},
@@ -347,13 +347,13 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgesvd_bufferSize, :cusolverDnSg
                          (cusolverDnHandle_t, Cint, Cint, Ref{Cint}),
                         dense_handle(), m, n, bufSize)
 
-            buffer  = CuArray{$elty}(bufSize[])
-            rbuffer = CuArray{$relty}(5 * min(m, n))
-            devinfo = CuArray{Cint}(1)
-            U       = CuArray{$elty}(m, m)
+            buffer  = CuArray{$elty}(undef, bufSize[])
+            rbuffer = CuArray{$relty}(undef, 5 * min(m, n))
+            devinfo = CuArray{Cint}(undef, 1)
+            U       = CuArray{$elty}(undef, m, m)
             ldu     = max(1, stride(U, 2))
-            S       = CuArray{$relty}(min(m, n))
-            Vt      = CuArray{$elty}(n, n)
+            S       = CuArray{$relty}(undef, min(m, n))
+            Vt      = CuArray{$elty}(undef, n, n)
             ldvt    = max(1, stride(Vt, 2))
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cuchar, Cuchar, Cint,

--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -18,8 +18,8 @@ CuQRPackedQ(factors::AbstractMatrix{T}, τ::CuVector{T}) where {T} = CuQRPackedQ
 LinearAlgebra.qr!(A::CuMatrix{T}) where T = CuQR(geqrf!(A::CuMatrix{T})...)
 Base.size(A::CuQR) = size(A.factors)
 Base.size(A::CuQRPackedQ, dim::Integer) = 0 < dim ? (dim <= 2 ? size(A.factors, 1) : 1) : throw(BoundsError())
-Base.convert(::Type{CuMatrix}, A::CuQRPackedQ) = orgqr!(copy(A.factors), A.τ)
-Base.convert(::Type{CuArray}, A::CuQRPackedQ) = convert(CuMatrix, A)
+CuArrays.CuMatrix(A::CuQRPackedQ) = orgqr!(copy(A.factors), A.τ)
+CuArrays.CuArray(A::CuQRPackedQ) = convert(CuMatrix, A)
 Base.Matrix(A::CuQRPackedQ) = Matrix(CuMatrix(A))
 
 function Base.getproperty(A::CuQR, d::Symbol)

--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -49,7 +49,7 @@ LinearAlgebra.lmul!(trA::Transpose{T,<:CuQRPackedQ{T,S}}, B::CuVecOrMat{T}) wher
     ormqr!('L', 'T', parent(trA).factors, parent(trA).τ, B)
 
 function Base.getindex(A::CuQRPackedQ{T, S}, i::Integer, j::Integer) where {T, S}
-    x = CuArray{T}(size(A, 2)) .= 0
+    x = CuArray{T}(undef, size(A, 2)) .= 0
     x[j] = 1
     lmul!(A, x)
     return _getindex(x, i)

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -28,7 +28,7 @@ end
 
 # for contiguous views just return a new CuArray
 _cuview(A::CuArray{T}, I::NTuple{N,ViewIndex}, dims::NTuple{M,Integer}) where {T,N,M} =
-    CuArray{T,M}(A.buf, A.offset + compute_offset1(A, 1, I) * sizeof(T), dims)
+    CuArray{T,M}(A.buf, dims, A.offset + compute_offset1(A, 1, I) * sizeof(T))
 
 # fallback to SubArray when the view is not contiguous
 _cuview(A, I::NTuple{N,ViewIndex}, ::NonContiguous) where {N} = invoke(view, Tuple{AbstractArray, typeof(I).parameters...}, A, I...)

--- a/test/base.jl
+++ b/test/base.jl
@@ -8,15 +8,15 @@ end
 @testset "Memory" begin
   CuArrays.alloc(0)
 
-  @test (CuArrays.@allocated CuArray{Int32}()) == 4
+  @test (CuArrays.@allocated CuArray{Int32}(undef,1)) == 4
 
-  ret, out = @grab_output CuArrays.@time CuArray{Int32}()
+  ret, out = @grab_output CuArrays.@time CuArray{Int32}(undef, 1)
   @test isa(ret, CuArray{Int32})
   @test occursin("1 GPU allocation: 4 bytes", out)
 end
 
 @testset "Array" begin
-  xs = CuArray(2, 3)
+  xs = CuArray{Int}(undef, 2, 3)
   @test collect(CuArray([1 2; 3 4])) == [1 2; 3 4]
   @test collect(cu[1, 2, 3]) == [1, 2, 3]
   @test collect(cu([1, 2, 3])) == [1, 2, 3]
@@ -35,7 +35,7 @@ end
   @test testf((x)       -> 2x,           rand(2, 3))
   @test testf((x, y)    -> x .+ y,       rand(2, 3), rand(1, 3))
   @test testf((z, x, y) -> z .= x .+ y,  rand(2, 3), rand(2, 3), rand(2))
-  @test (CuArray{Ptr{Cvoid}}(1) .= C_NULL) == CuArray([C_NULL])
+  @test (CuArray{Ptr{Cvoid}}(undef, 1) .= C_NULL) == CuArray([C_NULL])
   @test CuArray([1,2,3]) .+ CuArray([1.0,2.0,3.0]) == CuArray([2,4,6])
 
   @eval struct Whatever{T}
@@ -76,7 +76,7 @@ end
 end
 
 @testset "0D" begin
-  x = CuArray{Float64}()
+  x = CuArray{Float64}(undef)
   x .= 1
   @test collect(x)[] == 1
   x /= 2

--- a/test/blas.jl
+++ b/test/blas.jl
@@ -12,7 +12,7 @@ k = 13
 
     @testset "Level 1 with element type $T" for T in [Float32, Float64, ComplexF32, ComplexF64]
         A = CuArray(rand(T, m))
-        B = CuArray{T}(m)
+        B = CuArray{T}(undef, m)
         CuArrays.CUBLAS.blascopy!(m,A,1,B,1)
         @test Array(A) == Array(B)
 

--- a/test/rand.jl
+++ b/test/rand.jl
@@ -10,7 +10,7 @@ for (f,T) in ((rand!,Float32),
               (rand_logn!,Float32),
               (rand_poisson!,Cuint)),
     d in (2, (2,2), (2,2,2))
-    A = CuArray{T}(d)
+    A = CuArray{T}(undef, d)
     f(A)
 end
 
@@ -39,7 +39,7 @@ for (f,T) in ((curand,Int64),),
 end
 for (f,T) in ((rand!,Int64),),
     d in (2, (2,2), (2,2,2))
-    A = CuArray{T}(d)
+    A = CuArray{T}(undef, d)
     f(A)
 end
 


### PR DESCRIPTION
CuArrays/GPUArrays currently define lots of constructors (and methods of `similar` and `convert`) that have diverged from Base and really should not exist. This PR tries to get rid of them, to improve maintainability and code portability.

As part of that work, I propose to move essential functionality such as constructors to the concrete packages (ie. CuArrays). Defining these methods in a generic fashion is cumbersome, introduces loads of ambiguities, and results in applicable but nonsensical method invocations. For example:

```julia
julia> convert(GPUArray, cu([1]))
ERROR: MethodError: no method matching GPUArray{Float32,N} where N(::UndefInitializer, ::Tuple{Int64})
Stacktrace:
 [1] similar(::Type{GPUArray{Float32,N} where N}, ::Tuple{Int64}) at ./abstractarray.jl:618
 [2] convert(::Type{GPUArray}, ::CuArray{Float32,1}) at /home/tbesard/Julia/GPUArrays/src/construction.jl:97
 [3] top-level scope at none:0
```

This because of a generic `Base.convert(::Type{<: GPUArray{T1}}, ...)` that is only defined to be invoked on concrete subtypes. Base doesn't attempt to share such functionality between Array and AbstractArray.

Obviously massively breaking, but seems to pass tests except for some CUSOLVER failure.