### PR TITLE
add a setting for the CUBLAS math mode to enable using tensor gemm

### DIFF
--- a/src/blas/CUBLAS.jl
+++ b/src/blas/CUBLAS.jl
@@ -28,13 +28,6 @@ function handle()
     return _handle[]
 end
 
-@enum CUBLASMathMode::Cint begin
-   CUBLAS_DEFAULT_MATH = 0
-   CUBLAS_TENSOR_OP_MATH = 1
-end
-
-setmathmode(mode::CUBLASMathMode) = @check ccall((:cublasSetMathMode, libcublas), cublasStatus_t, (cublasHandle_t, Cint), handle(), Cint(mode))
-
 include("libcublas.jl")
 include("util.jl")
 include("wrappers.jl")

--- a/src/blas/CUBLAS.jl
+++ b/src/blas/CUBLAS.jl
@@ -28,6 +28,13 @@ function handle()
     return _handle[]
 end
 
+@enum CUBLASMathMode::Cint begin
+   CUBLAS_DEFAULT_MATH = 0
+   CUBLAS_TENSOR_OP_MATH = 1
+end
+
+setmathmode(mode::CUBLASMathMode) = @check ccall((:cublasSetMathMode, libcublas), cublasStatus_t, (cublasHandle_t, Cint), handle(), Cint(mode))
+
 include("libcublas.jl")
 include("util.jl")
 include("wrappers.jl")

--- a/src/blas/CUBLAS.jl
+++ b/src/blas/CUBLAS.jl
@@ -20,6 +20,13 @@ function handle()
         _handle[] = get!(_handles, active_context[]) do
             context = active_context[]
             handle = cublasCreate_v2()
+
+            # enable tensor math mode if our device supports it, and fast math is enabled
+            dev = CUDAdrv.device(context)
+            if Base.JLOptions().fast_math == 1 && CUDAdrv.capability(dev) >= v"7.0"
+              cublasSetMathMode(CUBLAS_TENSOR_OP_MATH, handle)
+            end
+
             atexit(()->CUDAdrv.isvalid(context) && cublasDestroy_v2(handle))
             handle
         end

--- a/src/blas/libcublas.jl
+++ b/src/blas/libcublas.jl
@@ -1923,3 +1923,10 @@ function cublasGetProperty(property::CUDAapi.libraryPropertyType)
                property, value_ref)
   value_ref[]
 end
+
+# NOTE: this method needs to take an explicit handle since we call it from its "constructor"
+cublasSetMathMode(mode::CUBLASMathMode, handle=handle()) =
+  @check ccall((:cublasSetMathMode, libcublas),
+               cublasStatus_t,
+               (cublasHandle_t, Cint),
+               handle, Cint(mode))

--- a/src/blas/libcublas_types.jl
+++ b/src/blas/libcublas_types.jl
@@ -97,3 +97,8 @@ if CUDAdrv.version() >= v"0.7.5"
     const CUDA_R_32U = UInt32(12)
     const CUDA_C_32U = UInt32(13)
 end
+
+@enum CUBLASMathMode::Cint begin
+   CUBLAS_DEFAULT_MATH = 0
+   CUBLAS_TENSOR_OP_MATH = 1
+end

--- a/test/blas.jl
+++ b/test/blas.jl
@@ -17,6 +17,9 @@ k = 13
 @test_throws ArgumentError CUBLAS.cublasdiag('V')
 @test_throws ArgumentError CUBLAS.cublasside('V')
 
+# this is an internal function, but only used on some devices so make sure it works
+CUBLAS.cublasSetMathMode(CUBLAS.CUBLAS_DEFAULT_MATH)
+
 #################
 # level 1 tests #
 #################


### PR DESCRIPTION
Fixes #242 

Not sure where to put this / where to document it. Should probably add a test as well.

As an example of performance difference using `m=n=k=2048` with `Float32` on a V-100:

```
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   81.70%  1.5610ms         1  1.5610ms  1.5610ms  1.5610ms  volta_sgemm_128x64_nn
                   18.06%  345.02us         1  345.02us  345.02us  345.02us  volta_s884gemm_128x128_ldg8_f2f_nn
```