### PR TITLE
Implement Base.unsafe_wrap

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -22,6 +22,20 @@ function unsafe_free!(xs::CuArray)
   return
 end
 
+# Wrap CuArray around the data at the address given by `pointer`,
+function Base.unsafe_wrap(::Union{Type{CuArray},Type{CuArray{T}},Type{CuArray{T,N}}},
+                     p::Ptr{T}, dims::NTuple{N,Int}; own::Bool = false) where {T,N}
+    @assert !own "not implemented yet"
+    buf = CuArrays.Mem.Buffer(
+            convert(Ptr{Cvoid}, p),
+            prod(dims) * sizeof(T),
+            CuArrays.CuCurrentContext())
+
+    # add refcount in advance such that the refcount never drops to zero
+    # TODO: fix me
+    CuArrays.Mem.retain(buf)
+    return CuArrays.CuArray{T, length(dims)}(buf, dims)
+end
 
 ## construction
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -62,8 +62,8 @@ take ownership of the memory, calling `free` when the array is no longer referen
 function Base.unsafe_wrap(::Union{Type{CuArray},Type{CuArray{T}},Type{CuArray{T,N}}},
                           p::Ptr{T}, dims::NTuple{N,Int};
                           own::Bool=false, ctx::CuContext=CuCurrentContext()) where {T,N}
