### PR TITLE
add cudnnSetConvolutionMathType

### DIFF
--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -119,6 +119,13 @@ function cudnnDestroyConvolutionDescriptor(convDesc)
                  convDesc)
 end
 
+function cudnnSetConvolutionMathType(convDesc, mathType)
+    @check ccall((:cudnnSetConvolutionMathType,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnConvolutionDescriptor_t, cudnnMathType_t),
+                 convDesc, mathType)
+end
+
 function cudnnCreatePoolingDescriptor(poolingDesc)
     @check ccall((:cudnnCreatePoolingDescriptor,libcudnn),
                  cudnnStatus_t,

--- a/src/dnn/libcudnn_types.jl
+++ b/src/dnn/libcudnn_types.jl
@@ -203,3 +203,10 @@ const cudnnBatchNormMode_t = UInt32
 const CUDNN_BATCHNORM_PER_ACTIVATION = (UInt32)(0)
 const CUDNN_BATCHNORM_SPATIAL = (UInt32)(1)
 # end enum cudnnBatchNormMode_t
+
+# begin enum cudnnMathType_t
+const cudnnMathType_t = UInt32
+const CUDNN_DEFAULT_MATH                    = 0
+const CUDNN_TENSOR_OP_MATH                  = 1
+const CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION = 2
+# end enum cudnnMathType_t


### PR DESCRIPTION
Not sure what the best way to add a test is. Something stupid like

```jl
julia> convDesc = CuArrays.CUDNN.ConvDesc(Float32, 2, 0, 1, 1, 0);;

julia> CuArrays.CUDNN.cudnnSetConvolutionMathType(convDesc, CuArrays.CUDNN.CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION);

julia> @test_throws CuArrays.CUDNN.CUDNNError CuArrays.CUDNN.cudnnSetConvolutionMathType(convDesc, 3)
Test Passed
      Thrown: CuArrays.CUDNN.CUDNNError
```

?