### PR TITLE
Allow unsafe free

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -22,6 +22,7 @@ CuMatrix{T} = CuArray{T,2}
 CuVecOrMat{T} = Union{CuVector{T},CuMatrix{T}}
 
 function unsafe_free!(xs::CuArray)
+  Mem.refcounts[xs.buf] == 0 && return
   Mem.release(xs.buf) && dealloc(xs.buf, prod(xs.dims)*sizeof(eltype(xs)))
   return
 end


### PR DESCRIPTION
This is a hack but I'm just putting it up for discussion (and so https://github.com/denizyuret/Knet.jl/pull/396 can use it).

Knet wants to be able to early-free pointers where it can. Right now this leads to an assertion error in the CuArrays finaliser. I'm not sure how best to handle this without just removing the assert entirely. @maleadt would be great to hear your thoughts.