### PR TITLE
Remove broken build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # CuArrays
 
-[![][gitlab-img]][gitlab-url]
 [![][codecov-img]][codecov-url]
-
-[gitlab-img]: https://gitlab.com/JuliaGPU/CuArrays.jl/badges/master/pipeline.svg
-[gitlab-url]: https://gitlab.com/JuliaGPU/CuArrays.jl/pipelines
 
 [codecov-img]: https://codecov.io/gh/JuliaGPU/CuArrays.jl/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JuliaGPU/CuArrays.jl


### PR DESCRIPTION
It's pretty nonsensical anyway (CI checks out master branches, doesn't reflect regular Pkg usage, etc).
Commit overview still has statuses.