### PR TITLE
Make bors monitor both branches

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,4 @@
 status = [
-  "ci/gitlab/trying"
+  "ci/gitlab/%"
 ]
 delete_merged_branches = true


### PR DESCRIPTION
This allows you to have bors merge the branches in,
instead of only being able to use `try`.