-    buf = Mem.Buffer(convert(Ptr{Cvoid}, p), prod(dims) * sizeof(T), ctx)
-    return CuArray{T, length(dims)}(buf, dims; own=own)
+  buf = Mem.Buffer(convert(Ptr{Cvoid}, p), prod(dims) * sizeof(T), ctx)
+  return CuArray{T, length(dims)}(buf, dims; own=own)
 end
 function Base.unsafe_wrap(Atype::Union{Type{CuArray},Type{CuArray{T}},Type{CuArray{T,1}}},
                           p::Ptr{T}, dim::Integer;
@@ -102,6 +102,13 @@ CuArray{T,N}(xs::CuArray{T,N}) where {T,N} = xs
 
 Base.convert(::Type{T}, x::T) where T <: CuArray = x
 
+function Base._reshape(parent::CuArray, dims::Dims)
+  n = length(parent)
+  prod(dims) == n || throw(DimensionMismatch("parent has $n elements, which is incompatible with size $dims"))
+  return CuArray{eltype(parent),length(dims)}(parent.buf, dims;
+                                              offset=parent.offset, own=parent.own)
+end
+
 
 
 ## interop with C libraries
@@ -126,41 +133,42 @@ Base.cconvert(::Type{Ptr{Nothing}}, x::CuArray) = buffer(x)
 ## interop with CUDAnative
 
 function Base.convert(::Type{CuDeviceArray{T,N,AS.Global}}, a::CuArray{T,N}) where {T,N}
-    ptr = Base.unsafe_convert(Ptr{T}, a.buf)
-    CuDeviceArray{T,N,AS.Global}(a.dims, DevicePtr{T,AS.Global}(ptr+a.offset))
+  ptr = Base.unsafe_convert(Ptr{T}, a.buf)
+  CuDeviceArray{T,N,AS.Global}(a.dims, DevicePtr{T,AS.Global}(ptr+a.offset))
 end
 
 Adapt.adapt_storage(::CUDAnative.Adaptor, xs::CuArray{T,N}) where {T,N} =
   convert(CuDeviceArray{T,N,AS.Global}, xs)
 
 
-## other
 
-function Base._reshape(parent::CuArray, dims::Dims)
-  n = length(parent)
-  prod(dims) == n || throw(DimensionMismatch("parent has $n elements, which is incompatible with size $dims"))
-  return CuArray{eltype(parent),length(dims)}(parent.buf, dims;
-                                              offset=parent.offset, own=parent.own)
-end
+## interop with CPU array
 
-# Interop with CPU array
+# We don't convert isbits types in `adapt`, since they are already
+# considered GPU-compatible.
+
+Adapt.adapt_storage(::Type{<:CuArray}, xs::AbstractArray) =
+  isbits(xs) ? xs : convert(CuArray, xs)
+
+Adapt.adapt_storage(::Type{<:CuArray{T}}, xs::AbstractArray{<:Real}) where T <: AbstractFloat =
+  isbits(xs) ? xs : convert(CuArray{T}, xs)
+
+Base.collect(x::CuArray{T,N}) where {T,N} = copyto!(Array{T,N}(undef, size(x)), x)
 
 function Base.unsafe_copyto!(dest::CuArray{T}, doffs, src::Array{T}, soffs, n) where T
-    Mem.upload!(buffer(dest, doffs), pointer(src, soffs), n*sizeof(T))
-    return dest
+  Mem.upload!(buffer(dest, doffs), pointer(src, soffs), n*sizeof(T))
+  return dest
 end
 
 function Base.unsafe_copyto!(dest::Array{T}, doffs, src::CuArray{T}, soffs, n) where T
-    Mem.download!(pointer(dest, doffs), buffer(src, soffs), n*sizeof(T))
-    return dest
+  Mem.download!(pointer(dest, doffs), buffer(src, soffs), n*sizeof(T))
+  return dest
 end
 
 function Base.unsafe_copyto!(dest::CuArray{T}, doffs, src::CuArray{T}, soffs, n) where T
-    Mem.transfer!(buffer(dest, doffs), buffer(src, soffs), n*sizeof(T))
-    return dest
+  Mem.transfer!(buffer(dest, doffs), buffer(src, soffs), n*sizeof(T))
+  return dest
 end
-
-Base.collect(x::CuArray{T,N}) where {T,N} = copyto!(Array{T,N}(undef, size(x)), x)
 
 function Base.deepcopy_internal(x::CuArray, dict::IdDict)
   haskey(dict, x) && return dict[x]::typeof(x)
@@ -168,7 +176,10 @@ function Base.deepcopy_internal(x::CuArray, dict::IdDict)
 end
 
 
-# Utils
+## utilities
+
+cu(xs) = adapt(CuArray{Float32}, xs)
+Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
 
 cuzeros(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 0)
 cuones(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 1)
@@ -186,59 +197,41 @@ function Base.fill!(A::CuArray{T}, x) where T <: MemsetCompatTypes
   A
 end
 
-Base.print_array(io::IO, x::CuArray) = Base.print_array(io, collect(x))
-Base.print_array(io::IO, x::LinearAlgebra.Adjoint{<:Any,<:CuArray}) = Base.print_array(io, LinearAlgebra.adjoint(collect(x.parent)))
-Base.print_array(io::IO, x::LinearAlgebra.Transpose{<:Any,<:CuArray}) = Base.print_array(io, LinearAlgebra.transpose(collect(x.parent)))
 
-# We don't convert isbits types in `adapt`, since they are already
-# considered gpu-compatible.
-
-Adapt.adapt_storage(::Type{<:CuArray}, xs::AbstractArray) =
-  isbits(xs) ? xs : convert(CuArray, xs)
-
-Adapt.adapt_storage(::Type{<:CuArray{T}}, xs::AbstractArray{<:Real}) where T <: AbstractFloat =
-  isbits(xs) ? xs : convert(CuArray{T}, xs)
-
-cu(xs) = adapt(CuArray{Float32}, xs)
-
-
-Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
-
-
-# Generic linear algebra routines
+## generic linear algebra routines
 
 function LinearAlgebra.tril!(A::CuMatrix{T}, d::Integer = 0) where T
-    function kernel!(_A, _d)
-        li = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-        m, n = size(_A)
-        if 0 < li <= m*n
-            i, j = Tuple(CartesianIndices(_A)[li])
-            if i < j - _d
-                _A[i, j] = 0
-            end
-        end
-        return nothing
+  function kernel!(_A, _d)
+    li = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    m, n = size(_A)
+    if 0 < li <= m*n
+      i, j = Tuple(CartesianIndices(_A)[li])
+      if i < j - _d
+        _A[i, j] = 0
+      end
     end
+    return nothing
+  end
 
-    blk, thr = cudims(A)
-    @cuda blocks=blk threads=thr kernel!(A, d)
-    return A
+  blk, thr = cudims(A)
+  @cuda blocks=blk threads=thr kernel!(A, d)
+  return A
 end
 
 function LinearAlgebra.triu!(A::CuMatrix{T}, d::Integer = 0) where T
-    function kernel!(_A, _d)
-        li = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-        m, n = size(_A)
-        if 0 < li <= m*n
-            i, j = Tuple(CartesianIndices(_A)[li])
-            if j < i + _d
-                _A[i, j] = 0
-            end
-        end
-        return nothing
+  function kernel!(_A, _d)
+    li = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    m, n = size(_A)
+    if 0 < li <= m*n
+      i, j = Tuple(CartesianIndices(_A)[li])
+      if j < i + _d
+        _A[i, j] = 0
+      end
     end
+    return nothing
+  end
 
-    blk, thr = cudims(A)
-    @cuda blocks=blk threads=thr kernel!(A, d)
-    return A
+  blk, thr = cudims(A)
+  @cuda blocks=blk threads=thr kernel!(A, d)
+  return A
 end

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -29,7 +29,7 @@ end
 
 # for contiguous views just return a new CuArray
 _cuview(A::CuArray{T}, I::NTuple{N,ViewIndex}, dims::NTuple{M,Integer}) where {T,N,M} =
-    CuArray{T,M}(A.buf, dims, A.offset + compute_offset1(A, 1, I) * sizeof(T))
+    CuArray{T,M}(A.buf, dims; offset=A.offset + compute_offset1(A, 1, I) * sizeof(T), own=A.own)
 
 # fallback to SubArray when the view is not contiguous
 _cuview(A, I, ::NonContiguous) where {N} = invoke(view, Tuple{AbstractArray, typeof(I).parameters...}, A, I...)

--- a/test/base.jl
+++ b/test/base.jl
@@ -1,6 +1,8 @@
 using ForwardDiff: Dual
 using LinearAlgebra
 
+import CUDAdrv
+
 @testset "GPUArrays test suite" begin
   GPUArrays.test(CuArray)
 end
@@ -30,6 +32,18 @@ end
   # Check that allowscalar works
   @test_throws ErrorException xs[1]
   @test_throws ErrorException xs[1] = 1
+
+  # unsafe_wrap
+  ptr = C_NULL
+  buf = CUDAdrv.Mem.Buffer(C_NULL, 2, CuCurrentContext())
+  @test Base.unsafe_wrap(CuArray, C_NULL, 1; own=false).own == false
+  @test Base.unsafe_wrap(CuArray, C_NULL, 1; ctx=CUDAdrv.CuCurrentContext()).buf.ctx == CUDAdrv.CuCurrentContext()
+  @test Base.unsafe_wrap(CuArray, C_NULL, 2)            == CuArray{Nothing,1}(buf, (2,))
+  @test Base.unsafe_wrap(CuArray{Nothing}, C_NULL, 2)   == CuArray{Nothing,1}(buf, (2,))
+  @test Base.unsafe_wrap(CuArray{Nothing,1}, C_NULL, 2) == CuArray{Nothing,1}(buf, (2,))
+  @test Base.unsafe_wrap(CuArray, C_NULL, (1,2))            == CuArray{Nothing,2}(buf, (1,2))
+  @test Base.unsafe_wrap(CuArray{Nothing}, C_NULL, (1,2))   == CuArray{Nothing,2}(buf, (1,2))
+  @test Base.unsafe_wrap(CuArray{Nothing,2}, C_NULL, (1,2)) == CuArray{Nothing,2}(buf, (1,2))
 end
 
 @testset "Broadcast" begin

--- a/test/base.jl
+++ b/test/base.jl
@@ -35,7 +35,7 @@ end
 
   # unsafe_wrap
   ptr = C_NULL
-  buf = CUDAdrv.Mem.Buffer(C_NULL, 2, CuCurrentContext())
+  buf = CUDAdrv.Mem.Buffer(C_NULL, 2, CUDAdrv.CuCurrentContext())
   @test Base.unsafe_wrap(CuArray, C_NULL, 1; own=false).own == false
   @test Base.unsafe_wrap(CuArray, C_NULL, 1; ctx=CUDAdrv.CuCurrentContext()).buf.ctx == CUDAdrv.CuCurrentContext()
   @test Base.unsafe_wrap(CuArray, C_NULL, 2)            == CuArray{Nothing,1}(buf, (2,))

--- a/test/base.jl
+++ b/test/base.jl
@@ -13,6 +13,10 @@ end
   ret, out = @grab_output CuArrays.@time CuArray{Int32}(undef, 1)
   @test isa(ret, CuArray{Int32})
   @test occursin("1 GPU allocation: 4 bytes", out)
+
+  ret, out = @grab_output CuArrays.@time Base.unsafe_wrap(CuArray, Ptr{Int32}(12345678), (2, 3))
+  @test isa(ret, CuArray{Int32})
+  @test !occursin("GPU allocation", out)
 end
 
 @testset "Array" begin


### PR DESCRIPTION
Continuation of #205, implements #203.

@yatra9, upon further consideration an `own` field is required to deal with array wrappers. I added it in this PR, fixed all uses and streamlined the interface. I decided against adding a custom free function for now since Base doesn't do that either. `CuCurrentContext()` seemed reasonable but I added a `ctx` keyword.