### PR TITLE
NNlib without CUDNN

### DIFF
--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -47,6 +47,8 @@ libcufft !== nothing    && include("fft/CUFFT.jl")
 libcurand !== nothing   && include("rand/CURAND.jl")
 libcudnn !== nothing    && include("dnn/CUDNN.jl")
 
+include("nnlib.jl")
+
 include("deprecated.jl")
 
 function __init__()

--- a/src/nnlib.jl
+++ b/src/nnlib.jl
@@ -26,3 +26,15 @@ cufunc(::typeof(swish)) = x -> x * cufunc(σ)(x)
 end
 
 @cufunc softplus(x) = log1p(exp(x))
+
+if !@isdefined CUDNN
+  function conv!(y::CuArray, x::CuArray, w::CuArray; kw...)
+    error("CUDNN is not installed.")
+  end
+  function softmax!(out::CuVecOrMat, xs::CuVecOrMat)
+    error("CUDNN is not installed.")
+  end
+  function logsoftmax!(out::CuVecOrMat, xs::CuVecOrMat)
+    error("CUDNN is not installed.")
+  end
+end

--- a/src/nnlib.jl
+++ b/src/nnlib.jl
@@ -1,0 +1,28 @@
+using NNlib
+import NNlib: conv!, ∇conv_filter!, ∇conv_data!,
+  maxpool!, meanpool!, ∇maxpool!, ∇meanpool!,
+  softmax, softmax!, ∇softmax!, logsoftmax, logsoftmax!, ∇logsoftmax
+using CUDAnative
+
+# Activation functions
+@cufunc σ(x) = ifelse(x < -80, zero(x), one(x) / (one(x) + exp(-x)))
+
+@cufunc function logσ(x)
+  max_v = max(zero(x), -x)
+  z = exp(-max_v) + exp(-x-max_v)
+  -(max_v + log(z))
+end
+
+@cufunc elu(x, α = one(x)) =
+  ifelse(x ≥ 0, x/1, α * (exp(x) - one(x)))
+
+# TODO: make @cufunc recognise its own definitions
+cufunc(::typeof(swish)) = x -> x * cufunc(σ)(x)
+
+@cufunc function selu(x)
+  λ = oftype(x/1, 1.0507009873554804934193349852946)
+  α = oftype(x/1, 1.6732632423543772848170429916717)
+  λ * ifelse(x > 0, x/1, α * (exp(x) - 1))
+end
+
+@cufunc softplus(x) = log1p(exp(x))

--- a/test/dnn.jl
+++ b/test/dnn.jl
@@ -24,7 +24,7 @@ using CuArrays.CUDNN
   @test testf(NNlib.crosscor, rand(Float64, 10, 10, 3, 1), rand(Float64, 2, 2, 3, 4))
   @test testf(∇conv_data, rand(Float64, 9, 9, 4, 1), rand(Float64, 10, 10, 3, 1), rand(Float64, 2, 2, 3, 4); flipkernel=1)
   @test testf(∇conv_filter, rand(Float64, 9, 9, 4, 1), rand(Float64, 10, 10, 3, 1), rand(Float64, 2, 2, 3, 4); flipkernel=1)
-  
+
   @test_nowarn NNlib.conv!(cu(zeros(Float64, 9, 9, 3, 1)), cu(rand(Float64, 10, 10, 1, 1)), cu(rand(Float64, 2, 2, 1, 3)), algo=1)
   @test_nowarn NNlib.∇conv_data!(cu(zeros(Float64, 10, 10, 1, 1)), cu(ones(Float64, 9, 9, 3, 1)), cu(rand(Float64, 10, 10, 1, 1)), cu(rand(Float64, 2, 2, 1, 3)), algo=1)
   @test_nowarn NNlib.∇conv_filter!(cu(zeros(Float64, 2, 2, 1, 3)), cu(ones(Float64, 9, 9, 3, 1)), cu(rand(Float64, 10, 10, 1, 1)), cu(rand(Float64, 2, 2, 1, 3)), algo=1)
@@ -32,7 +32,7 @@ using CuArrays.CUDNN
   @test testf(NNlib.conv, rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4))
   @test testf(∇conv_data, rand(Float64, 9, 9, 9, 4, 1), rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4))
   @test testf(∇conv_filter, rand(Float64, 9, 9, 9, 4, 1), rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4))
-  
+
   @test testf(NNlib.conv, rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4); dilation=2)
   @test testf(∇conv_data, rand(Float64, 8, 8, 8, 4, 1), rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4); dilation=2)
   @test testf(∇conv_filter, rand(Float64, 8, 8, 8, 4, 1), rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4); dilation=2)
@@ -40,7 +40,7 @@ using CuArrays.CUDNN
   @test testf(NNlib.crosscor, rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4))
   @test testf(∇conv_data, rand(Float64, 9, 9, 9, 4, 1), rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4); flipkernel=1)
   @test testf(∇conv_filter, rand(Float64, 9, 9, 9, 4, 1), rand(Float64, 10, 10, 10, 3, 1), rand(Float64, 2, 2, 2, 3, 4); flipkernel=1)
-  
+
   @test testf(x -> maxpool(x, (2,2)), rand(Float64, 10, 10, 3, 1))
   @test testf(x -> meanpool(x, (2,2)), rand(Float64, 10, 10, 3, 1))
   @test testf((x, dy) -> ∇maxpool(dy, maxpool(x, (2,2)), x, (2,2)), rand(Float64, 10, 10, 3, 1), rand(Float64, 5, 5, 3, 1))


### PR DESCRIPTION
This patch refactors our NNlib wrappers so that more things are independent of CUDNN.

Right now the main benefit is to give better errors when CUDNN isn't installed (https://github.com/FluxML/Flux.jl/issues/287). Of course we'd ideally have generic, if non-optimal, implementations of these functions available in future.