### PR TITLE
Fix view bug

### DIFF
--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -32,4 +32,4 @@ _cuview(A::CuArray{T}, I::NTuple{N,ViewIndex}, dims::NTuple{M,Integer}) where {T
     CuArray{T,M}(A.buf, dims, A.offset + compute_offset1(A, 1, I) * sizeof(T))
 
 # fallback to SubArray when the view is not contiguous
-_cuview(A, I::NTuple{N,ViewIndex}, ::NonContiguous) where {N} = invoke(view, Tuple{AbstractArray, typeof(I).parameters...}, A, I...)
+_cuview(A, I, ::NonContiguous) where {N} = invoke(view, Tuple{AbstractArray, typeof(I).parameters...}, A, I...)

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -1,7 +1,7 @@
 import Base: view
 
 using Base: ScalarIndex, ViewIndex, Slice, @_inline_meta, @boundscheck, 
-            to_indices, compute_offset1, unsafe_length
+            to_indices, compute_offset1, unsafe_length, _maybe_reshape_parent, index_ndims
 
 struct Contiguous end
 struct NonContiguous end
@@ -24,7 +24,7 @@ function _cuview(A, I, ::Contiguous)
     @_inline_meta
     J = to_indices(A, I)
     @boundscheck checkbounds(A, J...)
-    _cuview(A, J, cuviewlength(J...))
+    _cuview(_maybe_reshape_parent(A, index_ndims(J...)), J, cuviewlength(J...))
 end
 
 # for contiguous views just return a new CuArray

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -8,9 +8,10 @@ struct NonContiguous end
 
 # Detect whether the view is contiguous or not
 CuIndexStyle() = Contiguous()
-CuIndexStyle(i1::Colon, I...) = CuIndexStyle(I...)
-CuIndexStyle(i1::AbstractUnitRange, ::ScalarIndex...) = Contiguous()
 CuIndexStyle(I...) = NonContiguous()
+CuIndexStyle(i1::Colon, ::ScalarIndex...) = Contiguous()
+CuIndexStyle(i1::AbstractUnitRange, ::ScalarIndex...) = Contiguous()
+CuIndexStyle(i1::Colon, I...) = CuIndexStyle(I...)
 
 cuviewlength() = ()
 cuviewlength(::Real, I...) = (@_inline_meta; cuviewlength(I...)) # skip scalars

--- a/test/base.jl
+++ b/test/base.jl
@@ -112,6 +112,8 @@ end
     @test typeof(view(x, 1, :, 3)) <: SubArray
     @test typeof(view(x, 1, 1:4, 3)) <: SubArray
     @test typeof(view(x, :, 1, 1:3)) <: SubArray
+    @test typeof(view(x, :, 1:2:4, 1)) <: SubArray
+    @test typeof(view(x, 1:2:5, 1, 1)) <: SubArray
   end
 end
 

--- a/test/base.jl
+++ b/test/base.jl
@@ -104,6 +104,8 @@ end
     @test typeof(view(x, :, 1:4, 3)) == CuMatrix{Float32}
     @test typeof(view(x, :, :, 1)) == CuMatrix{Float32}
     @test typeof(view(x, :, :, :)) == CuArray{Float32,3}
+    @test typeof(view(x, :)) == CuVector{Float32}
+    @test typeof(view(x, 1:3)) == CuVector{Float32}
 
     # Non-contiguous views should fall back to base's SubArray
     @test typeof(view(x, 1:3, 1:3, 3)) <: SubArray

--- a/test/base.jl
+++ b/test/base.jl
@@ -97,8 +97,19 @@ end
   @test testf(x->view(x, :, 1:4, 3), rand(Float32, 5, 4, 3))
   @allowscalar let x = cu(rand(Float32, 5, 4, 3))
     @test_throws BoundsError view(x, :, :, 1:10)
-    @test typeof(view(x, :, 1:4, 3)) <: CuMatrix # contiguous view
-    @test typeof(view(x, 1, 1:4, 3)) <: SubArray # non-contiguous view
+
+    # Contiguous views should return new CuArray
+    @test typeof(view(x, :, 1, 2)) == CuVector{Float32}
+    @test typeof(view(x, 1:4, 1, 2)) == CuVector{Float32}
+    @test typeof(view(x, :, 1:4, 3)) == CuMatrix{Float32}
+    @test typeof(view(x, :, :, 1)) == CuMatrix{Float32}
+    @test typeof(view(x, :, :, :)) == CuArray{Float32,3}
+
+    # Non-contiguous views should fall back to base's SubArray
+    @test typeof(view(x, 1:3, 1:3, 3)) <: SubArray
+    @test typeof(view(x, 1, :, 3)) <: SubArray
+    @test typeof(view(x, 1, 1:4, 3)) <: SubArray
+    @test typeof(view(x, :, 1, 1:3)) <: SubArray
   end
 end
 


### PR DESCRIPTION
Fixes #193: adds a missing definition for contiguous views of the form `colon` + `integer`, and makes the signature of `_cuview` less strict, cause apparently that failed.

Also adds a bunch of additional tests to make sure we hit all cases.