### PR TITLE
Fix adapt to Array for Flux.jl

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -153,6 +153,8 @@ Adapt.adapt_storage(::Type{<:CuArray}, xs::AbstractArray) =
 Adapt.adapt_storage(::Type{<:CuArray{T}}, xs::AbstractArray{<:Real}) where T <: AbstractFloat =
   isbits(xs) ? xs : convert(CuArray{T}, xs)
 
+Adapt.adapt_storage(::Type{<:Array}, xs::CuArray) = convert(Array, xs)
+
 Base.collect(x::CuArray{T,N}) where {T,N} = copyto!(Array{T,N}(undef, size(x)), x)
 
 function Base.unsafe_copyto!(dest::CuArray{T}, doffs, src::Array{T}, soffs, n) where T

--- a/test/base.jl
+++ b/test/base.jl
@@ -1,5 +1,6 @@
 using ForwardDiff: Dual
 using LinearAlgebra
+using Adapt: adapt
 
 import CUDAdrv
 
@@ -44,6 +45,12 @@ end
   @test Base.unsafe_wrap(CuArray, C_NULL, (1,2))            == CuArray{Nothing,2}(buf, (1,2))
   @test Base.unsafe_wrap(CuArray{Nothing}, C_NULL, (1,2))   == CuArray{Nothing,2}(buf, (1,2))
   @test Base.unsafe_wrap(CuArray{Nothing,2}, C_NULL, (1,2)) == CuArray{Nothing,2}(buf, (1,2))
+end
+
+@testset "Adapt" begin
+  A = rand(3, 3)
+  dA = cu(A)
+  @test adapt(Array, dA) == A
 end
 
 @testset "Broadcast" begin

--- a/test/base.jl
+++ b/test/base.jl
@@ -48,9 +48,10 @@ end
 end
 
 @testset "Adapt" begin
-  A = rand(3, 3)
-  dA = cu(A)
-  @test adapt(Array, dA) == A
+  A = rand(Float32, 3, 3)
+  dA = CuArray(A)
+  @test adapt(Array, dA) ≈ A
+  @test adapt(CuArray, A) ≈ dA
 end
 
 @testset "Broadcast" begin


### PR DESCRIPTION
the `cpu` conversion doesn't work in Flux:

https://github.com/FluxML/Flux.jl/issues/508

This should fix it.