### PR TITLE
Fix bug in gemm strided batched

### DIFF
--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -1053,7 +1053,7 @@ for (fname, elty) in
                       alpha::($elty),
                       A::CuArray{$elty, 3},
                       B::CuArray{$elty, 3})
-            C = similar(B, (size(A, 1), size(B, 2), size(A, 3)))
+            C = similar(B, (size(A, transA == 'N' ? 1 : 2), size(B, transB == 'N' ? 2 : 1), size(A, 3)))
             gemm_strided_batched!(transA, transB, alpha, A, B, zero($elty), C )
         end
         function gemm_strided_batched(transA::Char,

--- a/test/blas.jl
+++ b/test/blas.jl
@@ -673,6 +673,22 @@ end # level 2 testset
         end
         h_C = Array(d_C)
         @test C ≈ h_C
+        
+        # generate matrices
+        A = rand(elty, k, m, nbatch)
+        B = rand(elty, k, n, nbatch)
+        C = zeros(elty, m, n, nbatch)
+        # move to device
+        d_A = CuArray{elty, 3}(A)
+        d_B = CuArray{elty, 3}(B)
+
+        d_C = CuArrays.CUBLAS.gemm_strided_batched('T', 'N', d_A, d_B)
+
+        for i in 1:nbatch
+            C[:, :, i] = transpose(A[:, :, i]) * B[:, :, i]
+        end
+        h_C = Array(d_C)
+        @test C ≈ h_C
     end
 
 


### PR DESCRIPTION
MWE:
```julia
using CuArrays
a = cu(rand(4, 3, 2))
b = cu(rand(3, 4, 2))
CuArrays.CUBLAS.gemm_strided_batched('T', 'T', a, b)
```
From my understanding this should give a `3 x 3 x 2` array. Instead we get a `Dimension Mismatch`.