### PR TITLE
implement Base.unsafe_wrap to support CuArray without memory ownership

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -22,6 +22,20 @@ function unsafe_free!(xs::CuArray)
   return
 end
 
+# Wrap CuArray around the data at the address given by `pointer`,
+function Base.unsafe_wrap(::Union{Type{CuArray},Type{CuArray{T}},Type{CuArray{T,N}}},
+                     p::Ptr{T}, dims::NTuple{N,Int}; own::Bool = false) where {T,N}
+    @assert !own "not implemented yet"
+    buf = CuArrays.Mem.Buffer(
+            convert(Ptr{Cvoid}, p),
+            prod(dims) * sizeof(T),
+            CuArrays.CuCurrentContext())
+
+    # add refcount in advance such that the refcount never drops to zero
+    # TODO: fix me
+    CuArrays.Mem.retain(buf)
+    return CuArrays.CuArray{T, length(dims)}(buf, dims)
+end
 
 ## construction
 

--- a/test/base.jl
+++ b/test/base.jl
@@ -13,6 +13,10 @@ end
   ret, out = @grab_output CuArrays.@time CuArray{Int32}(undef, 1)
   @test isa(ret, CuArray{Int32})
   @test occursin("1 GPU allocation: 4 bytes", out)
+
+  ret, out = @grab_output CuArrays.@time Base.unsafe_wrap(CuArray, Ptr{Int32}(12345678), (2, 3))
+  @test isa(ret, CuArray{Int32})
+  @test !occursin("GPU allocation", out)
 end
 
 @testset "Array" begin


### PR DESCRIPTION
Implements #203.

This PR extends `Base.unsafe_wrap' to support CuArray without memory ownership.

But, I feel a little bit uncomfortable to extend `Base.unsafe_wrap(CuArray, pointer::Ptr{T}, dims; own = false)`.
How can we obtain `CuContext` from a raw `pointer`? 
Using `CuCurrentContext()` is reasonable or not? 

Another point is what we should do when `own` is `true`.
(Now, only `own=false` case is implemented.)
I think users may want to provide a custom deleter when `own=true`.
For example, users may want to obtain `CuArray` from [dlpack](https://github.com/dmlc/dlpack)'s `DLManagedTensor`.
