### PR TITLE
Adapt to the new CUDAdrv.CuPtr pointer type

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 1.0
-CUDAnative 1.0.0
-CUDAdrv 1.0.1
+CUDAnative 1.1
+CUDAdrv 1.1
 CUDAapi 0.5.3
 NNlib 0.4.3
 GPUArrays 0.5

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,13 @@
 using Documenter
 using Literate
-using CuArrays
 
 using Pkg
 if haskey(ENV, "GITLAB_CI")
     Pkg.add([PackageSpec(name = x; rev = "master")
              for x in ["CUDAapi", "GPUArrays", "CUDAnative", "NNlib", "CUDAdrv"]])
 end
+
+using CuArrays
 
 # generate tutorials
 OUTPUT = joinpath(@__DIR__, "src/tutorials/generated")

--- a/src/blas/CUBLAS.jl
+++ b/src/blas/CUBLAS.jl
@@ -1,6 +1,6 @@
 module CUBLAS
 
-import CUDAdrv: CUDAdrv, CuContext, CuStream_t
+import CUDAdrv: CUDAdrv, CuContext, CuStream_t, CuPtr, PtrOrCuPtr, CU_NULL
 import CUDAapi
 
 using ..CuArrays

--- a/src/blas/highlevel.jl
+++ b/src/blas/highlevel.jl
@@ -1,12 +1,14 @@
+# LinearAlgebra-style wrappers of the CUBLAS functionality
+
+
 cublas_size(t::Char, M::CuVecOrMat) = (size(M, t=='N' ? 1 : 2), size(M, t=='N' ? 2 : 1))
 
 CublasArray{T<:CublasFloat} = CuArray{T}
 
-###########
+
 #
 # BLAS 1
 #
-###########
 
 LinearAlgebra.rmul!(x::CuArray{<:CublasFloat}, k::Number) =
   scal!(length(x), convert(eltype(x), k), x, 1)
@@ -50,15 +52,12 @@ Base.argmax(xs::CublasArray{<:CublasReal}) = iamax(xs)
 
 
 
-############
 #
 # BLAS 2
 #
-############
 
-#########
 # GEMV
-##########
+
 function gemv_wrapper!(y::CuVector{T}, tA::Char, A::CuMatrix{T}, x::CuVector{T},
                        alpha = one(T), beta = zero(T)) where T<:CublasFloat
     mA, nA = cublas_size(tA, A)
@@ -84,15 +83,12 @@ LinearAlgebra.lmul!(Y::CuVector{T}, A::LinearAlgebra.Adjoint{<:Any, CuMatrix{T}}
 
 
 
-############
 #
 # BLAS 3
 #
-############
 
-########
 # GEMM
-########
+
 function gemm_wrapper!(C::CuVecOrMat{T}, tA::Char, tB::Char,
                    A::CuVecOrMat{T},
                    B::CuVecOrMat{T},
@@ -149,9 +145,7 @@ LinearAlgebra.mul!(C::CuMatrix{T}, adjA::LinearAlgebra.Adjoint{<:Any, <:CuMatrix
     gemm_wrapper!(C, 'C', 'T', parent(adjA), parent(trB))
 
 
-########
 # TRSM
-########
 
 # ldiv!
 ## No transpose/adjoint

--- a/src/blas/libcublas.jl
+++ b/src/blas/libcublas.jl
@@ -72,56 +72,56 @@ end
 function cublasSetVector(n, elemSize, x, incx, devicePtr, incy)
   @check ccall((:cublasSetVector, libcublas),
                cublasStatus_t,
-               (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint),
+               (Cint, Cint, Ptr{Nothing}, Cint, CuPtr{Nothing}, Cint),
                n, elemSize, x, incx, devicePtr, incy)
 end
 
 function cublasGetVector(n, elemSize, x, incx, y, incy)
   @check ccall((:cublasGetVector, libcublas),
                cublasStatus_t,
-               (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint),
+               (Cint, Cint, CuPtr{Nothing}, Cint, Ptr{Nothing}, Cint),
                n, elemSize, x, incx, y, incy)
 end
 
 function cublasSetMatrix(rows, cols, elemSize, A, lda, B, ldb)
   @check ccall((:cublasSetMatrix, libcublas),
                cublasStatus_t,
-               (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint),
+               (Cint, Cint, Cint, Ptr{Nothing}, Cint, CuPtr{Nothing}, Cint),
                rows, cols, elemSize, A, lda, B, ldb)
 end
 
 function cublasGetMatrix(rows, cols, elemSize, A, lda, B, ldb)
   @check ccall((:cublasGetMatrix, libcublas),
                cublasStatus_t,
-               (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint),
+               (Cint, Cint, Cint, CuPtr{Nothing}, Cint, Ptr{Nothing}, Cint),
                rows, cols, elemSize, A, lda, B, ldb)
 end
 
 function cublasSetVectorAsync(n, elemSize, hostPtr, incx, devicePtr, incy, stream)
   @check ccall((:cublasSetVectorAsync, libcublas),
                cublasStatus_t,
-               (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t),
+               (Cint, Cint, Ptr{Nothing}, Cint, CuPtr{Nothing}, Cint, CuStream_t),
                n, elemSize, hostPtr, incx, devicePtr, incy, stream)
 end
 
 function cublasGetVectorAsync(n, elemSize, devicePtr, incx, hostPtr, incy, stream)
   @check ccall((:cublasGetVectorAsync, libcublas),
                cublasStatus_t,
-               (Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t),
+               (Cint, Cint, CuPtr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t),
                n, elemSize, devicePtr, incx, hostPtr, incy, stream)
 end
 
 function cublasSetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
   @check ccall((:cublasSetMatrixAsync, libcublas),
                cublasStatus_t,
-               (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t),
+               (Cint, Cint, Cint, Ptr{Nothing}, Cint, CuPtr{Nothing}, Cint, CuStream_t),
                rows, cols, elemSize, A, lda, B, ldb, stream)
 end
 
 function cublasGetMatrixAsync(rows, cols, elemSize, A, lda, B, ldb, stream)
   @check ccall((:cublasGetMatrixAsync, libcublas),
                cublasStatus_t,
-               (Cint, Cint, Cint, Ptr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t),
+               (Cint, Cint, Cint, CuPtr{Nothing}, Cint, Ptr{Nothing}, Cint, CuStream_t),
                rows, cols, elemSize, A, lda, B, ldb, stream)
 end
 
@@ -135,417 +135,417 @@ end
 function cublasSnrm2_v2(handle, n, x, incx, result)
   @check ccall((:cublasSnrm2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}),
                handle, n, x, incx, result)
 end
 
 function cublasDnrm2_v2(handle, n, x, incx, result)
   @check ccall((:cublasDnrm2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}),
+               (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble}),
                handle, n, x, incx, result)
 end
 
 function cublasScnrm2_v2(handle, n, x, incx, result)
   @check ccall((:cublasScnrm2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat}),
+               (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{Cfloat}),
                handle, n, x, incx, result)
 end
 
 function cublasDznrm2_v2(handle, n, x, incx, result)
   @check ccall((:cublasDznrm2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble}),
+               (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{Cdouble}),
                handle, n, x, incx, result)
 end
 
 function cublasSdot_v2(handle, n, x, incx, y, incy, result)
   @check ccall((:cublasSdot_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}),
                handle, n, x, incx, y, incy, result)
 end
 
 function cublasDdot_v2(handle, n, x, incx, y, incy, result)
   @check ccall((:cublasDdot_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}),
+               (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble}),
                handle, n, x, incx, y, incy, result)
 end
 
 function cublasCdotu_v2(handle, n, x, incx, y, incy, result)
   @check ccall((:cublasCdotu_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}),
+               (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex}),
                handle, n, x, incx, y, incy, result)
 end
 
 function cublasCdotc_v2(handle, n, x, incx, y, incy, result)
   @check ccall((:cublasCdotc_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint,
-                Ptr{cuComplex}),
+               (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
+                PtrOrCuPtr{cuComplex}),
                handle, n, x, incx, y, incy, result)
 end
 
 function cublasZdotu_v2(handle, n, x, incx, y, incy, result)
   @check ccall((:cublasZdotu_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}),
+               (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{cuDoubleComplex}),
                handle, n, x, incx, y, incy, result)
 end
 
 function cublasZdotc_v2(handle, n, x, incx, y, incy, result)
   @check ccall((:cublasZdotc_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}),
+               (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{cuDoubleComplex}),
                handle, n, x, incx, y, incy, result)
 end
 
 function cublasSscal_v2(handle, n, alpha, x, incx)
   @check ccall((:cublasSscal_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
                handle, n, alpha, x, incx)
 end
 
 function cublasDscal_v2(handle, n, alpha, x, incx)
   @check ccall((:cublasDscal_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
                handle, n, alpha, x, incx)
 end
 
 function cublasCscal_v2(handle, n, alpha, x, incx)
   @check ccall((:cublasCscal_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint),
                handle, n, alpha, x, incx)
 end
 
 function cublasCsscal_v2(handle, n, alpha, x, incx)
   @check ccall((:cublasCsscal_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{cuComplex}, Cint),
                handle, n, alpha, x, incx)
 end
 
 function cublasZscal_v2(handle, n, alpha, x, incx)
   @check ccall((:cublasZscal_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, n, alpha, x, incx)
 end
 
 function cublasZdscal_v2(handle, n, alpha, x, incx)
   @check ccall((:cublasZdscal_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, Cint, PtrOrCuPtr{Cdouble}, CuPtr{cuDoubleComplex}, Cint),
                handle, n, alpha, x, incx)
 end
 
 function cublasSaxpy_v2(handle, n, alpha, x, incx, y, incy)
   @check ccall((:cublasSaxpy_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                handle, n, alpha, x, incx, y, incy)
 end
 
 function cublasDaxpy_v2(handle, n, alpha, x, incx, y, incy)
   @check ccall((:cublasDaxpy_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                handle, n, alpha, x, incx, y, incy)
 end
 
 function cublasCaxpy_v2(handle, n, alpha, x, incx, y, incy)
   @check ccall((:cublasCaxpy_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint,
-                Ptr{cuComplex}, Cint),
+               (cublasHandle_t, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint,
+                CuPtr{cuComplex}, Cint),
                handle, n, alpha, x, incx, y, incy)
 end
 
 function cublasZaxpy_v2(handle, n, alpha, x, incx, y, incy)
   @check ccall((:cublasZaxpy_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint,
-                Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint,
+                CuPtr{cuDoubleComplex}, Cint),
                handle, n, alpha, x, incx, y, incy)
 end
 
 function cublasScopy_v2(handle, n, x, incx, y, incy)
   @check ccall((:cublasScopy_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                handle, n, x, incx, y, incy)
 end
 
 function cublasDcopy_v2(handle, n, x, incx, y, incy)
   @check ccall((:cublasDcopy_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                handle, n, x, incx, y, incy)
 end
 
 function cublasCcopy_v2(handle, n, x, incx, y, incy)
   @check ccall((:cublasCcopy_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, n, x, incx, y, incy)
 end
 
 function cublasZcopy_v2(handle, n, x, incx, y, incy)
   @check ccall((:cublasZcopy_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, n, x, incx, y, incy)
 end
 
 function cublasSswap_v2(handle, n, x, incx, y, incy)
   @check ccall((:cublasSswap_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                handle, n, x, incx, y, incy)
 end
 
 function cublasDswap_v2(handle, n, x, incx, y, incy)
   @check ccall((:cublasDswap_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                handle, n, x, incx, y, incy)
 end
 
 function cublasCswap_v2(handle, n, x, incx, y, incy)
   @check ccall((:cublasCswap_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, n, x, incx, y, incy)
 end
 
 function cublasZswap_v2(handle, n, x, incx, y, incy)
   @check ccall((:cublasZswap_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, n, x, incx, y, incy)
 end
 
 function cublasIsamax_v2(handle, n, x, incx, result)
   @check ccall((:cublasIsamax_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cint}),
+               (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cint}),
                handle, n, x, incx, result)
 end
 
 function cublasIdamax_v2(handle, n, x, incx, result)
   @check ccall((:cublasIdamax_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cint}),
+               (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cint}),
                handle, n, x, incx, result)
 end
 
 function cublasIcamax_v2(handle, n, x, incx, result)
   @check ccall((:cublasIcamax_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cint}),
+               (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{Cint}),
                handle, n, x, incx, result)
 end
 
 function cublasIzamax_v2(handle, n, x, incx, result)
   @check ccall((:cublasIzamax_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cint}),
+               (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{Cint}),
                handle, n, x, incx, result)
 end
 
 function cublasIsamin_v2(handle, n, x, incx, result)
   @check ccall((:cublasIsamin_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cint}),
+               (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cint}),
                handle, n, x, incx, result)
 end
 
 function cublasIdamin_v2(handle, n, x, incx, result)
   @check ccall((:cublasIdamin_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cint}),
+               (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cint}),
                handle, n, x, incx, result)
 end
 
 function cublasIcamin_v2(handle, n, x, incx, result)
   @check ccall((:cublasIcamin_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cint}),
+               (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{Cint}),
                handle, n, x, incx, result)
 end
 
 function cublasIzamin_v2(handle, n, x, incx, result)
   @check ccall((:cublasIzamin_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cint}),
+               (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{Cint}),
                handle, n, x, incx, result)
 end
 
 function cublasSasum_v2(handle, n, x, incx, result)
   @check ccall((:cublasSasum_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}),
                handle, n, x, incx, result)
 end
 
 function cublasDasum_v2(handle, n, x, incx, result)
   @check ccall((:cublasDasum_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}),
+               (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble}),
                handle, n, x, incx, result)
 end
 
 function cublasScasum_v2(handle, n, x, incx, result)
   @check ccall((:cublasScasum_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat}),
+               (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{Cfloat}),
                handle, n, x, incx, result)
 end
 
 function cublasDzasum_v2(handle, n, x, incx, result)
   @check ccall((:cublasDzasum_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble}),
+               (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{Cdouble}),
                handle, n, x, incx, result)
 end
 
 function cublasSrot_v2(handle, n, x, incx, y, incy, c, s)
   @check ccall((:cublasSrot_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat},
-                Ptr{Cfloat}),
+               (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat},
+                PtrOrCuPtr{Cfloat}),
                handle, n, x, incx, y, incy, c, s)
 end
 
 function cublasDrot_v2(handle, n, x, incx, y, incy, c, s)
   @check ccall((:cublasDrot_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint,
-                Ptr{Cdouble}, Ptr{Cdouble}),
+               (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
+                PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}),
                handle, n, x, incx, y, incy, c, s)
 end
 
 function cublasCrot_v2(handle, n, x, incx, y, incy, c, s)
   @check ccall((:cublasCrot_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint,
-                Ptr{Cfloat}, Ptr{cuComplex}),
+               (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
+                PtrOrCuPtr{Cfloat}, PtrOrCuPtr{cuComplex}),
                handle, n, x, incx, y, incy, c, s)
 end
 
 function cublasCsrot_v2(handle, n, x, incx, y, incy, c, s)
   @check ccall((:cublasCsrot_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint,
-                Ptr{Cfloat}, Ptr{Cfloat}),
+               (cublasHandle_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint,
+                PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}),
                handle, n, x, incx, y, incy, c, s)
 end
 
 function cublasZrot_v2(handle, n, x, incx, y, incy, c, s)
   @check ccall((:cublasZrot_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}),
+               (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{cuDoubleComplex}),
                handle, n, x, incx, y, incy, c, s)
 end
 
 function cublasZdrot_v2(handle, n, x, incx, y, incy, c, s)
   @check ccall((:cublasZdrot_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{Cdouble}, Ptr{Cdouble}),
+               (cublasHandle_t, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}),
                handle, n, x, incx, y, incy, c, s)
 end
 
 function cublasSrotg_v2(handle, a, b, c, s)
   @check ccall((:cublasSrotg_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}),
+               (cublasHandle_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}),
                handle, a, b, c, s)
 end
 
 function cublasDrotg_v2(handle, a, b, c, s)
   @check ccall((:cublasDrotg_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}),
+               (cublasHandle_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}),
                handle, a, b, c, s)
 end
 
 function cublasCrotg_v2(handle, a, b, c, s)
   @check ccall((:cublasCrotg_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Ptr{cuComplex}, Ptr{cuComplex}, Ptr{Cfloat}, Ptr{cuComplex}),
+               (cublasHandle_t, PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex}, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{cuComplex}),
                handle, a, b, c, s)
 end
 
 function cublasZrotg_v2(handle, a, b, c, s)
   @check ccall((:cublasZrotg_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Ptr{Cdouble},
-                Ptr{cuDoubleComplex}),
+               (cublasHandle_t, PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{Cdouble},
+                PtrOrCuPtr{cuDoubleComplex}),
                handle, a, b, c, s)
 end
 
 function cublasSrotm_v2(handle, n, x, incx, y, incy, param)
   @check ccall((:cublasSrotm_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               (cublasHandle_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}),
                handle, n, x, incx, y, incy, param)
 end
 
 function cublasDrotm_v2(handle, n, x, incx, y, incy, param)
   @check ccall((:cublasDrotm_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint,
-                Ptr{Cdouble}),
+               (cublasHandle_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint,
+                PtrOrCuPtr{Cdouble}),
                handle, n, x, incx, y, incy, param)
 end
 
 function cublasSrotmg_v2(handle, d1, d2, x1, y1, param)
   @check ccall((:cublasSrotmg_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat}, Ptr{Cfloat},
-                Ptr{Cfloat}),
+               (cublasHandle_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat},
+                PtrOrCuPtr{Cfloat}),
                handle, d1, d2, x1, y1, param)
 end
 
 function cublasDrotmg_v2(handle, d1, d2, x1, y1, param)
   @check ccall((:cublasDrotmg_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble}, Ptr{Cdouble},
-                Ptr{Cdouble}),
+               (cublasHandle_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble},
+                PtrOrCuPtr{Cdouble}),
                handle, d1, d2, x1, y1, param)
 end
 
 function cublasSgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasSgemv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat},
-                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat},
+                Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
                handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasDgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasDgemv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble},
-                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble},
+                Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
                handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasCgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasCgemv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{cuComplex},
-                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex},
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, PtrOrCuPtr{cuComplex},
+                CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
                 Cint),
                handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
 end
@@ -553,33 +553,33 @@ end
 function cublasZgemv_v2(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasZgemv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasOperation_t, Cint, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasSgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasSgbmv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, Ptr{Cfloat},
-                Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, PtrOrCuPtr{Cfloat},
+                CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
                handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasDgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasDgbmv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, Ptr{Cdouble},
-                Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, PtrOrCuPtr{Cdouble},
+                CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
                handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasCgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasCgbmv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, Ptr{cuComplex},
-                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex},
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint, PtrOrCuPtr{cuComplex},
+                CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
                 Cint),
                handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
 end
@@ -588,8 +588,8 @@ function cublasZgbmv_v2(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, bet
   @check ccall((:cublasZgbmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
 end
 
@@ -597,7 +597,7 @@ function cublasStrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
   @check ccall((:cublasStrmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+                Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                handle, uplo, trans, diag, n, A, lda, x, incx)
 end
 
@@ -605,7 +605,7 @@ function cublasDtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
   @check ccall((:cublasDtrmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+                Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                handle, uplo, trans, diag, n, A, lda, x, incx)
 end
 
@@ -613,7 +613,7 @@ function cublasCtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
   @check ccall((:cublasCtrmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+                Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, uplo, trans, diag, n, A, lda, x, incx)
 end
 
@@ -621,7 +621,7 @@ function cublasZtrmv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
   @check ccall((:cublasZtrmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+                Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, diag, n, A, lda, x, incx)
 end
 
@@ -629,7 +629,7 @@ function cublasStbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
   @check ccall((:cublasStbmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+                Cint, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                handle, uplo, trans, diag, n, k, A, lda, x, incx)
 end
 
@@ -637,7 +637,7 @@ function cublasDtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
   @check ccall((:cublasDtbmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+                Cint, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                handle, uplo, trans, diag, n, k, A, lda, x, incx)
 end
 
@@ -645,7 +645,7 @@ function cublasCtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
   @check ccall((:cublasCtbmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+                Cint, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, uplo, trans, diag, n, k, A, lda, x, incx)
 end
 
@@ -653,7 +653,7 @@ function cublasZtbmv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
   @check ccall((:cublasZtbmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+                Cint, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, diag, n, k, A, lda, x, incx)
 end
 
@@ -661,7 +661,7 @@ function cublasStpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
   @check ccall((:cublasStpmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+                Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
                handle, uplo, trans, diag, n, AP, x, incx)
 end
 
@@ -669,7 +669,7 @@ function cublasDtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
   @check ccall((:cublasDtpmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+                Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
                handle, uplo, trans, diag, n, AP, x, incx)
 end
 
@@ -677,7 +677,7 @@ function cublasCtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
   @check ccall((:cublasCtpmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+                Cint, CuPtr{cuComplex}, CuPtr{cuComplex}, Cint),
                handle, uplo, trans, diag, n, AP, x, incx)
 end
 
@@ -685,7 +685,7 @@ function cublasZtpmv_v2(handle, uplo, trans, diag, n, AP, x, incx)
   @check ccall((:cublasZtpmv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+                Cint, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, diag, n, AP, x, incx)
 end
 
@@ -693,7 +693,7 @@ function cublasStrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
   @check ccall((:cublasStrsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+                Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                handle, uplo, trans, diag, n, A, lda, x, incx)
 end
 
@@ -701,7 +701,7 @@ function cublasDtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
   @check ccall((:cublasDtrsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+                Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                handle, uplo, trans, diag, n, A, lda, x, incx)
 end
 
@@ -709,7 +709,7 @@ function cublasCtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
   @check ccall((:cublasCtrsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+                Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, uplo, trans, diag, n, A, lda, x, incx)
 end
 
@@ -717,7 +717,7 @@ function cublasZtrsv_v2(handle, uplo, trans, diag, n, A, lda, x, incx)
   @check ccall((:cublasZtrsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+                Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, diag, n, A, lda, x, incx)
 end
 
@@ -725,7 +725,7 @@ function cublasStpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
   @check ccall((:cublasStpsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+                Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
                handle, uplo, trans, diag, n, AP, x, incx)
 end
 
@@ -733,7 +733,7 @@ function cublasDtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
   @check ccall((:cublasDtpsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+                Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
                handle, uplo, trans, diag, n, AP, x, incx)
 end
 
@@ -741,7 +741,7 @@ function cublasCtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
   @check ccall((:cublasCtpsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+                Cint, CuPtr{cuComplex}, CuPtr{cuComplex}, Cint),
                handle, uplo, trans, diag, n, AP, x, incx)
 end
 
@@ -749,7 +749,7 @@ function cublasZtpsv_v2(handle, uplo, trans, diag, n, AP, x, incx)
   @check ccall((:cublasZtpsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+                Cint, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, diag, n, AP, x, incx)
 end
 
@@ -757,7 +757,7 @@ function cublasStbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
   @check ccall((:cublasStbsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+                Cint, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                handle, uplo, trans, diag, n, k, A, lda, x, incx)
 end
 
@@ -765,7 +765,7 @@ function cublasDtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
   @check ccall((:cublasDtbsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+                Cint, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                handle, uplo, trans, diag, n, k, A, lda, x, incx)
 end
 
@@ -773,7 +773,7 @@ function cublasCtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
   @check ccall((:cublasCtbsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+                Cint, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, uplo, trans, diag, n, k, A, lda, x, incx)
 end
 
@@ -781,331 +781,331 @@ function cublasZtbsv_v2(handle, uplo, trans, diag, n, k, A, lda, x, incx)
   @check ccall((:cublasZtbsv_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, cublasDiagType_t,
-                Cint, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+                Cint, Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, diag, n, k, A, lda, x, incx)
 end
 
 function cublasSsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasSsymv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat},
-                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat},
+                Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
                handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasDsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasDsymv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
-                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble},
+                Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
                handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasCsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasCsymv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
-                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
+                Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint),
                handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasZsymv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasZsymv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasChemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasChemv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
-                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
+                Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint),
                handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasZhemv_v2(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasZhemv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasSsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasSsbmv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat},
-                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat},
+                Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
                handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasDsbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasDsbmv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble},
-                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble},
+                Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
                handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasChbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasChbmv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{cuComplex},
-                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, Cint, PtrOrCuPtr{cuComplex},
+                CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint),
                handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasZhbmv_v2(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
   @check ccall((:cublasZhbmv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
 end
 
 function cublasSspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
   @check ccall((:cublasSspmv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat},
-                Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat},
+                CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
                handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
 end
 
 function cublasDspmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
   @check ccall((:cublasDspmv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
-                Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble},
+                CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
                handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
 end
 
 function cublasChpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
   @check ccall((:cublasChpmv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex},
-                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuComplex},
+                CuPtr{cuComplex}, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint),
                handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
 end
 
 function cublasZhpmv_v2(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
   @check ccall((:cublasZhpmv_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
 end
 
 function cublasSger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasSger_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint,
-                Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, Cint, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint,
+                CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                handle, m, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasDger_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasDger_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint,
-                Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, Cint, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
+                CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                handle, m, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasCgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasCgeru_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint,
-                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, Cint, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint,
+                CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, m, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasCgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasCgerc_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint,
-                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, Cint, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint,
+                CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, m, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasZgeru_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasZgeru_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, Cint, Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
+                Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, m, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasZgerc_v2(handle, m, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasZgerc_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, Cint, Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
+                Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, m, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasSsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
   @check ccall((:cublasSsyr_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat},
-                Cint, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat},
+                Cint, CuPtr{Cfloat}, Cint),
                handle, uplo, n, alpha, x, incx, A, lda)
 end
 
 function cublasDsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
   @check ccall((:cublasDsyr_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
-                Cint, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble},
+                Cint, CuPtr{Cdouble}, Cint),
                handle, uplo, n, alpha, x, incx, A, lda)
 end
 
 function cublasCsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
   @check ccall((:cublasCsyr_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
-                Cint, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
+                Cint, CuPtr{cuComplex}, Cint),
                handle, uplo, n, alpha, x, incx, A, lda)
 end
 
 function cublasZsyr_v2(handle, uplo, n, alpha, x, incx, A, lda)
   @check ccall((:cublasZsyr_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, n, alpha, x, incx, A, lda)
 end
 
 function cublasCher_v2(handle, uplo, n, alpha, x, incx, A, lda)
   @check ccall((:cublasCher_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{cuComplex},
-                Cint, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{cuComplex},
+                Cint, CuPtr{cuComplex}, Cint),
                handle, uplo, n, alpha, x, incx, A, lda)
 end
 
 function cublasZher_v2(handle, uplo, n, alpha, x, incx, A, lda)
   @check ccall((:cublasZher_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cdouble}, CuPtr{cuDoubleComplex},
+                Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, n, alpha, x, incx, A, lda)
 end
 
 function cublasSspr_v2(handle, uplo, n, alpha, x, incx, AP)
   @check ccall((:cublasSspr_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat},
-                Cint, Ptr{Cfloat}),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat},
+                Cint, CuPtr{Cfloat}),
                handle, uplo, n, alpha, x, incx, AP)
 end
 
 function cublasDspr_v2(handle, uplo, n, alpha, x, incx, AP)
   @check ccall((:cublasDspr_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
-                Cint, Ptr{Cdouble}),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble},
+                Cint, CuPtr{Cdouble}),
                handle, uplo, n, alpha, x, incx, AP)
 end
 
 function cublasChpr_v2(handle, uplo, n, alpha, x, incx, AP)
   @check ccall((:cublasChpr_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{cuComplex},
-                Cint, Ptr{cuComplex}),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{cuComplex},
+                Cint, CuPtr{cuComplex}),
                handle, uplo, n, alpha, x, incx, AP)
 end
 
 function cublasZhpr_v2(handle, uplo, n, alpha, x, incx, AP)
   @check ccall((:cublasZhpr_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble},
-                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cdouble},
+                CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}),
                handle, uplo, n, alpha, x, incx, AP)
 end
 
 function cublasSsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasSsyr2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat},
-                Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat},
+                Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                handle, uplo, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasDsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasDsyr2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
-                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble},
+                Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                handle, uplo, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasCsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasCsyr2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
-                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
+                Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, uplo, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasZsyr2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasZsyr2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint,
-                Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
+                CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasCher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasCher2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
-                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
+                Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, uplo, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasZher2_v2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
   @check ccall((:cublasZher2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint,
-                Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
+                CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, n, alpha, x, incx, y, incy, A, lda)
 end
 
 function cublasSspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
   @check ccall((:cublasSspr2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint,
-                Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint,
+                CuPtr{Cfloat}, Cint, CuPtr{Cfloat}),
                handle, uplo, n, alpha, x, incx, y, incy, AP)
 end
 
 function cublasDspr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
   @check ccall((:cublasDspr2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble},
-                Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble},
+                Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}),
                handle, uplo, n, alpha, x, incx, y, incy, AP)
 end
 
 function cublasChpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
   @check ccall((:cublasChpr2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex},
-                Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
+                Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}),
                handle, uplo, n, alpha, x, incx, y, incy, AP)
 end
 
 function cublasZhpr2_v2(handle, uplo, n, alpha, x, incx, y, incy, AP)
   @check ccall((:cublasZhpr2_v2, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint,
-                Ptr{cuDoubleComplex}),
+               (cublasHandle_t, cublasFillMode_t, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint,
+                CuPtr{cuDoubleComplex}),
                handle, uplo, n, alpha, x, incx, y, incy, AP)
 end
 
@@ -1113,7 +1113,7 @@ function cublasSgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, 
   @check ccall((:cublasSgemm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat},
+                PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat},
                 Cint),
                handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
@@ -1122,8 +1122,8 @@ function cublasDgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, 
   @check ccall((:cublasDgemm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble},
-                Ptr{Cdouble}, Cint),
+                PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble},
+                CuPtr{Cdouble}, Cint),
                handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1131,8 +1131,8 @@ function cublasCgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, 
   @check ccall((:cublasCgemm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex},
-                Ptr{cuComplex}, Cint),
+                PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex},
+                CuPtr{cuComplex}, Cint),
                handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1140,8 +1140,8 @@ function cublasZgemm_v2(handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, 
   @check ccall((:cublasZgemm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1149,7 +1149,7 @@ function cublasSsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
   @check ccall((:cublasSsyrk_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+                PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -1157,7 +1157,7 @@ function cublasDsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
   @check ccall((:cublasDsyrk_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+                PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -1165,7 +1165,7 @@ function cublasCsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
   @check ccall((:cublasCsyrk_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+                PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -1173,8 +1173,8 @@ function cublasZsyrk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
   @check ccall((:cublasZsyrk_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -1182,7 +1182,7 @@ function cublasCherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
   @check ccall((:cublasCherk_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{Cfloat}, Ptr{cuComplex}, Cint, Ptr{Cfloat}, Ptr{cuComplex}, Cint),
+                PtrOrCuPtr{Cfloat}, CuPtr{cuComplex}, Cint, PtrOrCuPtr{Cfloat}, CuPtr{cuComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -1190,8 +1190,8 @@ function cublasZherk_v2(handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
   @check ccall((:cublasZherk_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint, Ptr{Cdouble},
-                Ptr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{Cdouble}, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{Cdouble},
+                CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -1199,8 +1199,8 @@ function cublasSsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
   @check ccall((:cublasSsyr2k_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat},
-                Ptr{Cfloat}, Cint),
+                PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat},
+                CuPtr{Cfloat}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1208,8 +1208,8 @@ function cublasDsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
   @check ccall((:cublasDsyr2k_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble},
-                Ptr{Cdouble}, Cint),
+                PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble},
+                CuPtr{Cdouble}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1217,8 +1217,8 @@ function cublasCsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
   @check ccall((:cublasCsyr2k_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex},
-                Ptr{cuComplex}, Cint),
+                PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex},
+                CuPtr{cuComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1226,8 +1226,8 @@ function cublasZsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
   @check ccall((:cublasZsyr2k_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{cuDoubleComplex},
+                Cint, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1235,8 +1235,8 @@ function cublasCher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
   @check ccall((:cublasCher2k_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat},
-                Ptr{cuComplex}, Cint),
+                PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{Cfloat},
+                CuPtr{cuComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1244,8 +1244,8 @@ function cublasZher2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
   @check ccall((:cublasZher2k_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{Cdouble}, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1253,8 +1253,8 @@ function cublasSsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
   @check ccall((:cublasSsyrkx, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat},
-                Ptr{Cfloat}, Cint),
+                PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat},
+                CuPtr{Cfloat}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1262,8 +1262,8 @@ function cublasDsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
   @check ccall((:cublasDsyrkx, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble},
-                Ptr{Cdouble}, Cint),
+                PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble},
+                CuPtr{Cdouble}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1271,8 +1271,8 @@ function cublasCsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
   @check ccall((:cublasCsyrkx, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint, 
-                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex},
-                Ptr{cuComplex}, Cint),
+                PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex},
+                CuPtr{cuComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1280,8 +1280,8 @@ function cublasZsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
   @check ccall((:cublasZsyrkx, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1289,8 +1289,8 @@ function cublasCherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
   @check ccall((:cublasCherkx, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{Cfloat},
-                Ptr{cuComplex}, Cint),
+                PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{Cfloat},
+                CuPtr{cuComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1298,8 +1298,8 @@ function cublasZherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
   @check ccall((:cublasZherkx, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{Cdouble}, Ptr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{Cdouble}, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1307,8 +1307,8 @@ function cublasSsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C
   @check ccall((:cublasSsymm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
-                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat},
-                Ptr{Cfloat}, Cint),
+                PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat},
+                CuPtr{Cfloat}, Cint),
                handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1316,8 +1316,8 @@ function cublasDsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C
   @check ccall((:cublasDsymm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
-                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble},
-                Ptr{Cdouble}, Cint),
+                PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble},
+                CuPtr{Cdouble}, Cint),
                handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1325,8 +1325,8 @@ function cublasCsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C
   @check ccall((:cublasCsymm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
-                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex},
-                Ptr{cuComplex}, Cint),
+                PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex},
+                CuPtr{cuComplex}, Cint),
                handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1334,8 +1334,8 @@ function cublasZsymm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C
   @check ccall((:cublasZsymm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1343,8 +1343,8 @@ function cublasChemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C
   @check ccall((:cublasChemm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
-                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex},
-                Ptr{cuComplex}, Cint),
+                PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex},
+                CuPtr{cuComplex}, Cint),
                handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1352,8 +1352,8 @@ function cublasZhemm_v2(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C
   @check ccall((:cublasZhemm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, Cint, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1361,7 +1361,7 @@ function cublasStrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
   @check ccall((:cublasStrsm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat},
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat},
                 Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
 end
@@ -1370,8 +1370,8 @@ function cublasDtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
   @check ccall((:cublasDtrsm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint,
-                Ptr{Cdouble}, Cint),
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
+                CuPtr{Cdouble}, Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
 end
 
@@ -1379,8 +1379,8 @@ function cublasCtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
   @check ccall((:cublasCtrsm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint,
-                Ptr{cuComplex}, Cint),
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint,
+                CuPtr{cuComplex}, Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
 end
 
@@ -1388,8 +1388,8 @@ function cublasZtrsm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
   @check ccall((:cublasZtrsm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}, Cint),
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
+                Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
 end
 
@@ -1406,8 +1406,8 @@ function cublasDtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
   @check ccall((:cublasDtrmm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint,
-                Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
+                CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
 end
 
@@ -1415,8 +1415,8 @@ function cublasCtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
   @check ccall((:cublasCtrmm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint,
-                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint,
+                CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
 end
 
@@ -1424,8 +1424,8 @@ function cublasZtrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
   @check ccall((:cublasZtrmm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
+                Cint, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
 end
 
@@ -1433,8 +1433,8 @@ function cublasSgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
   @check ccall((:cublasSgemmBatched, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                Ptr{Cfloat}, Ptr{Ptr{Cfloat}}, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cfloat},
-                Ptr{Ptr{Cfloat}}, Cint, Cint),
+                PtrOrCuPtr{Cfloat}, CuPtr{CuPtr{Cfloat}}, Cint, CuPtr{CuPtr{Cfloat}}, Cint, PtrOrCuPtr{Cfloat},
+                CuPtr{CuPtr{Cfloat}}, Cint, Cint),
                handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta,
                Carray, ldc, batchCount)
 end
@@ -1443,8 +1443,8 @@ function cublasDgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
   @check ccall((:cublasDgemmBatched, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                Ptr{Cdouble}, Ptr{Ptr{Cdouble}}, Cint, Ptr{Ptr{Cdouble}}, Cint,
-                Ptr{Cdouble}, Ptr{Ptr{Cdouble}}, Cint, Cint),
+                PtrOrCuPtr{Cdouble}, CuPtr{CuPtr{Cdouble}}, Cint, CuPtr{CuPtr{Cdouble}}, Cint,
+                PtrOrCuPtr{Cdouble}, CuPtr{CuPtr{Cdouble}}, Cint, Cint),
                handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta,
                Carray, ldc, batchCount)
 end
@@ -1453,8 +1453,8 @@ function cublasCgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
   @check ccall((:cublasCgemmBatched, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                Ptr{cuComplex}, Ptr{Ptr{cuComplex}}, Cint, Ptr{Ptr{cuComplex}}, Cint,
-                Ptr{cuComplex}, Ptr{Ptr{cuComplex}}, Cint, Cint),
+                PtrOrCuPtr{cuComplex}, CuPtr{CuPtr{cuComplex}}, Cint, CuPtr{CuPtr{cuComplex}}, Cint,
+                PtrOrCuPtr{cuComplex}, CuPtr{CuPtr{cuComplex}}, Cint, Cint),
                handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta,
                Carray, ldc, batchCount)
 end
@@ -1463,9 +1463,9 @@ function cublasZgemmBatched(handle, transa, transb, m, n, k, alpha, Aarray, lda,
   @check ccall((:cublasZgemmBatched, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                Ptr{cuDoubleComplex}, Ptr{Ptr{cuDoubleComplex}}, Cint,
-                Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{cuDoubleComplex},
-                Ptr{Ptr{cuDoubleComplex}}, Cint, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{CuPtr{cuDoubleComplex}}, Cint,
+                CuPtr{CuPtr{cuDoubleComplex}}, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{CuPtr{cuDoubleComplex}}, Cint, Cint),
                handle, transa, transb, m, n, k, alpha, Aarray, lda, Barray, ldb, beta,
                Carray, ldc, batchCount)
 end
@@ -1474,7 +1474,7 @@ function cublasSgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, 
   @check ccall((:cublasSgeam, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
-                Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat},
+                PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, Cint, CuPtr{Cfloat},
                 Cint),
                handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
 end
@@ -1483,8 +1483,8 @@ function cublasDgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, 
   @check ccall((:cublasDgeam, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
-                Ptr{Cdouble}, Ptr{Cdouble}, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint,
-                Ptr{Cdouble}, Cint),
+                PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, Cint,
+                CuPtr{Cdouble}, Cint),
                handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
 end
 
@@ -1492,8 +1492,8 @@ function cublasCgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, 
   @check ccall((:cublasCgeam, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
-                Ptr{cuComplex}, Ptr{cuComplex}, Cint, Ptr{cuComplex}, Ptr{cuComplex},
-                Cint, Ptr{cuComplex}, Cint),
+                PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, PtrOrCuPtr{cuComplex},
+                Cint, CuPtr{cuComplex}, Cint),
                handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
 end
 
@@ -1501,65 +1501,65 @@ function cublasZgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, 
   @check ccall((:cublasZgeam, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
-                Ptr{cuDoubleComplex}, Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                PtrOrCuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
 end
 
 function cublasSgetrfBatched(handle, n, A, lda, P, info, batchSize)
   @check ccall((:cublasSgetrfBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{Cfloat}}, Cint, CuPtr{Cint}, CuPtr{Cint}, Cint),
                handle, n, A, lda, P, info, batchSize)
 end
 
 function cublasDgetrfBatched(handle, n, A, lda, P, info, batchSize)
   @check ccall((:cublasDgetrfBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{Cdouble}}, Cint, CuPtr{Cint}, CuPtr{Cint}, Cint),
                handle, n, A, lda, P, info, batchSize)
 end
 
 function cublasCgetrfBatched(handle, n, A, lda, P, info, batchSize)
   @check ccall((:cublasCgetrfBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{cuComplex}}, Cint, CuPtr{Cint}, CuPtr{Cint}, Cint),
                handle, n, A, lda, P, info, batchSize)
 end
 
 function cublasZgetrfBatched(handle, n, A, lda, P, info, batchSize)
   @check ccall((:cublasZgetrfBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{cuDoubleComplex}}, Cint, CuPtr{Cint}, CuPtr{Cint}, Cint),
                handle, n, A, lda, P, info, batchSize)
 end
 
 function cublasSgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
   @check ccall((:cublasSgetriBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{Cfloat}}, Cint, CuPtr{Cint}, CuPtr{CuPtr{Cfloat}}, Cint, CuPtr{Cint}, Cint),
                handle, n, A, lda, P, C, ldc, info, batchSize)
 end
 
 function cublasDgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
   @check ccall((:cublasDgetriBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{Cdouble}}, Cint, CuPtr{Cint}, CuPtr{CuPtr{Cdouble}}, Cint, CuPtr{Cint}, Cint),
                handle, n, A, lda, P, C, ldc, info, batchSize)
 end
 
 function cublasCgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
   @check ccall((:cublasCgetriBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{cuComplex}}, Cint, CuPtr{Cint}, CuPtr{CuPtr{cuComplex}}, Cint, CuPtr{Cint}, Cint),
                handle, n, A, lda, P, C, ldc, info, batchSize)
 end
 
 function cublasZgetriBatched(handle, n, A, lda, P, C, ldc, info, batchSize)
   @check ccall((:cublasZgetriBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint},
-                Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{cuDoubleComplex}}, Cint, CuPtr{Cint},
+                CuPtr{CuPtr{cuDoubleComplex}}, Cint, CuPtr{Cint}, Cint),
                handle, n, A, lda, P, C, ldc, info, batchSize)
 end
 
@@ -1567,8 +1567,8 @@ function cublasStrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda
   @check ccall((:cublasStrsmBatched, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{Cfloat}, Ptr{Ptr{Cfloat}}, Cint,
-                Ptr{Ptr{Cfloat}}, Cint, Cint),
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{Cfloat}, CuPtr{CuPtr{Cfloat}}, Cint,
+                CuPtr{CuPtr{Cfloat}}, Cint, Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
 end
 
@@ -1576,8 +1576,8 @@ function cublasDtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda
   @check ccall((:cublasDtrsmBatched, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{Cdouble}, Ptr{Ptr{Cdouble}}, Cint,
-                Ptr{Ptr{Cdouble}}, Cint, Cint),
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{Cdouble}, CuPtr{CuPtr{Cdouble}}, Cint,
+                CuPtr{CuPtr{Cdouble}}, Cint, Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
 end
 
@@ -1585,8 +1585,8 @@ function cublasCtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda
   @check ccall((:cublasCtrsmBatched, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{cuComplex}, Ptr{Ptr{cuComplex}}, Cint,
-                Ptr{Ptr{cuComplex}}, Cint, Cint),
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{cuComplex}, CuPtr{CuPtr{cuComplex}}, Cint,
+                CuPtr{CuPtr{cuComplex}}, Cint, Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
 end
 
@@ -1594,45 +1594,45 @@ function cublasZtrsmBatched(handle, side, uplo, trans, diag, m, n, alpha, A, lda
   @check ccall((:cublasZtrsmBatched, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{cuDoubleComplex}, Ptr{Ptr{cuDoubleComplex}},
-                Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Cint),
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{CuPtr{cuDoubleComplex}},
+                Cint, CuPtr{CuPtr{cuDoubleComplex}}, Cint, Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, batchCount)
 end
 
 function cublasSmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
   @check ccall((:cublasSmatinvBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{Cfloat}}, Cint, CuPtr{CuPtr{Cfloat}}, Cint, CuPtr{Cint}, Cint),
                handle, n, A, lda, Ainv, lda_inv, info, batchSize)
 end
 
 function cublasDmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
   @check ccall((:cublasDmatinvBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{Cdouble}}, Cint, CuPtr{CuPtr{Cdouble}}, Cint, CuPtr{Cint}, Cint),
                handle, n, A, lda, Ainv, lda_inv, info, batchSize)
 end
 
 function cublasCmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
   @check ccall((:cublasCmatinvBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{cuComplex}}, Cint, CuPtr{CuPtr{cuComplex}}, Cint, CuPtr{Cint}, Cint),
                handle, n, A, lda, Ainv, lda_inv, info, batchSize)
 end
 
 function cublasZmatinvBatched(handle, n, A, lda, Ainv, lda_inv, info, batchSize)
   @check ccall((:cublasZmatinvBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint,
-                Ptr{Ptr{cuDoubleComplex}},
-                Cint, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, CuPtr{CuPtr{cuDoubleComplex}}, Cint,
+                CuPtr{CuPtr{cuDoubleComplex}},
+                Cint, CuPtr{Cint}, Cint),
                handle, n, A, lda, Ainv, lda_inv, info, batchSize)
 end
 
 function cublasSgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
   @check ccall((:cublasSgeqrfBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Cint, Ptr{Ptr{Cfloat}}, Cint, Ptr{Ptr{Cfloat}},
+               (cublasHandle_t, Cint, Cint, CuPtr{CuPtr{Cfloat}}, Cint, CuPtr{CuPtr{Cfloat}},
                 Ptr{Cint}, Cint),
                handle, m, n, Aarray, lda, TauArray, info, batchSize)
 end
@@ -1640,7 +1640,7 @@ end
 function cublasDgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
   @check ccall((:cublasDgeqrfBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Ptr{Cdouble}},
+               (cublasHandle_t, Cint, Cint, CuPtr{CuPtr{Cdouble}}, Cint, CuPtr{CuPtr{Cdouble}},
                 Ptr{Cint}, Cint),
                handle, m, n, Aarray, lda, TauArray, info, batchSize)
 end
@@ -1648,7 +1648,7 @@ end
 function cublasCgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
   @check ccall((:cublasCgeqrfBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Ptr{cuComplex}},
+               (cublasHandle_t, Cint, Cint, CuPtr{CuPtr{cuComplex}}, Cint, CuPtr{CuPtr{cuComplex}},
                 Ptr{Cint}, Cint),
                handle, m, n, Aarray, lda, TauArray, info, batchSize)
 end
@@ -1656,32 +1656,32 @@ end
 function cublasZgeqrfBatched(handle, m, n, Aarray, lda, TauArray, info, batchSize)
   @check ccall((:cublasZgeqrfBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, Cint, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint,
-                Ptr{Ptr{cuDoubleComplex}}, Ptr{Cint}, Cint),
+               (cublasHandle_t, Cint, Cint, CuPtr{CuPtr{cuDoubleComplex}}, Cint,
+                CuPtr{CuPtr{cuDoubleComplex}}, Ptr{Cint}, Cint),
                handle, m, n, Aarray, lda, TauArray, info, batchSize)
 end
 
 function cublasSgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
   @check ccall((:cublasSgelsBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Ptr{Cfloat}}, Cint,
-                Ptr{Ptr{Cfloat}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, CuPtr{CuPtr{Cfloat}}, Cint,
+                CuPtr{CuPtr{Cfloat}}, Cint, Ptr{Cint}, CuPtr{Cint}, Cint),
                handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
 end
 
 function cublasDgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
   @check ccall((:cublasDgelsBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Ptr{Cdouble}},
-                Cint, Ptr{Ptr{Cdouble}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, CuPtr{CuPtr{Cdouble}},
+                Cint, CuPtr{CuPtr{Cdouble}}, Cint, Ptr{Cint}, CuPtr{Cint}, Cint),
                handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
 end
 
 function cublasCgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
   @check ccall((:cublasCgelsBatched, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, Ptr{Ptr{cuComplex}},
-                Cint, Ptr{Ptr{cuComplex}}, Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+               (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint, CuPtr{CuPtr{cuComplex}},
+                Cint, CuPtr{CuPtr{cuComplex}}, Cint, Ptr{Cint}, CuPtr{Cint}, Cint),
                handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
 end
 
@@ -1689,98 +1689,98 @@ function cublasZgelsBatched(handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc,
   @check ccall((:cublasZgelsBatched, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, Cint, Cint, Cint,
-                Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Ptr{cuDoubleComplex}}, Cint, Ptr{Cint},
-                Ptr{Cint}, Cint),
+                CuPtr{CuPtr{cuDoubleComplex}}, Cint, CuPtr{CuPtr{cuDoubleComplex}}, Cint, Ptr{Cint},
+                CuPtr{Cint}, Cint),
                handle, trans, m, n, nrhs, Aarray, lda, Carray, ldc, info, devInfoArray, batchSize)
 end
 
 function cublasSdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
   @check ccall((:cublasSdgmm, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{Cfloat}, Cint,
-                Ptr{Cfloat}, Cint, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, cublasSideMode_t, Cint, Cint, CuPtr{Cfloat}, Cint,
+                CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, Cint),
                handle, mode, m, n, A, lda, x, incx, C, ldc)
 end
 
 function cublasDdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
   @check ccall((:cublasDdgmm, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{Cdouble}, Cint,
-                Ptr{Cdouble}, Cint, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, cublasSideMode_t, Cint, Cint, CuPtr{Cdouble}, Cint,
+                CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, Cint),
                handle, mode, m, n, A, lda, x, incx, C, ldc)
 end
 
 function cublasCdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
   @check ccall((:cublasCdgmm, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{cuComplex}, Cint,
-                Ptr{cuComplex}, Cint, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, cublasSideMode_t, Cint, Cint, CuPtr{cuComplex}, Cint,
+                CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, Cint),
                handle, mode, m, n, A, lda, x, incx, C, ldc)
 end
 
 function cublasZdgmm(handle, mode, m, n, A, lda, x, incx, C, ldc)
   @check ccall((:cublasZdgmm, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasSideMode_t, Cint, Cint, Ptr{cuDoubleComplex}, Cint,
-                Ptr{cuDoubleComplex}, Cint, Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, cublasSideMode_t, Cint, Cint, CuPtr{cuDoubleComplex}, Cint,
+                CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, mode, m, n, A, lda, x, incx, C, ldc)
 end
 
 function cublasStpttr(handle, uplo, n, AP, A, lda)
   @check ccall((:cublasStpttr, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, CuPtr{Cfloat}, Cint),
                handle, uplo, n, AP, A, lda)
 end
 
 function cublasDtpttr(handle, uplo, n, AP, A, lda)
   @check ccall((:cublasDtpttr, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Ptr{Cdouble}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, CuPtr{Cdouble}, Cint),
                handle, uplo, n, AP, A, lda)
 end
 
 function cublasCtpttr(handle, uplo, n, AP, A, lda)
   @check ccall((:cublasCtpttr, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Ptr{cuComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, CuPtr{cuComplex}, Cint),
                handle, uplo, n, AP, A, lda)
 end
 
 function cublasZtpttr(handle, uplo, n, AP, A, lda)
   @check ccall((:cublasZtpttr, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
-                Ptr{cuDoubleComplex}, Cint),
+               (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, n, AP, A, lda)
 end
 
 function cublasStrttp(handle, uplo, n, A, lda, AP)
   @check ccall((:cublasStrttp, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cfloat}, Cint, Ptr{Cfloat}),
+               (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}),
                handle, uplo, n, A, lda, AP)
 end
 
 function cublasDtrttp(handle, uplo, n, A, lda, AP)
   @check ccall((:cublasDtrttp, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{Cdouble}, Cint, Ptr{Cdouble}),
+               (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}),
                handle, uplo, n, A, lda, AP)
 end
 
 function cublasCtrttp(handle, uplo, n, A, lda, AP)
   @check ccall((:cublasCtrttp, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuComplex}, Cint, Ptr{cuComplex}),
+               (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}),
                handle, uplo, n, A, lda, AP)
 end
 
 function cublasZtrttp(handle, uplo, n, A, lda, AP)
   @check ccall((:cublasZtrttp, libcublas),
                cublasStatus_t,
-               (cublasHandle_t, cublasFillMode_t, Cint, Ptr{cuDoubleComplex},
-                Cint, Ptr{cuDoubleComplex}),
+               (cublasHandle_t, cublasFillMode_t, Cint, CuPtr{cuDoubleComplex},
+                Cint, CuPtr{cuDoubleComplex}),
                handle, uplo, n, A, lda, AP)
 end
 
@@ -1789,15 +1789,15 @@ if CUDAdrv.version() ≥ v"7.5"
     function cublasNrm2Ex(handle, n, x, xType, incx, result, resultType, executionType)
         @check ccall((:cublasNrm2Ex, libcublas),
                       cublasStatus_t,
-                      (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint,
-                        Ptr{Nothing}, cudaDataType_t, cudaDataType_t),
+                      (cublasHandle_t, Cint, CuPtr{Nothing}, cudaDataType_t, Cint,
+                        PtrOrCuPtr{Nothing}, cudaDataType_t, cudaDataType_t),
                      handle, n, x, xType, incx, result, resultType, executionType)
     end
     function cublasDotEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
         @check ccall((:cublasDotEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint,
-                      Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t,
+                     (cublasHandle_t, Cint, CuPtr{Nothing}, cudaDataType_t, Cint,
+                      CuPtr{Nothing}, cudaDataType_t, Cint, PtrOrCuPtr{Nothing}, cudaDataType_t,
                       cudaDataType_t),
                      handle, n, x, xType, incx, y, yType, incy, result, resultType,
                      executionType)
@@ -1805,31 +1805,31 @@ if CUDAdrv.version() ≥ v"7.5"
     function cublasDotcEx(handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
         @check ccall((:cublasDotcEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint,
-                      Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t,
+                     (cublasHandle_t, Cint, CuPtr{Nothing}, cudaDataType_t, Cint,
+                      CuPtr{Nothing}, cudaDataType_t, Cint, PtrOrCuPtr{Nothing}, cudaDataType_t,
                       cudaDataType_t),
                      handle, n, x, xType, incx, y, yType, incy, result, resultType, executionType)
     end
     function cublasScalEx(handle, n, alpha, alphaType, x, xType, incx, executionType)
         @check ccall((:cublasScalEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Ptr{Nothing},
+                     (cublasHandle_t, Cint, PtrOrCuPtr{Nothing}, cudaDataType_t, CuPtr{Nothing},
                       cudaDataType_t, Cint, cudaDataType_t),
                      handle, n, alpha, alphaType, x, xType, incx, executionType)
     end
     function cublasAxpyEx(handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
         @check ccall((:cublasAxpyEx, libcublas),
                      cublasStatus_t,
-                     (cublasHandle_t, Cint, Ptr{Nothing}, cudaDataType_t, Ptr{Nothing},
-                      cudaDataType_t, Cint, Ptr{Nothing}, cudaDataType_t, Cint, cudaDataType_t),
+                     (cublasHandle_t, Cint, PtrOrCuPtr{Nothing}, cudaDataType_t, CuPtr{Nothing},
+                      cudaDataType_t, Cint, CuPtr{Nothing}, cudaDataType_t, Cint, cudaDataType_t),
                      handle, n, alpha, alphaType, x, xType, incx, y, yType, incy, executionType)
     end
     function cublasCgemm3mEx(handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb, beta, C, Ctype, ldc)
         @check ccall((:cublasCgemm3mEx, libcublas),
                      cublasStatus_t,
                      (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                      Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing},
-                      cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t,
+                      PtrOrCuPtr{cuComplex}, CuPtr{Nothing}, cudaDataType_t, Cint, CuPtr{Nothing},
+                      cudaDataType_t, Cint, PtrOrCuPtr{cuComplex}, CuPtr{Nothing}, cudaDataType_t,
                       Cint),
                      handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb,
                      beta, C, Ctype, ldc)
@@ -1838,8 +1838,8 @@ if CUDAdrv.version() ≥ v"7.5"
         @check ccall((:cublasSgemmEx, libcublas),
                      cublasStatus_t,
                      (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                      Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing},
-                      cudaDataType_t, Cint, Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint),
+                      PtrOrCuPtr{Cfloat}, CuPtr{Nothing}, cudaDataType_t, Cint, CuPtr{Nothing},
+                      cudaDataType_t, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Nothing}, cudaDataType_t, Cint),
                      handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb,
                      beta, C, Ctype, ldc)
     end
@@ -1847,8 +1847,8 @@ if CUDAdrv.version() ≥ v"7.5"
         @check ccall((:cublasGemmEx, libcublas),
                      cublasStatus_t,
                      (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                      Ptr{Nothing}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing},
-                      cudaDataType_t, Cint, Ptr{Nothing}, Ptr{Nothing}, cudaDataType_t,
+                      PtrOrCuPtr{Nothing}, CuPtr{Nothing}, cudaDataType_t, Cint, CuPtr{Nothing},
+                      cudaDataType_t, Cint, PtrOrCuPtr{Nothing}, CuPtr{Nothing}, cudaDataType_t,
                       Cint, cudaDataType_t, cublasGemmAlgo_t),
                      handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb,
                      beta, C, Ctype, ldc, computeType, algo)
@@ -1857,8 +1857,8 @@ if CUDAdrv.version() ≥ v"7.5"
         @check ccall((:cublasCgemmEx, libcublas),
                      cublasStatus_t,
                      (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint, Cint,
-                      Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Nothing},
-                      cudaDataType_t, Cint, Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t,
+                      PtrOrCuPtr{cuComplex}, CuPtr{Nothing}, cudaDataType_t, Cint, CuPtr{Nothing},
+                      cudaDataType_t, Cint, PtrOrCuPtr{cuComplex}, CuPtr{Nothing}, cudaDataType_t,
                       Cint),
                      handle, transa, transb, m, n, k, alpha, A, Atype, lda, B, Btype, ldb,
                      beta, C, Ctype, ldc)
@@ -1867,32 +1867,32 @@ if CUDAdrv.version() ≥ v"7.5"
         @check ccall((:cublasCsyrkEx, libcublas),
                      cublasStatus_t,
                      (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                      Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{cuComplex},
-                      Ptr{Nothing}, cudaDataType_t, Cint),
+                      PtrOrCuPtr{cuComplex}, CuPtr{Nothing}, cudaDataType_t, Cint, PtrOrCuPtr{cuComplex},
+                      CuPtr{Nothing}, cudaDataType_t, Cint),
                      handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     end
     function cublasCsyrk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
         @check ccall((:cublasCsyrk3mEx, libcublas),
                      cublasStatus_t,
                      (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                      Ptr{cuComplex}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{cuComplex},
-                      Ptr{Nothing}, cudaDataType_t, Cint),
+                      PtrOrCuPtr{cuComplex}, CuPtr{Nothing}, cudaDataType_t, Cint, PtrOrCuPtr{cuComplex},
+                      CuPtr{Nothing}, cudaDataType_t, Cint),
                      handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     end
     function cublasCherkEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
         @check ccall((:cublasCherkEx, libcublas),
                      cublasStatus_t,
                      (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                      Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Cfloat},
-                      Ptr{Nothing}, cudaDataType_t, Cint),
+                      PtrOrCuPtr{Cfloat}, CuPtr{Nothing}, cudaDataType_t, Cint, PtrOrCuPtr{Cfloat},
+                      CuPtr{Nothing}, cudaDataType_t, Cint),
                      handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     end
     function cublasCherk3mEx(handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
         @check ccall((:cublasCherk3mEx, libcublas),
                      cublasStatus_t,
                      (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                      Ptr{Cfloat}, Ptr{Nothing}, cudaDataType_t, Cint, Ptr{Cfloat},
-                      Ptr{Nothing}, cudaDataType_t, Cint),
+                      PtrOrCuPtr{Cfloat}, CuPtr{Nothing}, cudaDataType_t, Cint, PtrOrCuPtr{Cfloat},
+                      CuPtr{Nothing}, cudaDataType_t, Cint),
                      handle, uplo, trans, n, k, alpha, A, Atype, lda, beta, C, Ctype, ldc)
     end
     # Wrap FP16 functions (CUDA 7.5+)
@@ -1900,16 +1900,16 @@ if CUDAdrv.version() ≥ v"7.5"
         @check ccall((:cublasHgemm, libcublas),
                      cublasStatus_t,
                      (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
-                      Cint, Ptr{__half}, Ptr{__half}, Cint, Ptr{__half}, Cint, Ptr{__half},
-                      Ptr{__half}, Cint),
+                      Cint, PtrOrCuPtr{__half}, CuPtr{__half}, Cint, CuPtr{__half}, Cint, PtrOrCuPtr{__half},
+                      CuPtr{__half}, Cint),
                      handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     end
     function cublasHgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta, C, ldc, strideC, batchCount)
         @check ccall((:cublasHgemmStridedBatched, libcublas),
                      cublasStatus_t,
                      (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
-                      Cint, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Ptr{__half}, Cint,
-                      Clonglong, Ptr{__half}, Ptr{__half}, Cint, Clonglong, Cint),
+                      Cint, PtrOrCuPtr{__half}, CuPtr{__half}, Cint, Clonglong, CuPtr{__half}, Cint,
+                      Clonglong, PtrOrCuPtr{__half}, CuPtr{__half}, Cint, Clonglong, Cint),
                      handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb,
                      strideB, beta, C, ldc, strideC, batchCount)
     end

--- a/src/blas/libcublas.jl
+++ b/src/blas/libcublas.jl
@@ -1,6 +1,4 @@
-# Julia wrapper for header: /usr/local/cuda/include/cublas_v2.h
-# Automatically generated using Clang.jl wrap_c, version v0.0.1
-# Manually copied from ../gen to this directory
+# low-level wrappers of the CUBLAS library
 
 function cublasCreate_v2()
   handle = Ref{cublasHandle_t}()
@@ -1226,8 +1224,8 @@ function cublasZsyr2k_v2(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta,
   @check ccall((:cublasZsyr2k_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasFillMode_t, cublasOperation_t, Cint, Cint,
-                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{cuDoubleComplex},
-                Cint, CuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
+                Cint, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint),
                handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -1397,8 +1395,8 @@ function cublasStrmm_v2(handle, side, uplo, trans, diag, m, n, alpha, A, lda, B,
   @check ccall((:cublasStrmm_v2, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasSideMode_t, cublasFillMode_t, cublasOperation_t,
-                cublasDiagType_t, Cint, Cint, Ptr{Cfloat}, Ptr{Cfloat}, Cint, Ptr{Cfloat},
-                Cint, Ptr{Cfloat}, Cint),
+                cublasDiagType_t, Cint, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat},
+                Cint, CuPtr{Cfloat}, Cint),
                handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
 end
 
@@ -1474,7 +1472,7 @@ function cublasSgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, 
   @check ccall((:cublasSgeam, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
-                PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, Cint, CuPtr{Cfloat},
+                PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Cint, CuPtr{Cfloat},
                 Cint),
                handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
 end
@@ -1483,7 +1481,7 @@ function cublasDgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, 
   @check ccall((:cublasDgeam, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
-                PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint, CuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, Cint,
+                PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Cint,
                 CuPtr{Cdouble}, Cint),
                handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
 end
@@ -1492,7 +1490,7 @@ function cublasCgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, 
   @check ccall((:cublasCgeam, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
-                PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint, CuPtr{cuComplex}, PtrOrCuPtr{cuComplex},
+                PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Cint, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
                 Cint, CuPtr{cuComplex}, Cint),
                handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
 end
@@ -1501,8 +1499,8 @@ function cublasZgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, 
   @check ccall((:cublasZgeam, libcublas),
                cublasStatus_t,
                (cublasHandle_t, cublasOperation_t, cublasOperation_t, Cint, Cint,
-                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex},
-                PtrOrCuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
+                PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Cint, PtrOrCuPtr{cuDoubleComplex},
+                CuPtr{cuDoubleComplex}, Cint, CuPtr{cuDoubleComplex}, Cint),
                handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
 end
 
@@ -1930,3 +1928,44 @@ cublasSetMathMode(mode::CUBLASMathMode, handle=handle()) =
                cublasStatus_t,
                (cublasHandle_t, Cint),
                handle, Cint(mode))
+
+
+function cublasDgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb,
+                                   strideB, beta, C, ldc, strideC, batchCount)
+  @check ccall((:cublasDgemmStridedBatched, libcublas), cublasStatus_t, (cublasHandle_t,
+                cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, PtrOrCuPtr{Float64},
+                CuPtr{Float64}, Cint, Cint, CuPtr{Float64}, Cint, Cint, PtrOrCuPtr{Float64},
+                CuPtr{Float64}, Cint, Cint, Cint),
+               handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta,
+               C, ldc, strideC, batchCount)
+end
+
+function cublasSgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb,
+                                   strideB, beta, C, ldc, strideC, batchCount)
+  @check ccall((:cublasSgemmStridedBatched, libcublas), cublasStatus_t, (cublasHandle_t,
+                cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, PtrOrCuPtr{Float32},
+                CuPtr{Float32}, Cint, Cint, CuPtr{Float32}, Cint, Cint, PtrOrCuPtr{Float32},
+                CuPtr{Float32}, Cint, Cint, Cint),
+               handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta,
+               C, ldc, strideC, batchCount)
+end
+
+function cublasZgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb,
+                                   strideB, beta, C, ldc, strideC, batchCount)
+  @check ccall((:cublasZgemmStridedBatched, libcublas), cublasStatus_t, (cublasHandle_t,
+                cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, PtrOrCuPtr{ComplexF64},
+                CuPtr{ComplexF64}, Cint, Cint, CuPtr{ComplexF64}, Cint, Cint, PtrOrCuPtr{ComplexF64},
+                CuPtr{ComplexF64}, Cint, Cint, Cint),
+               handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta,
+               C, ldc, strideC, batchCount)
+end
+
+function cublasCgemmStridedBatched(handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb,
+                                   strideB, beta, C, ldc, strideC, batchCount)
+  @check ccall((:cublasCgemmStridedBatched, libcublas), cublasStatus_t, (cublasHandle_t,
+                cublasOperation_t, cublasOperation_t, Cint, Cint, Cint, PtrOrCuPtr{ComplexF32},
+                CuPtr{ComplexF32}, Cint, Cint, CuPtr{ComplexF32}, Cint, Cint, PtrOrCuPtr{ComplexF32},
+                CuPtr{ComplexF32}, Cint, Cint, Cint),
+               handle, transa, transb, m, n, k, alpha, A, lda, strideA, B, ldb, strideB, beta,
+               C, ldc, strideC, batchCount)
+end

--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -71,8 +71,8 @@ for (fname, elty) in ((:cublasDcopy_v2,:Float64),
                            DY::CuArray{$elty},
                            incy::Integer)
               @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                           (cublasHandle_t, Cint, Ptr{$elty}, Cint,
-                            Ptr{$elty}, Cint),
+                           (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
+                            CuPtr{$elty}, Cint),
                            handle(), n, DX, incx, DY, incy)
             DY
         end
@@ -91,7 +91,7 @@ for (fname, elty) in ((:cublasDscal_v2,:Float64),
                        DX::CuArray{$elty},
                        incx::Integer)
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Ptr{$elty}, Ptr{$elty},
+                         (cublasHandle_t, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty},
                           Cint),
                          handle(), n, [DA], DX, incx)
             DX
@@ -110,7 +110,7 @@ for (fname, elty, celty) in ((:cublasSscal_v2, :Float32, :ComplexF32),
             #DY = reinterpret($elty,DX,(2*n,))
             #$(cublascall(fname))(handle(),2*n,[DA],DY,incx)
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Ptr{$elty}, Ptr{$celty},
+                         (cublasHandle_t, Cint, PtrOrCuPtr{$elty}, CuPtr{$celty},
                           Cint),
                          handle(), 2*n, [DA], DX, incx)
             DX
@@ -139,8 +139,8 @@ for (jname, fname, elty) in ((:dot,:cublasDdot_v2,:Float64),
                         incy::Integer)
             result = Ref{$elty}()
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Ptr{$elty}, Cint,
-                          Ptr{$elty}, Cint, Ptr{$elty}),
+                         (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
+                          CuPtr{$elty}, Cint, PtrOrCuPtr{$elty}),
                          handle(), n, DX, incx, DY, incy, result)
             return result[]
         end
@@ -159,8 +159,8 @@ for (fname, elty, ret_type) in ((:cublasDnrm2_v2,:Float64,:Float64),
                       incx::Integer)
             result = Ref{$ret_type}()
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Ptr{$elty}, Cint,
-                          Ptr{$ret_type}),
+                         (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
+                          PtrOrCuPtr{$ret_type}),
                          handle(), n, X, incx, result)
             return result[]
         end
@@ -182,8 +182,8 @@ for (fname, elty, ret_type) in ((:cublasDasum_v2,:Float64,:Float64),
                       incx::Integer)
             result = Ref{$ret_type}()
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Ptr{$elty}, Cint,
-                          Ptr{$ret_type}),
+                         (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
+                          PtrOrCuPtr{$ret_type}),
                          handle(), n, X, incx, result)
             return result[]
         end
@@ -213,10 +213,10 @@ for (fname, elty) in ((:cublasDaxpy_v2,:Float64),
                        dy::CuArray{$elty},
                        incy::Integer)
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Ref{$elty}, Ptr{$elty},
-                          Cint, Ptr{$elty},
+                         (cublasHandle_t, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty},
+                          Cint, CuPtr{$elty},
                           Cint),
-                         handle(), n, alpha, dx, incx, dy, incy)
+                         handle(), n, [alpha], dx, incx, dy, incy)
             dy
         end
     end
@@ -248,8 +248,8 @@ for (fname, elty) in ((:cublasIdamax_v2,:Float64),
                        incx::Integer)
             result = Ref{Cint}()
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Ptr{$elty}, Cint,
-                          Ptr{Cint}),
+                         (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
+                          PtrOrCuPtr{Cint}),
                          handle(), n, dx, incx, result)
             return result[]
         end
@@ -269,8 +269,8 @@ for (fname, elty) in ((:cublasIdamin_v2,:Float64),
                        incx::Integer)
             result = Ref{Cint}()
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Ptr{$elty}, Cint,
-                          Ptr{Cint}),
+                         (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
+                          PtrOrCuPtr{Cint}),
                          handle(), n, dx, incx, result)
             return result[]
         end
@@ -311,8 +311,8 @@ for (fname, elty) in ((:cublasDgemv_v2,:Float64),
             incy = stride(Y,1)
             @check ccall(($(string(fname)), libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasOperation_t, Cint, Cint,
-                         Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty},
-                         Cint, Ptr{$elty}, Ptr{$elty}, Cint), handle(),
+                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty},
+                         Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint), handle(),
                          cutrans, m, n, [alpha], A, lda, X, incx, [beta], Y,
                          incy)
             Y
@@ -358,8 +358,8 @@ for (fname, elty) in ((:cublasDgbmv_v2,:Float64),
             incy = stride(y,1)
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasOperation_t, Cint, Cint,
-                          Cint, Cint, Ptr{$elty}, Ptr{$elty}, Cint,
-                          Ptr{$elty}, Cint, Ptr{$elty}, Ptr{$elty},
+                          Cint, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint,
+                          CuPtr{$elty}, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty},
                           Cint), handle(), cutrans, m, n, kl, ku, [alpha], A,
                          lda, x, incx, [beta], y, incy)
             y
@@ -414,9 +414,9 @@ for (fname, elty) in ((:cublasDsymv_v2,:Float64),
             incy = stride(y,1)
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t,
-                         Cint,Ptr{$elty}, Ptr{$elty}, Cint,
-                         Ptr{$elty}, Cint, Ptr{$elty},
-                         Ptr{$elty},Cint),
+                         Cint,PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint,
+                         CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
+                         CuPtr{$elty},Cint),
                          handle(), cuuplo, n, [alpha],
                          A, lda, x, incx, [beta], y, incy)
             y
@@ -456,9 +456,9 @@ for (fname, elty) in ((:cublasZhemv_v2,:ComplexF64),
             incy = stride(y,1)
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t,
-                         Cint,Ptr{$elty}, Ptr{$elty}, Cint,
-                         Ptr{$elty}, Cint, Ptr{$elty},
-                         Ptr{$elty},Cint),
+                         Cint,PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint,
+                         CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
+                         CuPtr{$elty},Cint),
                          handle(), cuuplo, n, [alpha],
                          A, lda, x, incx, [beta], y, incy)
             y
@@ -503,8 +503,8 @@ for (fname, elty) in ((:cublasDsbmv_v2,:Float64),
             incy = stride(y,1)
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, Cint, Cint,
-                         Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty}, Cint,
-                         Ptr{$elty}, Ptr{$elty}, Cint), handle(),
+                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint,
+                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint), handle(),
                          cuuplo, n, k, [alpha], A, lda, x, incx, [beta], y,
                          incy)
             y
@@ -547,8 +547,8 @@ for (fname, elty) in ((:cublasZhbmv_v2,:ComplexF64),
             incy = stride(y,1)
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, Cint, Cint,
-                         Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty}, Cint,
-                         Ptr{$elty}, Ptr{$elty}, Cint), handle(),
+                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint,
+                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint), handle(),
                          cuuplo, n, k, [alpha], A, lda, x, incx, [beta], y,
                          incy)
             y
@@ -593,8 +593,8 @@ for (fname, elty) in ((:cublasStbmv_v2,:Float32),
             incx = stride(x,1)
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, cublasOperation_t,
-                         cublasDiagType_t, Cint, Cint, Ptr{$elty}, Cint,
-                         Ptr{$elty}, Cint), handle(), cuuplo, cutrans,
+                         cublasDiagType_t, Cint, Cint, CuPtr{$elty}, Cint,
+                         CuPtr{$elty}, Cint), handle(), cuuplo, cutrans,
                          cudiag, n, k, A, lda, x, incx)
             x
         end
@@ -636,8 +636,8 @@ for (fname, elty) in ((:cublasStbsv_v2,:Float32),
             incx = stride(x,1)
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, cublasOperation_t,
-                         cublasDiagType_t, Cint, Cint, Ptr{$elty}, Cint,
-                         Ptr{$elty}, Cint), handle(), cuuplo, cutrans,
+                         cublasDiagType_t, Cint, Cint, CuPtr{$elty}, Cint,
+                         CuPtr{$elty}, Cint), handle(), cuuplo, cutrans,
                          cudiag, n, k, A, lda, x, incx)
             x
         end
@@ -681,7 +681,7 @@ for (fname, elty) in ((:cublasDtrmv_v2,:Float64),
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t,
                           cublasOperation_t, cublasDiagType_t, Cint,
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint), handle(),
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint), handle(),
                          cuuplo, cutrans, cudiag, n, A, lda, x, incx)
             x
         end
@@ -724,7 +724,7 @@ for (fname, elty) in ((:cublasDtrsv_v2,:Float64),
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t,
                           cublasOperation_t, cublasDiagType_t, Cint,
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint), handle(),
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint), handle(),
                          cuuplo, cutrans, cudiag, n, A, lda, x, incx)
             x
         end
@@ -760,8 +760,8 @@ for (fname, elty) in ((:cublasDger_v2,:Float64),
             incy = stride(y,1)
             lda = max(1,stride(A,2))
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Cint, Ptr{$elty},
-                         Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty},
+                         (cublasHandle_t, Cint, Cint, PtrOrCuPtr{$elty},
+                         CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, CuPtr{$elty},
                          Cint), handle(), m, n, [alpha], x, incx, y,
                          incy, A, lda)
             A
@@ -792,7 +792,7 @@ for (fname, elty) in ((:cublasDsyr_v2,:Float64),
             lda = max(1,stride(A,2))
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, Cint,
-                         Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty}, Cint),
+                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint),
                          handle(), cuuplo, n, [alpha], x, incx, A,
                          lda)
             A
@@ -816,7 +816,7 @@ for (fname, elty) in ((:cublasZher_v2,:ComplexF64),
             lda = max(1,stride(A,2))
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, Cint,
-                         Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty}, Cint),
+                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint),
                          handle(), cuuplo, n, [alpha], x, incx, A,
                          lda)
             A
@@ -843,8 +843,8 @@ for (fname, elty) in ((:cublasZher2_v2,:ComplexF64),
             lda = max(1,stride(A,2))
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t, Cint,
-                          Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty}, Cint,
-                          Ptr{$elty}, Cint),
+                          PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint,
+                          CuPtr{$elty}, Cint),
                          handle(), cuuplo, n, [alpha], x, incx, y, incy, A,
                          lda)
             A
@@ -887,9 +887,9 @@ for (fname, elty) in
             ldc = max(1,stride(C,2))
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasOperation_t,
-                          cublasOperation_t, Cint, Cint, Cint, Ptr{$elty},
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty},
-                          Ptr{$elty}, Cint),
+                          cublasOperation_t, Cint, Cint, Cint, PtrOrCuPtr{$elty},
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
+                          CuPtr{$elty}, Cint),
                          handle(), cutransA,
                          cutransB, m, n, k, [alpha], A, lda, B, ldb, [beta],
                          C, ldc)
@@ -916,7 +916,7 @@ end
 # helper function to get a device array of device pointers
 function device_batch(batch::Array{T}) where {T<:CuArray}
   E = eltype(T)
-  ptrs = [Base.unsafe_convert(Ptr{E}, arr.buf) for arr in batch]
+  ptrs = [Base.unsafe_convert(CuPtr{E}, Base.cconvert(CuPtr{E}, arr)) for arr in batch]
   CuArray(ptrs)
 end
 
@@ -964,9 +964,9 @@ for (fname, elty) in
             Cptrs = device_batch(C)
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasOperation_t,
-                          cublasOperation_t, Cint, Cint, Cint, Ptr{$elty},
-                          Ptr{Ptr{$elty}}, Cint, Ptr{Ptr{$elty}}, Cint, Ptr{$elty},
-                          Ptr{Ptr{$elty}}, Cint, Cint),
+                          cublasOperation_t, Cint, Cint, Cint, PtrOrCuPtr{$elty},
+                          CuPtr{CuPtr{$elty}}, Cint, CuPtr{CuPtr{$elty}}, Cint, PtrOrCuPtr{$elty},
+                          CuPtr{CuPtr{$elty}}, Cint, Cint),
                          handle(), cutransA,
                          cutransB, m, n, k, [alpha], Aptrs, lda, Bptrs, ldb, [beta],
                          Cptrs, ldc, length(A))
@@ -1040,9 +1040,9 @@ for (fname, elty) in
            batchCount = size(A, 3)
            @check ccall(($(string(fname)), libcublas), cublasStatus_t,
                         (cublasHandle_t, cublasOperation_t,
-                         cublasOperation_t, Cint, Cint, Cint, Ptr{$elty},
-                         Ptr{$elty}, Cint, Cint, Ptr{$elty}, Cint, Cint, Ptr{$elty},
-                         Ptr{$elty}, Cint, Cint, Cint),
+                         cublasOperation_t, Cint, Cint, Cint, PtrOrCuPtr{$elty},
+                         CuPtr{$elty}, Cint, Cint, CuPtr{$elty}, Cint, Cint, PtrOrCuPtr{$elty},
+                         CuPtr{$elty}, Cint, Cint, Cint),
                         handle(), cutransA,
                         cutransB, m, n, k, [alpha], A, lda, strideA, B, ldb, strideB, [beta],
                         C, ldc, strideC, batchCount)
@@ -1099,9 +1099,9 @@ for (fname, elty) in ((:cublasDsymm_v2,:Float64),
             ldc = max(1,stride(C,2))
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasSideMode_t,
-                         cublasFillMode_t, Cint, Cint, Ptr{$elty},
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty},
-                          Ptr{$elty}, Cint),
+                         cublasFillMode_t, Cint, Cint, PtrOrCuPtr{$elty},
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
+                          CuPtr{$elty}, Cint),
                          handle(), cuside,
                          cuuplo, m, n, [alpha], A, lda, B, ldb, [beta], C,
                          ldc)
@@ -1151,8 +1151,8 @@ for (fname, elty) in ((:cublasDsyrk_v2,:Float64),
            ldc = max(1,stride(C,2))
            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                         (cublasHandle_t, cublasFillMode_t,
-                         cublasOperation_t, Cint, Cint, Ptr{$elty},
-                         Ptr{$elty}, Cint, Ptr{$elty}, Ptr{$elty}, Cint),
+                         cublasOperation_t, Cint, Cint, PtrOrCuPtr{$elty},
+                         CuPtr{$elty}, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint),
                         handle(), cuuplo, cutrans, n, k, [alpha], A,
                         lda, [beta], C, ldc)
             C
@@ -1204,8 +1204,8 @@ for (fname, elty) in ((:cublasZhemm_v2,:ComplexF64),
            ldc = max(1,stride(C,2))
            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                         (cublasHandle_t, cublasSideMode_t, cublasFillMode_t,
-                        Cint, Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty},
-                         Cint, Ptr{$elty}, Ptr{$elty}, Cint),
+                        Cint, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty},
+                         Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint),
                         handle(),
                         cuside, cuuplo, m, n, [alpha], A, lda, B, ldb, [beta], C, ldc)
            C
@@ -1248,8 +1248,8 @@ for (fname, elty) in ((:cublasZherk_v2,:ComplexF64),
            ldc = max(1,stride(C,2))
            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                         (cublasHandle_t, cublasFillMode_t,
-                         cublasOperation_t, Cint, Cint, Ptr{$elty},
-                         Ptr{$elty}, Cint, Ptr{$elty}, Ptr{$elty}, Cint),
+                         cublasOperation_t, Cint, Cint, PtrOrCuPtr{$elty},
+                         CuPtr{$elty}, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint),
                         handle(), cuuplo, cutrans, n, k, [alpha], A,
                         lda, [beta], C, ldc)
            C
@@ -1301,9 +1301,9 @@ for (fname, elty) in ((:cublasDsyr2k_v2,:Float64),
             ldc = max(1,stride(C,2))
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasFillMode_t,
-                         cublasOperation_t, Cint, Cint, Ptr{$elty},
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty},
-                          Ptr{$elty}, Cint),
+                         cublasOperation_t, Cint, Cint, PtrOrCuPtr{$elty},
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
+                          CuPtr{$elty}, Cint),
                          handle(), cuuplo,
                          cutrans, n, k, [alpha], A, lda, B, ldb, [beta], C,
                          ldc)
@@ -1357,9 +1357,9 @@ for (fname, elty1, elty2) in ((:cublasZher2k_v2,:ComplexF64,:Float64),
            ldc = max(1,stride(C,2))
            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                         (cublasHandle_t, cublasFillMode_t,
-                        cublasOperation_t, Cint, Cint, Ptr{$elty1},
-                         Ptr{$elty1}, Cint, Ptr{$elty1}, Cint, Ptr{$elty2},
-                         Ptr{$elty1}, Cint),
+                        cublasOperation_t, Cint, Cint, PtrOrCuPtr{$elty1},
+                         CuPtr{$elty1}, Cint, CuPtr{$elty1}, Cint, PtrOrCuPtr{$elty2},
+                         CuPtr{$elty1}, Cint),
                         handle(), cuuplo, cutrans, n, k,
                         [alpha], A, lda, B, ldb, [beta], C, ldc)
            C
@@ -1421,8 +1421,8 @@ for (mmname, smname, elty) in
             @check ccall(($(string(mmname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasSideMode_t,
                           cublasFillMode_t, cublasOperation_t,
-                          cublasDiagType_t, Cint, Cint, Ptr{$elty},
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty},
+                          cublasDiagType_t, Cint, Cint, PtrOrCuPtr{$elty},
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, CuPtr{$elty},
                           Cint),
                          handle(), cuside, cuuplo, cutransa,
                          cudiag, m, n, [alpha], A, lda, B, ldb, C, ldc)
@@ -1465,8 +1465,8 @@ for (mmname, smname, elty) in
             @check ccall(($(string(smname)), libcublas), cublasStatus_t,
                           (cublasHandle_t, cublasSideMode_t,
                            cublasFillMode_t, cublasOperation_t,
-                           cublasDiagType_t, Cint, Cint, Ptr{$elty},
-                           Ptr{$elty}, Cint, Ptr{$elty}, Cint),
+                           cublasDiagType_t, Cint, Cint, PtrOrCuPtr{$elty},
+                           CuPtr{$elty}, Cint, CuPtr{$elty}, Cint),
                           handle(), cuside, cuuplo, cutransa, cudiag,
                           m, n, [alpha], A, lda, B, ldb)
             B
@@ -1526,7 +1526,7 @@ for (fname, elty) in
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasSideMode_t, cublasFillMode_t,
                           cublasOperation_t, cublasDiagType_t, Cint, Cint,
-                          Ptr{$elty}, Ptr{Ptr{$elty}}, Cint, Ptr{Ptr{$elty}},
+                          PtrOrCuPtr{$elty}, CuPtr{CuPtr{$elty}}, Cint, CuPtr{CuPtr{$elty}},
                           Cint, Cint),
                          handle(), cuside, cuuplo,
                          cutransa, cudiag, m, n, [alpha], Aptrs, lda,
@@ -1584,8 +1584,8 @@ for (fname, elty) in ((:cublasDgeam,:Float64),
            ldc = max(1,stride(C,2))
            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                         (cublasHandle_t, cublasOperation_t, cublasOperation_t,
-                         Cint, Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty},
-                         Ptr{$elty}, Cint, Ptr{$elty}, Cint), handle(),
+                         Cint, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
+                         CuPtr{$elty}, Cint, CuPtr{$elty}, Cint), handle(),
                         cutransa, cutransb, m, n, [alpha], A, lda, [beta], B, ldb, C, ldc)
            C
        end
@@ -1631,10 +1631,10 @@ for (fname, elty) in
             lda = max(1,stride(A[1],2))
             Aptrs = device_batch(A)
             info  = CuArray{Cint}(undef, length(A))
-            pivotArray  = Pivot ? CuArray{Int32}(undef, (n, length(A))) : C_NULL
+            pivotArray  = Pivot ? CuArray{Int32}(undef, (n, length(A))) : CU_NULL
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Ptr{Ptr{$elty}}, Cint,
-                          Ptr{Cint}, Ptr{Cint}, Cint), handle(), n,
+                         (cublasHandle_t, Cint, CuPtr{CuPtr{$elty}}, Cint,
+                          CuPtr{Cint}, CuPtr{Cint}, Cint), handle(), n,
                          Aptrs, lda, pivotArray, info, length(A))
             if( !Pivot )
                 pivotArray = CuArray(zeros(Cint, (n, length(A))))
@@ -1678,8 +1678,8 @@ for (fname, elty) in
             Cptrs = device_batch(C)
             info = CuArray(zeros(Cint,length(A)))
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Ptr{Ptr{$elty}}, Cint,
-                          Ptr{Cint}, Ptr{Ptr{$elty}}, Cint, Ptr{Cint}, Cint),
+                         (cublasHandle_t, Cint, CuPtr{CuPtr{$elty}}, Cint,
+                          CuPtr{Cint}, CuPtr{CuPtr{$elty}}, Cint, CuPtr{Cint}, Cint),
                          handle(), n, Aptrs, lda, pivotArray, Cptrs,
                          ldc, info, length(A))
             pivotArray, info, C
@@ -1717,8 +1717,8 @@ for (fname, elty) in
             Cptrs = device_batch(C)
             info = CuArray(zeros(Cint,length(A)))
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Ptr{Ptr{$elty}}, Cint,
-                          Ptr{Ptr{$elty}}, Cint, Ptr{Cint}, Cint),
+                         (cublasHandle_t, Cint, CuPtr{CuPtr{$elty}}, Cint,
+                          CuPtr{CuPtr{$elty}}, Cint, CuPtr{Cint}, Cint),
                          handle(), n, Aptrs, lda, Cptrs,
                          ldc, info, length(A))
             info, C
@@ -1750,8 +1750,8 @@ for (fname, elty) in
             Tauptrs = device_batch(TauArray)
             info    = zero(Cint)
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Cint, Ptr{Ptr{$elty}},
-                          Cint, Ptr{Ptr{$elty}}, Ptr{Cint}, Cint),
+                         (cublasHandle_t, Cint, Cint, CuPtr{CuPtr{$elty}},
+                          Cint, CuPtr{CuPtr{$elty}}, Ptr{Cint}, Cint),
                          handle(), m, n, Aptrs, lda,
                          Tauptrs, [info], length(A))
             if( info != 0 )
@@ -1805,8 +1805,8 @@ for (fname, elty) in
             infoarray = CuArray(zeros(Cint, length(A)))
             @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                          (cublasHandle_t, cublasOperation_t, Cint, Cint,
-                          Cint, Ptr{Ptr{$elty}}, Cint, Ptr{Ptr{$elty}},
-                          Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+                          Cint, CuPtr{CuPtr{$elty}}, Cint, CuPtr{CuPtr{$elty}},
+                          Cint, Ptr{Cint}, CuPtr{Cint}, Cint),
                          handle(), cutrans, m, n, nrhs, Aptrs, lda,
                          Cptrs, ldc, [info], infoarray, length(A))
             if( info != 0 )
@@ -1850,7 +1850,7 @@ for (fname, elty) in ((:cublasDdgmm,:Float64),
            ldc = max(1,stride(C,2))
            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
                         (cublasHandle_t, cublasSideMode_t, Cint, Cint,
-                         Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$elty}, Cint),
+                         CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint),
                         handle(), cuside, m, n, A, lda, X, incx, C, ldc)
            C
        end

--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -1,12 +1,8 @@
-# blas.jl
+# wrappers of the low-level CUBLAS functionality
 #
-# "High level" blas interface to cublas.
-# Modeled from julia/src/base/linalg/blas.jl
-#
-# Author: Nick Henderson <nwh@stanford.edu>
-# Created: 2014-08-26
-# License: MIT
-#
+# modeled from julia/src/base/linalg/blas.jl
+# originally authored by Nick Henderson <nwh@stanford.edu> (2014-08-26, MIT licensed)
+
 
 # Utility functions
 
@@ -70,10 +66,7 @@ for (fname, elty) in ((:cublasDcopy_v2,:Float64),
                            incx::Integer,
                            DY::CuArray{$elty},
                            incy::Integer)
-              @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                           (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
-                            CuPtr{$elty}, Cint),
-                           handle(), n, DX, incx, DY, incy)
+              $fname(handle(), n, DX, incx, DY, incy)
             DY
         end
     end
@@ -90,10 +83,7 @@ for (fname, elty) in ((:cublasDscal_v2,:Float64),
                        DA::$elty,
                        DX::CuArray{$elty},
                        incx::Integer)
-            @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty},
-                          Cint),
-                         handle(), n, [DA], DX, incx)
+            $fname(handle(), n, Ref(DA), DX, incx)
             DX
         end
     end
@@ -109,10 +99,7 @@ for (fname, elty, celty) in ((:cublasSscal_v2, :Float32, :ComplexF32),
                        incx::Integer)
             #DY = reinterpret($elty,DX,(2*n,))
             #$(cublascall(fname))(handle(),2*n,[DA],DY,incx)
-            @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, PtrOrCuPtr{$elty}, CuPtr{$celty},
-                          Cint),
-                         handle(), 2*n, [DA], DX, incx)
+            $fname(handle(), 2*n, Ref(DA), DX, incx)
             DX
         end
     end
@@ -138,10 +125,7 @@ for (jname, fname, elty) in ((:dot,:cublasDdot_v2,:Float64),
                         DY::CuArray{$elty},
                         incy::Integer)
             result = Ref{$elty}()
-            @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
-                          CuPtr{$elty}, Cint, PtrOrCuPtr{$elty}),
-                         handle(), n, DX, incx, DY, incy, result)
+            $fname(handle(), n, DX, incx, DY, incy, result)
             return result[]
         end
     end
@@ -158,10 +142,7 @@ for (fname, elty, ret_type) in ((:cublasDnrm2_v2,:Float64,:Float64),
                       X::CuArray{$elty},
                       incx::Integer)
             result = Ref{$ret_type}()
-            @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
-                          PtrOrCuPtr{$ret_type}),
-                         handle(), n, X, incx, result)
+            $fname(handle(), n, X, incx, result)
             return result[]
         end
     end
@@ -181,10 +162,7 @@ for (fname, elty, ret_type) in ((:cublasDasum_v2,:Float64,:Float64),
                       X::CuArray{$elty},
                       incx::Integer)
             result = Ref{$ret_type}()
-            @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
-                          PtrOrCuPtr{$ret_type}),
-                         handle(), n, X, incx, result)
+            $fname(handle(), n, X, incx, result)
             return result[]
         end
     end
@@ -212,11 +190,7 @@ for (fname, elty) in ((:cublasDaxpy_v2,:Float64),
                        incx::Integer,
                        dy::CuArray{$elty},
                        incy::Integer)
-            @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty},
-                          Cint, CuPtr{$elty},
-                          Cint),
-                         handle(), n, [alpha], dx, incx, dy, incy)
+            $fname(handle(), n, Ref(alpha), dx, incx, dy, incy)
             dy
         end
     end
@@ -247,10 +221,7 @@ for (fname, elty) in ((:cublasIdamax_v2,:Float64),
                        dx::CuArray{$elty},
                        incx::Integer)
             result = Ref{Cint}()
-            @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
-                          PtrOrCuPtr{Cint}),
-                         handle(), n, dx, incx, result)
+           $fname(handle(), n, dx, incx, result)
             return result[]
         end
     end
@@ -268,10 +239,7 @@ for (fname, elty) in ((:cublasIdamin_v2,:Float64),
                        dx::CuArray{$elty},
                        incx::Integer)
             result = Ref{Cint}()
-            @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, CuPtr{$elty}, Cint,
-                          PtrOrCuPtr{Cint}),
-                         handle(), n, dx, incx, result)
+            $fname(handle(), n, dx, incx, result)
             return result[]
         end
     end
@@ -309,12 +277,7 @@ for (fname, elty) in ((:cublasDgemv_v2,:Float64),
             lda = max(1,stride(A,2))
             incx = stride(X,1)
             incy = stride(Y,1)
-            @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasOperation_t, Cint, Cint,
-                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty},
-                         Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint), handle(),
-                         cutrans, m, n, [alpha], A, lda, X, incx, [beta], Y,
-                         incy)
+            $fname(handle(), cutrans, m, n, Ref(alpha), A, lda, X, incx, Ref(beta), Y, incy)
             Y
         end
         function gemv(trans::Char, alpha::($elty), A::CuMatrix{$elty}, X::CuVector{$elty})
@@ -356,12 +319,7 @@ for (fname, elty) in ((:cublasDgbmv_v2,:Float64),
             lda = max(1,stride(A,2))
             incx = stride(x,1)
             incy = stride(y,1)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasOperation_t, Cint, Cint,
-                          Cint, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint,
-                          CuPtr{$elty}, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty},
-                          Cint), handle(), cutrans, m, n, kl, ku, [alpha], A,
-                         lda, x, incx, [beta], y, incy)
+            $fname(handle(), cutrans, m, n, kl, ku, Ref(alpha), A, lda, x, incx, Ref(beta), y, incy)
             y
         end
         function gbmv(trans::Char,
@@ -412,13 +370,7 @@ for (fname, elty) in ((:cublasDsymv_v2,:Float64),
             lda = max(1,stride(A,2))
             incx = stride(x,1)
             incy = stride(y,1)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t,
-                         Cint,PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint,
-                         CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
-                         CuPtr{$elty},Cint),
-                         handle(), cuuplo, n, [alpha],
-                         A, lda, x, incx, [beta], y, incy)
+            $fname(handle(), cuuplo, n, Ref(alpha), A, lda, x, incx, Ref(beta), y, incy)
             y
         end
         function symv(uplo::Char, alpha::($elty), A::CuMatrix{$elty}, x::CuVector{$elty})
@@ -454,13 +406,7 @@ for (fname, elty) in ((:cublasZhemv_v2,:ComplexF64),
             lda = max(1,stride(A,2))
             incx = stride(x,1)
             incy = stride(y,1)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t,
-                         Cint,PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint,
-                         CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
-                         CuPtr{$elty},Cint),
-                         handle(), cuuplo, n, [alpha],
-                         A, lda, x, incx, [beta], y, incy)
+            $fname(handle(), cuuplo, n, Ref(alpha), A, lda, x, incx, Ref(beta), y, incy)
             y
         end
         function hemv(uplo::Char, alpha::($elty), A::CuMatrix{$elty},
@@ -501,12 +447,7 @@ for (fname, elty) in ((:cublasDsbmv_v2,:Float64),
             lda = max(1,stride(A,2))
             incx = stride(x,1)
             incy = stride(y,1)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t, Cint, Cint,
-                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint,
-                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint), handle(),
-                         cuuplo, n, k, [alpha], A, lda, x, incx, [beta], y,
-                         incy)
+            $fname(handle(), cuuplo, n, k, Ref(alpha), A, lda, x, incx, Ref(beta), y, incy)
             y
         end
         function sbmv(uplo::Char, k::Integer, alpha::($elty),
@@ -545,12 +486,7 @@ for (fname, elty) in ((:cublasZhbmv_v2,:ComplexF64),
             lda = max(1,stride(A,2))
             incx = stride(x,1)
             incy = stride(y,1)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t, Cint, Cint,
-                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint,
-                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint), handle(),
-                         cuuplo, n, k, [alpha], A, lda, x, incx, [beta], y,
-                         incy)
+            $fname(handle(), cuuplo, n, k, Ref(alpha), A, lda, x, incx, Ref(beta), y, incy)
             y
         end
         function hbmv(uplo::Char, k::Integer, alpha::($elty),
@@ -591,11 +527,7 @@ for (fname, elty) in ((:cublasStbmv_v2,:Float32),
             if n != length(x) throw(DimensionMismatch("")) end
             lda = max(1,stride(A,2))
             incx = stride(x,1)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t, cublasOperation_t,
-                         cublasDiagType_t, Cint, Cint, CuPtr{$elty}, Cint,
-                         CuPtr{$elty}, Cint), handle(), cuuplo, cutrans,
-                         cudiag, n, k, A, lda, x, incx)
+            $fname(handle(), cuuplo, cutrans, cudiag, n, k, A, lda, x, incx)
             x
         end
         function tbmv(uplo::Char,
@@ -634,11 +566,7 @@ for (fname, elty) in ((:cublasStbsv_v2,:Float32),
             if n != length(x) throw(DimensionMismatch("")) end
             lda = max(1,stride(A,2))
             incx = stride(x,1)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t, cublasOperation_t,
-                         cublasDiagType_t, Cint, Cint, CuPtr{$elty}, Cint,
-                         CuPtr{$elty}, Cint), handle(), cuuplo, cutrans,
-                         cudiag, n, k, A, lda, x, incx)
+            $fname(handle(), cuuplo, cutrans, cudiag, n, k, A, lda, x, incx)
             x
         end
         function tbsv(uplo::Char,
@@ -678,11 +606,7 @@ for (fname, elty) in ((:cublasDtrmv_v2,:Float64),
             cudiag = cublasdiag(diag)
             lda = max(1,stride(A,2))
             incx = stride(x,1)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t,
-                          cublasOperation_t, cublasDiagType_t, Cint,
-                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint), handle(),
-                         cuuplo, cutrans, cudiag, n, A, lda, x, incx)
+            $fname(handle(), cuuplo, cutrans, cudiag, n, A, lda, x, incx)
             x
         end
         function trmv(uplo::Char,
@@ -721,11 +645,7 @@ for (fname, elty) in ((:cublasDtrsv_v2,:Float64),
             cudiag = cublasdiag(diag)
             lda = max(1,stride(A,2))
             incx = stride(x,1)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t,
-                          cublasOperation_t, cublasDiagType_t, Cint,
-                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint), handle(),
-                         cuuplo, cutrans, cudiag, n, A, lda, x, incx)
+            $fname(handle(), cuuplo, cutrans, cudiag, n, A, lda, x, incx)
             x
         end
         function trsv(uplo::Char,
@@ -759,11 +679,7 @@ for (fname, elty) in ((:cublasDger_v2,:Float64),
             incx = stride(x,1)
             incy = stride(y,1)
             lda = max(1,stride(A,2))
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Cint, PtrOrCuPtr{$elty},
-                         CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, CuPtr{$elty},
-                         Cint), handle(), m, n, [alpha], x, incx, y,
-                         incy, A, lda)
+            $fname(handle(), m, n, [alpha], x, incx, y, incy, A, lda)
             A
         end
     end
@@ -790,11 +706,7 @@ for (fname, elty) in ((:cublasDsyr_v2,:Float64),
             length(x) == n || throw(DimensionMismatch("Length of vector must be the same as the matrix dimensions"))
             incx = stride(x,1)
             lda = max(1,stride(A,2))
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t, Cint,
-                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint),
-                         handle(), cuuplo, n, [alpha], x, incx, A,
-                         lda)
+            $fname(handle(), cuuplo, n, [alpha], x, incx, A, lda)
             A
         end
     end
@@ -814,11 +726,7 @@ for (fname, elty) in ((:cublasZher_v2,:ComplexF64),
             length(x) == n || throw(DimensionMismatch("Length of vector must be the same as the matrix dimensions"))
             incx = stride(x,1)
             lda = max(1,stride(A,2))
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t, Cint,
-                         PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint),
-                         handle(), cuuplo, n, [alpha], x, incx, A,
-                         lda)
+            $fname(handle(), cuuplo, n, [alpha], x, incx, A, lda)
             A
         end
     end
@@ -841,12 +749,7 @@ for (fname, elty) in ((:cublasZher2_v2,:ComplexF64),
             incx = stride(x,1)
             incy = stride(y,1)
             lda = max(1,stride(A,2))
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t, Cint,
-                          PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint,
-                          CuPtr{$elty}, Cint),
-                         handle(), cuuplo, n, [alpha], x, incx, y, incy, A,
-                         lda)
+            $fname(handle(), cuuplo, n, [alpha], x, incx, y, incy, A, lda)
             A
         end
     end
@@ -885,14 +788,7 @@ for (fname, elty) in
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasOperation_t,
-                          cublasOperation_t, Cint, Cint, Cint, PtrOrCuPtr{$elty},
-                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
-                          CuPtr{$elty}, Cint),
-                         handle(), cutransA,
-                         cutransB, m, n, k, [alpha], A, lda, B, ldb, [beta],
-                         C, ldc)
+            $fname(handle(), cutransA,cutransB, m, n, k, [alpha], A, lda, B, ldb, [beta],C, ldc)
             C
         end
         function gemm(transA::Char,
@@ -962,14 +858,8 @@ for (fname, elty) in
             Aptrs = device_batch(A)
             Bptrs = device_batch(B)
             Cptrs = device_batch(C)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasOperation_t,
-                          cublasOperation_t, Cint, Cint, Cint, PtrOrCuPtr{$elty},
-                          CuPtr{CuPtr{$elty}}, Cint, CuPtr{CuPtr{$elty}}, Cint, PtrOrCuPtr{$elty},
-                          CuPtr{CuPtr{$elty}}, Cint, Cint),
-                         handle(), cutransA,
-                         cutransB, m, n, k, [alpha], Aptrs, lda, Bptrs, ldb, [beta],
-                         Cptrs, ldc, length(A))
+            $fname(handle(), cutransA,cutransB, m, n, k, [alpha], Aptrs, lda, Bptrs,
+                   ldb, [beta], Cptrs, ldc, length(A))
             C
         end
         function gemm_batched(transA::Char,
@@ -1038,14 +928,8 @@ for (fname, elty) in
            strideB = stride(B, 3)
            strideC = stride(C, 3)
            batchCount = size(A, 3)
-           @check ccall(($(string(fname)), libcublas), cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t,
-                         cublasOperation_t, Cint, Cint, Cint, PtrOrCuPtr{$elty},
-                         CuPtr{$elty}, Cint, Cint, CuPtr{$elty}, Cint, Cint, PtrOrCuPtr{$elty},
-                         CuPtr{$elty}, Cint, Cint, Cint),
-                        handle(), cutransA,
-                        cutransB, m, n, k, [alpha], A, lda, strideA, B, ldb, strideB, [beta],
-                        C, ldc, strideC, batchCount)
+           $fname(handle(), cutransA,cutransB, m, n, k, [alpha], A, lda, strideA, B,
+                  ldb, strideB, [beta], C, ldc, strideC, batchCount)
            C
         end
         function gemm_strided_batched(transA::Char,
@@ -1097,14 +981,8 @@ for (fname, elty) in ((:cublasDsymm_v2,:Float64),
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasSideMode_t,
-                         cublasFillMode_t, Cint, Cint, PtrOrCuPtr{$elty},
-                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
-                          CuPtr{$elty}, Cint),
-                         handle(), cuside,
-                         cuuplo, m, n, [alpha], A, lda, B, ldb, [beta], C,
-                         ldc)
+            $fname(handle(), cuside, cuuplo, m, n, [alpha], A, lda, B, ldb,
+                   [beta], C, ldc)
             C
         end
         function symm(side::Char,
@@ -1149,12 +1027,7 @@ for (fname, elty) in ((:cublasDsyrk_v2,:Float64),
            k  = size(A, trans == 'N' ? 2 : 1)
            lda = max(1,stride(A,2))
            ldc = max(1,stride(C,2))
-           @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                        (cublasHandle_t, cublasFillMode_t,
-                         cublasOperation_t, Cint, Cint, PtrOrCuPtr{$elty},
-                         CuPtr{$elty}, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint),
-                        handle(), cuuplo, cutrans, n, k, [alpha], A,
-                        lda, [beta], C, ldc)
+           $fname(handle(), cuuplo, cutrans, n, k, [alpha], A, lda, [beta], C, ldc)
             C
         end
     end
@@ -1202,12 +1075,7 @@ for (fname, elty) in ((:cublasZhemm_v2,:ComplexF64),
            lda = max(1,stride(A,2))
            ldb = max(1,stride(B,2))
            ldc = max(1,stride(C,2))
-           @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                        (cublasHandle_t, cublasSideMode_t, cublasFillMode_t,
-                        Cint, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty},
-                         Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint),
-                        handle(),
-                        cuside, cuuplo, m, n, [alpha], A, lda, B, ldb, [beta], C, ldc)
+           $fname(handle(), cuside, cuuplo, m, n, [alpha], A, lda, B, ldb, [beta], C, ldc)
            C
        end
        function hemm(uplo::Char,
@@ -1246,12 +1114,7 @@ for (fname, elty) in ((:cublasZherk_v2,:ComplexF64),
            k  = size(A, trans == 'N' ? 2 : 1)
            lda = max(1,stride(A,2))
            ldc = max(1,stride(C,2))
-           @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                        (cublasHandle_t, cublasFillMode_t,
-                         cublasOperation_t, Cint, Cint, PtrOrCuPtr{$elty},
-                         CuPtr{$elty}, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint),
-                        handle(), cuuplo, cutrans, n, k, [alpha], A,
-                        lda, [beta], C, ldc)
+           $fname(handle(), cuuplo, cutrans, n, k, [alpha], A, lda, [beta], C, ldc)
            C
        end
        function herk(uplo::Char, trans::Char, alpha::($elty), A::CuVecOrMat{$elty})
@@ -1299,14 +1162,7 @@ for (fname, elty) in ((:cublasDsyr2k_v2,:Float64),
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasFillMode_t,
-                         cublasOperation_t, Cint, Cint, PtrOrCuPtr{$elty},
-                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
-                          CuPtr{$elty}, Cint),
-                         handle(), cuuplo,
-                         cutrans, n, k, [alpha], A, lda, B, ldb, [beta], C,
-                         ldc)
+            $fname(handle(), cuuplo, cutrans, n, k, [alpha], A, lda, B, ldb, [beta], C, ldc)
             C
         end
     end
@@ -1355,13 +1211,7 @@ for (fname, elty1, elty2) in ((:cublasZher2k_v2,:ComplexF64,:Float64),
            lda = max(1,stride(A,2))
            ldb = max(1,stride(B,2))
            ldc = max(1,stride(C,2))
-           @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                        (cublasHandle_t, cublasFillMode_t,
-                        cublasOperation_t, Cint, Cint, PtrOrCuPtr{$elty1},
-                         CuPtr{$elty1}, Cint, CuPtr{$elty1}, Cint, PtrOrCuPtr{$elty2},
-                         CuPtr{$elty1}, Cint),
-                        handle(), cuuplo, cutrans, n, k,
-                        [alpha], A, lda, B, ldb, [beta], C, ldc)
+           $fname(handle(), cuuplo, cutrans, n, k, [alpha], A, lda, B, ldb, [beta], C, ldc)
            C
        end
        function her2k(uplo::Char,
@@ -1418,14 +1268,7 @@ for (mmname, smname, elty) in
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
             ldc = max(1,stride(C,2))
-            @check ccall(($(string(mmname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasSideMode_t,
-                          cublasFillMode_t, cublasOperation_t,
-                          cublasDiagType_t, Cint, Cint, PtrOrCuPtr{$elty},
-                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, CuPtr{$elty},
-                          Cint),
-                         handle(), cuside, cuuplo, cutransa,
-                         cudiag, m, n, [alpha], A, lda, B, ldb, C, ldc)
+            $mmname(handle(), cuside, cuuplo, cutransa, cudiag, m, n, [alpha], A, lda, B, ldb, C, ldc)
             C
         end
         function trmm(side::Char,
@@ -1462,13 +1305,7 @@ for (mmname, smname, elty) in
             if nA != (side == 'L' ? m : n) throw(DimensionMismatch("trsm!")) end
             lda = max(1,stride(A,2))
             ldb = max(1,stride(B,2))
-            @check ccall(($(string(smname)), libcublas), cublasStatus_t,
-                          (cublasHandle_t, cublasSideMode_t,
-                           cublasFillMode_t, cublasOperation_t,
-                           cublasDiagType_t, Cint, Cint, PtrOrCuPtr{$elty},
-                           CuPtr{$elty}, Cint, CuPtr{$elty}, Cint),
-                          handle(), cuside, cuuplo, cutransa, cudiag,
-                          m, n, [alpha], A, lda, B, ldb)
+            $smname(handle(), cuside, cuuplo, cutransa, cudiag, m, n, [alpha], A, lda, B, ldb)
             B
         end
         function trsm(side::Char,
@@ -1523,14 +1360,7 @@ for (fname, elty) in
             ldb = max(1,stride(B[1],2))
             Aptrs = device_batch(A)
             Bptrs = device_batch(B)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasSideMode_t, cublasFillMode_t,
-                          cublasOperation_t, cublasDiagType_t, Cint, Cint,
-                          PtrOrCuPtr{$elty}, CuPtr{CuPtr{$elty}}, Cint, CuPtr{CuPtr{$elty}},
-                          Cint, Cint),
-                         handle(), cuside, cuuplo,
-                         cutransa, cudiag, m, n, [alpha], Aptrs, lda,
-                         Bptrs, ldb, length(A))
+            $fname(handle(), cuside, cuuplo, cutransa, cudiag, m, n, [alpha], Aptrs, lda, Bptrs, ldb, length(A))
             B
         end
         function trsm_batched(side::Char,
@@ -1582,11 +1412,7 @@ for (fname, elty) in ((:cublasDgeam,:Float64),
            lda = max(1,stride(A,2))
            ldb = max(1,stride(B,2))
            ldc = max(1,stride(C,2))
-           @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                        (cublasHandle_t, cublasOperation_t, cublasOperation_t,
-                         Cint, Cint, PtrOrCuPtr{$elty}, CuPtr{$elty}, Cint, PtrOrCuPtr{$elty},
-                         CuPtr{$elty}, Cint, CuPtr{$elty}, Cint), handle(),
-                        cutransa, cutransb, m, n, [alpha], A, lda, [beta], B, ldb, C, ldc)
+           $fname(handle(), cutransa, cutransb, m, n, [alpha], A, lda, [beta], B, ldb, C, ldc)
            C
        end
        function geam(transa::Char,
@@ -1632,10 +1458,7 @@ for (fname, elty) in
             Aptrs = device_batch(A)
             info  = CuArray{Cint}(undef, length(A))
             pivotArray  = Pivot ? CuArray{Int32}(undef, (n, length(A))) : CU_NULL
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, CuPtr{CuPtr{$elty}}, Cint,
-                          CuPtr{Cint}, CuPtr{Cint}, Cint), handle(), n,
-                         Aptrs, lda, pivotArray, info, length(A))
+            $fname(handle(), n, Aptrs, lda, pivotArray, info, length(A))
             if( !Pivot )
                 pivotArray = CuArray(zeros(Cint, (n, length(A))))
             end
@@ -1677,11 +1500,7 @@ for (fname, elty) in
             Aptrs = device_batch(A)
             Cptrs = device_batch(C)
             info = CuArray(zeros(Cint,length(A)))
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, CuPtr{CuPtr{$elty}}, Cint,
-                          CuPtr{Cint}, CuPtr{CuPtr{$elty}}, Cint, CuPtr{Cint}, Cint),
-                         handle(), n, Aptrs, lda, pivotArray, Cptrs,
-                         ldc, info, length(A))
+            $fname(handle(), n, Aptrs, lda, pivotArray, Cptrs, ldc, info, length(A))
             pivotArray, info, C
         end
     end
@@ -1716,11 +1535,7 @@ for (fname, elty) in
             Aptrs = device_batch(A)
             Cptrs = device_batch(C)
             info = CuArray(zeros(Cint,length(A)))
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, CuPtr{CuPtr{$elty}}, Cint,
-                          CuPtr{CuPtr{$elty}}, Cint, CuPtr{Cint}, Cint),
-                         handle(), n, Aptrs, lda, Cptrs,
-                         ldc, info, length(A))
+            $fname(handle(), n, Aptrs, lda, Cptrs, ldc, info, length(A))
             info, C
         end
     end
@@ -1749,11 +1564,7 @@ for (fname, elty) in
             end
             Tauptrs = device_batch(TauArray)
             info    = zero(Cint)
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, Cint, Cint, CuPtr{CuPtr{$elty}},
-                          Cint, CuPtr{CuPtr{$elty}}, Ptr{Cint}, Cint),
-                         handle(), m, n, Aptrs, lda,
-                         Tauptrs, [info], length(A))
+            $fname(handle(), m, n, Aptrs, lda, Tauptrs, [info], length(A))
             if( info != 0 )
                 throw(ArgumentError,string("Invalid value at ",-info))
             end
@@ -1803,12 +1614,7 @@ for (fname, elty) in
             Cptrs = device_batch(C)
             info  = zero(Cint)
             infoarray = CuArray(zeros(Cint, length(A)))
-            @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                         (cublasHandle_t, cublasOperation_t, Cint, Cint,
-                          Cint, CuPtr{CuPtr{$elty}}, Cint, CuPtr{CuPtr{$elty}},
-                          Cint, Ptr{Cint}, CuPtr{Cint}, Cint),
-                         handle(), cutrans, m, n, nrhs, Aptrs, lda,
-                         Cptrs, ldc, [info], infoarray, length(A))
+            $fname(handle(), cutrans, m, n, nrhs, Aptrs, lda, Cptrs, ldc, [info], infoarray, length(A))
             if( info != 0 )
                 throw(ArgumentError,string("Invalid value at ",-info))
             end
@@ -1848,10 +1654,7 @@ for (fname, elty) in ((:cublasDdgmm,:Float64),
            lda = max(1,stride(A,2))
            incx = stride(X,1)
            ldc = max(1,stride(C,2))
-           @check ccall(($(string(fname)),libcublas), cublasStatus_t,
-                        (cublasHandle_t, cublasSideMode_t, Cint, Cint,
-                         CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint),
-                        handle(), cuside, m, n, A, lda, X, incx, C, ldc)
+           $fname(handle(), cuside, m, n, A, lda, X, incx, C, ldc)
            C
        end
        function dgmm(mode::Char,

--- a/src/dnn/CUDNN.jl
+++ b/src/dnn/CUDNN.jl
@@ -1,7 +1,8 @@
 module CUDNN
 
-import CUDAdrv: CUDAdrv, CuContext
 import CUDAapi
+
+import CUDAdrv: CUDAdrv, CuContext, CuPtr, CU_NULL
 
 using ..CuArrays
 using ..CuArrays: libcudnn, active_context, configured

--- a/src/dnn/helpers.jl
+++ b/src/dnn/helpers.jl
@@ -73,8 +73,7 @@ function Base.size(f::FilterDesc)
   format = Ref{Cuint}()
   ndims = Ref{Cint}()
   dims = Vector{Cint}(undef, 8)
-  @check ccall((:cudnnGetFilterNdDescriptor,libcudnn), cudnnStatus_t, (Ptr{Nothing}, Cint, Ptr{UInt32}, Ptr{UInt32}, Ptr{Cint}, Ptr{Cint}),
-    f, 8, typ, format, ndims, dims)
+  cudnnGetFilterNdDescriptor(f, 8, typ, format, ndims, dims)
   @assert ndims[] ≤ 8
   return (dims[1:ndims[]]...,) |> reverse
 end

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -183,8 +183,8 @@ function cudnnSoftmaxForward(algo,mode,alpha,xDesc,x,beta,yDesc,y)
     @check ccall((:cudnnSoftmaxForward,libcudnn),
                  cudnnStatus_t,
                  (cudnnHandle_t,cudnnSoftmaxAlgorithm_t,cudnnSoftmaxMode_t,Ptr{Nothing},
-                  cudnnTensorDescriptor_t,Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,
-                  Ptr{Nothing}),
+                  cudnnTensorDescriptor_t,CuPtr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,
+                  CuPtr{Nothing}),
                  handle(),
                  algo,mode,alpha,xDesc,x,beta,yDesc,y)
 end
@@ -203,8 +203,8 @@ function cudnnSoftmaxBackward(algo,mode,alpha,yDesc,y,dyDesc,dy,beta,dxDesc,dx)
     @check ccall((:cudnnSoftmaxBackward,libcudnn),
                  cudnnStatus_t,
                  (cudnnHandle_t,cudnnSoftmaxAlgorithm_t,cudnnSoftmaxMode_t,Ptr{Nothing},
-                  cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},
-                  Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),
+                  cudnnTensorDescriptor_t,CuPtr{Nothing},cudnnTensorDescriptor_t,CuPtr{Nothing},
+                  Ptr{Nothing},cudnnTensorDescriptor_t,CuPtr{Nothing}),
                  handle(),
                  algo,mode,alpha,yDesc,y,dyDesc,dy,beta,dxDesc,dx)
 end
@@ -223,17 +223,17 @@ end
 function cudnnConvolutionBiasActivationForward(alpha1, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, alpha2, biasDesc, bias, activationDesc, yDesc, y)
     @check ccall((:cudnnConvolutionBiasActivationForward, libcudnn),
                 cudnnStatus_t,
-                (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing},
-                 cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t,
-                 cudnnConvolutionFwdAlgo_t, Ptr{Nothing}, Csize_t, Ptr{Nothing},
-                 cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t,
-                 Ptr{Nothing}, cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, Ptr{Nothing}),
+                (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, CuPtr{Nothing},
+                 cudnnFilterDescriptor_t, CuPtr{Nothing}, cudnnConvolutionDescriptor_t,
+                 cudnnConvolutionFwdAlgo_t, CuPtr{Nothing}, Csize_t, Ptr{Nothing},
+                 cudnnTensorDescriptor_t, CuPtr{Nothing}, cudnnTensorDescriptor_t,
+                 CuPtr{Nothing}, cudnnActivationDescriptor_t, cudnnTensorDescriptor_t, CuPtr{Nothing}),
                  handle(), alpha1, xDesc, x, wDesc, w, convDesc, algo, workspace,
                  workspace_size, alpha2, yDesc, y, biasDesc, bias, activationDesc, yDesc, y)
 end
 
 function cudnnConvolutionBiasActivationForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N}, bias::CuArray{T,N};
-                                               alpha1=1, workspace=C_NULL, workspace_size=0,
+                                               alpha1=1, workspace=CU_NULL, workspace_size=0,
                                                algo=0, alpha2=0, padding=0, stride=1, dilation=1, mode=0,
                                                activationMode=CUDNN_ACTIVATION_IDENTITY, activationCoeff=0.0,
                                                activationReluNanOpt=CUDNN_NOT_PROPAGATE_NAN) where {T,N}
@@ -245,19 +245,19 @@ function cudnnConvolutionBiasActivationForward(y::CuArray{T,N}, x::CuArray{T,N},
 end
 
 function cudnnConvolutionForward(alpha, xDesc, x, wDesc, w, convDesc, algo, workspace, workspace_size, beta, yDesc, y)
-    workspace = something(workspace, C_NULL)
+    workspace = something(workspace, CU_NULL)
     @check ccall((:cudnnConvolutionForward, libcudnn),
                  cudnnStatus_t,
-                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing},
-                  cudnnFilterDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t,
-                  cudnnConvolutionFwdAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing},
-                  cudnnTensorDescriptor_t, Ptr{Nothing}),
+                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, CuPtr{Nothing},
+                  cudnnFilterDescriptor_t, CuPtr{Nothing}, cudnnConvolutionDescriptor_t,
+                  cudnnConvolutionFwdAlgo_t, CuPtr{Nothing}, Cint, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, CuPtr{Nothing}),
                  handle(), alpha, xDesc, x, wDesc, w, convDesc, algo, workspace,
                  workspace_size, beta, yDesc, y)
 end
 
 function cudnnConvolutionForward(y::CuArray{T,N}, x::CuArray{T,N}, w::CuArray{T,N};
-                                 algo=0, workspace=C_NULL, workspace_size=0,
+                                 algo=0, workspace=CU_NULL, workspace_size=0,
                                  alpha=1, beta=0, padding=0, stride=1, dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     cudnnConvolutionForward(
@@ -285,19 +285,19 @@ function cudnnGetConvolutionForwardWorkspaceSize(y::CuArray{T,N}, x::CuArray{T,N
 end
 
 function cudnnConvolutionBackwardData(alpha, wDesc, w, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dxDesc, dx)
-    workspace = something(workspace, C_NULL)
+    workspace = something(workspace, CU_NULL)
     @check ccall((:cudnnConvolutionBackwardData, libcudnn),
                  cudnnStatus_t,
-                 (cudnnHandle_t, Ptr{Nothing}, cudnnFilterDescriptor_t, Ptr{Nothing},
-                  cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t,
-                  cudnnConvolutionBwdDataAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing},
-                  cudnnTensorDescriptor_t, Ptr{Nothing}),
+                 (cudnnHandle_t, Ptr{Nothing}, cudnnFilterDescriptor_t, CuPtr{Nothing},
+                  cudnnTensorDescriptor_t, CuPtr{Nothing}, cudnnConvolutionDescriptor_t,
+                  cudnnConvolutionBwdDataAlgo_t, CuPtr{Nothing}, Cint, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, CuPtr{Nothing}),
                  handle(), alpha, wDesc, w, dyDesc, dy, convDesc, algo, workspace,
                  workspace_size, beta, dxDesc, dx)
 end
 
 function cudnnConvolutionBackwardData(dx::CuArray{T,N}, w::CuArray{T,N}, dy::CuArray{T,N};
-                                      algo=0, workspace=C_NULL, workspace_size=0,
+                                      algo=0, workspace=CU_NULL, workspace_size=0,
                                       alpha=1, beta=0, padding=0, stride=1, dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     cudnnConvolutionBackwardData(
@@ -325,19 +325,19 @@ function cudnnGetConvolutionBackwardDataWorkspaceSize(dx::CuArray{T,N}, w::CuArr
 end
 
 function cudnnConvolutionBackwardFilter(alpha, xDesc, x, dyDesc, dy, convDesc, algo, workspace, workspace_size, beta, dwDesc, dw)
-    workspace = something(workspace, C_NULL)
+    workspace = something(workspace, CU_NULL)
     @check ccall((:cudnnConvolutionBackwardFilter, libcudnn),
                  cudnnStatus_t,
-                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing},
-                  cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnConvolutionDescriptor_t,
-                  cudnnConvolutionBwdFilterAlgo_t, Ptr{Nothing}, Cint, Ptr{Nothing},
-                  cudnnFilterDescriptor_t, Ptr{Nothing}),
+                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, CuPtr{Nothing},
+                  cudnnTensorDescriptor_t, CuPtr{Nothing}, cudnnConvolutionDescriptor_t,
+                  cudnnConvolutionBwdFilterAlgo_t, CuPtr{Nothing}, Cint, Ptr{Nothing},
+                  cudnnFilterDescriptor_t, CuPtr{Nothing}),
                  handle(), alpha, xDesc, x, dyDesc, dy, convDesc, algo, workspace,
                  workspace_size, beta, dwDesc, dw)
 end
 
 function cudnnConvolutionBackwardFilter(dw::CuArray{T,N}, x::CuArray{T,N}, dy::CuArray{T,N};
-                                        algo=0, workspace=C_NULL, workspace_size=0,
+                                        algo=0, workspace=CU_NULL, workspace_size=0,
                                         alpha=1, beta=0, padding=0, stride=1, dilation=1, mode=0) where {T,N}
     cd = ConvDesc(T, N-2, padding, stride, dilation, mode)
     cudnnConvolutionBackwardFilter(
@@ -367,8 +367,8 @@ end
 function cudnnConvolutionBackwardBias(alpha, dyDesc, dy, beta, dbDesc, db)
     @check ccall((:cudnnConvolutionBackwardBias, libcudnn),
                  cudnnStatus_t,
-                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing},
-                  Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}),
+                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, CuPtr{Nothing},
+                  Ptr{Nothing}, cudnnTensorDescriptor_t, CuPtr{Nothing}),
                  handle(), alpha, dyDesc, dy, beta, dbDesc, db)
 end
 
@@ -381,7 +381,7 @@ function cudnnPoolingForward(poolingDesc,alpha,xDesc,x,beta,yDesc,y)
     @check ccall((:cudnnPoolingForward,libcudnn),
                  cudnnStatus_t,
                  (cudnnHandle_t,cudnnPoolingDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,
-                  Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),
+                  CuPtr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,CuPtr{Nothing}),
                  handle(), poolingDesc,alpha,xDesc,x,beta,yDesc,y)
 end
 
@@ -389,8 +389,8 @@ function cudnnPoolingBackward(poolingDesc,alpha,yDesc,y,dyDesc,dy,xDesc,x,beta,d
     @check ccall((:cudnnPoolingBackward,libcudnn),
                  cudnnStatus_t,
                  (cudnnHandle_t,cudnnPoolingDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,
-                  Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing},cudnnTensorDescriptor_t,
-                  Ptr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,Ptr{Nothing}),
+                  CuPtr{Nothing},cudnnTensorDescriptor_t,CuPtr{Nothing},cudnnTensorDescriptor_t,
+                  CuPtr{Nothing},Ptr{Nothing},cudnnTensorDescriptor_t,CuPtr{Nothing}),
                  handle(),poolingDesc,alpha,yDesc,y,dyDesc,dy,xDesc,x,beta,dxDesc,dx)
 end
 
@@ -417,8 +417,8 @@ function cudnnActivationForward(activationDesc, alpha, xDesc, x, beta, yDesc, y)
     @check ccall((:cudnnActivationForward, libcudnn),
                  cudnnStatus_t,
                  (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Nothing},
-                  cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing},
-                  cudnnTensorDescriptor_t, Ptr{Nothing}),
+                  cudnnTensorDescriptor_t, CuPtr{Nothing}, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, CuPtr{Nothing}),
                  handle(), activationDesc, alpha, xDesc, x, beta, yDesc, y)
 end
 
@@ -433,9 +433,9 @@ function cudnnActivationBackward(activationDesc, alpha, yDesc, y, dyDesc, dy, xD
     @check ccall((:cudnnActivationBackward, libcudnn),
                  cudnnStatus_t,
                  (cudnnHandle_t, cudnnActivationDescriptor_t, Ptr{Nothing},
-                  cudnnTensorDescriptor_t, Ptr{Nothing}, cudnnTensorDescriptor_t,
-                  Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}, Ptr{Nothing},
-                  cudnnTensorDescriptor_t, Ptr{Nothing}),
+                  cudnnTensorDescriptor_t, CuPtr{Nothing}, cudnnTensorDescriptor_t,
+                  CuPtr{Nothing}, cudnnTensorDescriptor_t, CuPtr{Nothing}, Ptr{Nothing},
+                  cudnnTensorDescriptor_t, CuPtr{Nothing}),
                  handle(), activationDesc, alpha, yDesc, y, dyDesc, dy, xDesc, x, beta, dxDesc, dx)
 end
 
@@ -450,8 +450,8 @@ end
 function cudnnAddTensor(alpha, aDesc, A, beta, cDesc, C)
     @check ccall((:cudnnAddTensor, libcudnn),
                  cudnnStatus_t,
-                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing},
-                  Ptr{Nothing}, cudnnTensorDescriptor_t, Ptr{Nothing}),
+                 (cudnnHandle_t, Ptr{Nothing}, cudnnTensorDescriptor_t, CuPtr{Nothing},
+                  Ptr{Nothing}, cudnnTensorDescriptor_t, CuPtr{Nothing}),
                  handle(), alpha, aDesc, A, beta, cDesc, C)
 end
 

--- a/src/fft/CUFFT.jl
+++ b/src/fft/CUFFT.jl
@@ -2,6 +2,8 @@ module CUFFT
 
 import CUDAapi
 
+import CUDAdrv: CuPtr, PtrOrCuPtr
+
 using ..CuArrays
 using ..CuArrays: libcufft, configured
 

--- a/src/fft/libcufft.jl
+++ b/src/fft/libcufft.jl
@@ -1,10 +1,77 @@
+# low-level wrappers of the CUFFT library
+
 cufftGetVersion() = ccall((:cufftGetVersion,libcufft), Cint, ())
 
 function cufftGetProperty(property::CUDAapi.libraryPropertyType)
   value_ref = Ref{Cint}()
-  @check ccall((:cufftGetProperty, libcufft),
-               cufftStatus_t,
+  @check ccall((:cufftGetProperty, libcufft), cufftStatus_t,
                (Cint, Ptr{Cint}),
                property, value_ref)
   value_ref[]
+end
+
+cufftDestroy(plan) = ccall((:cufftDestroy,libcufft), Nothing, (cufftHandle_t,), plan)
+
+function cufftPlan1d(plan, nx, type, batch)
+    @check ccall((:cufftPlan1d,libcufft),cufftStatus_t,
+                 (Ptr{cufftHandle_t}, Cint, cufftType, Cint),
+                 plan, nx, type, batch)
+end
+
+function cufftPlan2d(plan, nx, ny, type)
+    @check ccall((:cufftPlan2d,libcufft),cufftStatus_t,
+                 (Ptr{cufftHandle_t}, Cint, Cint, cufftType),
+                 plan, nx, ny, type)
+end
+
+function cufftPlan3d(plan, nx, ny, nz, type)
+    @check ccall((:cufftPlan3d,libcufft),cufftStatus_t,
+                 (Ptr{cufftHandle_t}, Cint, Cint, Cint, cufftType),
+                 plan, nx, ny, nz, type)
+end
+
+function cufftPlanMany(plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch)
+    @check ccall((:cufftPlanMany,libcufft),cufftStatus_t,
+                 (Ptr{cufftHandle_t}, Cint, Ptr{Cint},
+                  Ptr{Cint}, Cint, Cint,
+                  Ptr{Cint}, Cint, Cint,
+                  cufftType, Cint),
+                 plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch)
+end
+
+function cufftExecC2C(plan, idata, odata, direction)
+    @check ccall((:cufftExecC2C,libcufft), cufftStatus_t,
+                 (cufftHandle_t, CuPtr{cufftComplex}, CuPtr{cufftComplex}, Cint),
+                 plan, idata, odata, direction)
+end
+
+function cufftExecC2R(plan, idata, odata)
+    @check ccall((:cufftExecC2R,libcufft), cufftStatus_t,
+                 (cufftHandle_t, CuPtr{cufftComplex}, CuPtr{cufftComplex}),
+                 plan, idata, odata)
+end
+
+function cufftExecR2C(plan, idata, odata)
+    @check ccall((:cufftExecR2C,libcufft), cufftStatus_t,
+                 (cufftHandle_t, CuPtr{cufftReal}, CuPtr{cufftComplex}),
+                 plan, idata, odata)
+end
+
+function cufftExecZ2Z(plan, idata, odata, direction)
+    @check ccall((:cufftExecZ2Z,libcufft), cufftStatus_t,
+                 (cufftHandle_t, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleComplex},
+                  Cint),
+                 plan, idata, odata, direction)
+end
+
+function cufftExecZ2D(plan, idata, odata)
+    @check ccall((:cufftExecZ2D,libcufft), cufftStatus_t,
+                 (cufftHandle_t, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleComplex}),
+                 plan, idata, odata)
+end
+
+function cufftExecD2Z(plan, idata, odata)
+    @check ccall((:cufftExecD2Z,libcufft), cufftStatus_t,
+                 (cufftHandle_t, CuPtr{cufftDoubleReal}, CuPtr{cufftDoubleComplex}),
+                 plan, idata, odata)
 end

--- a/src/fft/wrappers.jl
+++ b/src/fft/wrappers.jl
@@ -168,7 +168,7 @@ function unsafe_execute!(plan::cCuFFTPlan{cufftComplex,K,true,N},
                          x::CuArray{cufftComplex,N}) where {K,N}
     @assert plan.xtype == CUFFT_C2C
     @check ccall((:cufftExecC2C,libcufft), cufftStatus_t,
-                 (cufftHandle_t, Ptr{cufftComplex}, Ptr{cufftComplex},
+                 (cufftHandle_t, CuPtr{cufftComplex}, CuPtr{cufftComplex},
                   Cint),
                  plan, x, x, K)
 end
@@ -176,7 +176,7 @@ function unsafe_execute!(plan::rCuFFTPlan{cufftComplex,K,true,N},
                          x::CuArray{cufftComplex,N}) where {K,N}
     @assert plan.xtype == CUFFT_C2R
     @check ccall((:cufftExecC2R,libcufft), cufftStatus_t,
-                 (cufftHandle_t, Ptr{cufftComplex}, Ptr{cufftComplex}),
+                 (cufftHandle_t, CuPtr{cufftComplex}, CuPtr{cufftComplex}),
                  plan, x, x)
 end
 
@@ -185,7 +185,7 @@ function unsafe_execute!(plan::cCuFFTPlan{cufftComplex,K,false,N},
                          ) where {K,N}
     @assert plan.xtype == CUFFT_C2C
     @check ccall((:cufftExecC2C,libcufft), cufftStatus_t,
-                 (cufftHandle_t, Ptr{cufftComplex}, Ptr{cufftComplex}, Cint),
+                 (cufftHandle_t, CuPtr{cufftComplex}, CuPtr{cufftComplex}, Cint),
                  plan, x, y, K)
 end
 function unsafe_execute!(plan::rCuFFTPlan{cufftComplex,K,false,N},
@@ -193,7 +193,7 @@ function unsafe_execute!(plan::rCuFFTPlan{cufftComplex,K,false,N},
                          ) where {K,N}
     @assert plan.xtype == CUFFT_C2R
     @check ccall((:cufftExecC2R,libcufft), cufftStatus_t,
-                 (cufftHandle_t, Ptr{cufftComplex}, Ptr{cufftReal}),
+                 (cufftHandle_t, CuPtr{cufftComplex}, CuPtr{cufftReal}),
                  plan, x, y)
 end
 
@@ -202,7 +202,7 @@ function unsafe_execute!(plan::rCuFFTPlan{cufftReal,K,false,N},
                          ) where {K,N}
     @assert plan.xtype == CUFFT_R2C
     @check ccall((:cufftExecR2C,libcufft), cufftStatus_t,
-                 (cufftHandle_t, Ptr{cufftReal}, Ptr{cufftComplex}),
+                 (cufftHandle_t, CuPtr{cufftReal}, CuPtr{cufftComplex}),
                  plan, x, y)
 end
 
@@ -211,7 +211,7 @@ function unsafe_execute!(plan::cCuFFTPlan{cufftDoubleComplex,K,true,N},
                          x::CuArray{cufftDoubleComplex,N}) where {K,N}
     @assert plan.xtype == CUFFT_Z2Z
     @check ccall((:cufftExecZ2Z,libcufft), cufftStatus_t,
-                 (cufftHandle_t, Ptr{cufftDoubleComplex}, Ptr{cufftDoubleComplex},
+                 (cufftHandle_t, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleComplex},
                   Cint),
                  plan, x, x, K)
 end
@@ -219,7 +219,7 @@ function unsafe_execute!(plan::rCuFFTPlan{cufftDoubleComplex,K,true,N},
                          x::CuArray{cufftDoubleComplex,N}) where {K,N}
     @assert plan.xtype == CUFFT_Z2D
     @check ccall((:cufftExecZ2D,libcufft), cufftStatus_t,
-                 (cufftHandle_t, Ptr{cufftDoubleComplex}, Ptr{cufftDoubleComplex}),
+                 (cufftHandle_t, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleComplex}),
                  plan, x, x)
 end
 
@@ -228,7 +228,7 @@ function unsafe_execute!(plan::cCuFFTPlan{cufftDoubleComplex,K,false,N},
                          ) where {K,N}
     @assert plan.xtype == CUFFT_Z2Z
     @check ccall((:cufftExecZ2Z,libcufft), cufftStatus_t,
-                 (cufftHandle_t, Ptr{cufftDoubleComplex}, Ptr{cufftDoubleComplex}, Cint),
+                 (cufftHandle_t, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleComplex}, Cint),
                  plan, x, y, K)
 end
 function unsafe_execute!(plan::rCuFFTPlan{cufftDoubleComplex,K,false,N},
@@ -236,7 +236,7 @@ function unsafe_execute!(plan::rCuFFTPlan{cufftDoubleComplex,K,false,N},
                          ) where {K,N}
     @assert plan.xtype == CUFFT_Z2D
     @check ccall((:cufftExecZ2D,libcufft), cufftStatus_t,
-                 (cufftHandle_t, Ptr{cufftDoubleComplex}, Ptr{cufftDoubleReal}),
+                 (cufftHandle_t, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleReal}),
                  plan, x, y)
 end
 
@@ -245,6 +245,6 @@ function unsafe_execute!(plan::rCuFFTPlan{cufftDoubleReal,K,false,N},
                          ) where {K,N}
     @assert plan.xtype == CUFFT_D2Z
     @check ccall((:cufftExecD2Z,libcufft), cufftStatus_t,
-                 (cufftHandle_t, Ptr{cufftDoubleReal}, Ptr{cufftDoubleComplex}),
+                 (cufftHandle_t, CuPtr{cufftDoubleReal}, CuPtr{cufftDoubleComplex}),
                  plan, x, y)
 end

--- a/src/rand/CURAND.jl
+++ b/src/rand/CURAND.jl
@@ -1,6 +1,6 @@
 module CURAND
 
-import CUDAdrv: CUDAdrv, CuContext
+import CUDAdrv: CUDAdrv, CuContext, CuPtr
 import CUDAapi
 
 using ..CuArrays

--- a/src/rand/libcurand.jl
+++ b/src/rand/libcurand.jl
@@ -56,7 +56,7 @@ Generate 64-bit quasirandom numbers.
 function generate(rng::RNG, arr::CuArray, n::UInt)
     @check ccall((:curandGenerate, libcurand),
                  curandStatus_t,
-                 (curandGenerator_t, Ptr{UInt32}, Csize_t),
+                 (curandGenerator_t, CuPtr{UInt32}, Csize_t),
                  rng, arr, length(arr))
     return arr
 end
@@ -72,7 +72,7 @@ Valid RNG types are:
 function generate_long_long(rng::RNG, arr::CuArray)
     @check ccall((:curandGenerateLongLong, libcurand),
                  curandStatus_t,
-                 (curandGenerator_t, Ptr{Culonglong}, Csize_t),
+                 (curandGenerator_t, CuPtr{Culonglong}, Csize_t),
                  rng, arr, length(arr))
     return arr
 end
@@ -81,7 +81,7 @@ end
 function generate_uniform(rng::RNG, arr::CuArray)
     @check ccall((:curandGenerateUniform, libcurand),
                  curandStatus_t,
-                 (curandGenerator_t, Ptr{Float32}, Csize_t),
+                 (curandGenerator_t, CuPtr{Float32}, Csize_t),
                  rng, arr, length(arr))
     return arr
 end
@@ -89,7 +89,7 @@ end
 function generate_uniform_double(rng::RNG, arr::CuArray)
     @check ccall((:curandGenerateUniformDouble, libcurand),
                  curandStatus_t,
-                 (curandGenerator_t, Ptr{Float64}, Csize_t),
+                 (curandGenerator_t, CuPtr{Float64}, Csize_t),
                  rng, arr, length(arr))
     return arr
 end
@@ -98,7 +98,7 @@ end
 function generate_normal(rng::RNG, arr::CuArray, mean, stddev)
     @check ccall((:curandGenerateNormal, libcurand),
                  curandStatus_t,
-                 (curandGenerator_t, Ptr{Cfloat}, Csize_t, Cfloat, Cfloat),
+                 (curandGenerator_t, CuPtr{Cfloat}, Csize_t, Cfloat, Cfloat),
                  rng, arr, length(arr), mean, stddev)
     return arr
 end
@@ -106,7 +106,7 @@ end
 function generate_normal_double(rng::RNG, arr::CuArray, mean, stddev)
     @check ccall((:curandGenerateNormalDouble, libcurand),
                  curandStatus_t,
-                 (curandGenerator_t, Ptr{Cdouble}, Csize_t, Cdouble, Cdouble),
+                 (curandGenerator_t, CuPtr{Cdouble}, Csize_t, Cdouble, Cdouble),
                  rng, arr, length(arr), mean, stddev)
     return arr
 end
@@ -116,7 +116,7 @@ end
 function generate_log_normal(rng::RNG, arr::CuArray, mean, stddev)
     @check ccall((:curandGenerateLogNormal, libcurand),
                  curandStatus_t,
-                 (curandGenerator_t, Ptr{Cfloat}, Csize_t, Cfloat, Cfloat),
+                 (curandGenerator_t, CuPtr{Cfloat}, Csize_t, Cfloat, Cfloat),
                  rng, arr, length(arr), mean, stddev)
     return arr
 end
@@ -124,7 +124,7 @@ end
 function generate_log_normal_double(rng::RNG, arr::CuArray, mean, stddev)
     @check ccall((:curandGenerateLogNormalDouble, libcurand),
                  curandStatus_t,
-                 (curandGenerator_t, Ptr{Cdouble}, Csize_t, Cdouble, Cdouble),
+                 (curandGenerator_t, CuPtr{Cdouble}, Csize_t, Cdouble, Cdouble),
                  rng, arr, length(arr), mean, stddev)
     return arr
 end
@@ -154,7 +154,7 @@ end
 function generate_poisson(rng::RNG, arr::CuArray, lambda)
     @check ccall((:curandGeneratePoisson, libcurand),
                  curandStatus_t,
-                 (curandGenerator_t, Ptr{Cuint}, Csize_t, Cdouble),
+                 (curandGenerator_t, CuPtr{Cuint}, Csize_t, Cdouble),
                  rng, arr, length(arr), lambda)
     return arr
 end

--- a/src/solver/CUSOLVER.jl
+++ b/src/solver/CUSOLVER.jl
@@ -1,6 +1,6 @@
 module CUSOLVER
 
-import CUDAdrv: CUDAdrv, CuContext, CuStream_t
+import CUDAdrv: CUDAdrv, CuContext, CuStream_t, CuPtr, PtrOrCuPtr, CU_NULL
 import CUDAapi
 
 using ..CuArrays

--- a/src/solver/dense.jl
+++ b/src/solver/dense.jl
@@ -1,3 +1,7 @@
+# wrappers of the low-level dense CUSOLVER functionality
+#
+# TODO: move raw ccall wrappers to libcusolver.jl
+
 using LinearAlgebra: BlasInt, checksquare
 using LinearAlgebra.LAPACK: chkargsok
 

--- a/src/solver/dense.jl
+++ b/src/solver/dense.jl
@@ -27,14 +27,14 @@ for (bname, fname,elty) in ((:cusolverDnSpotrf_bufferSize, :cusolverDnSpotrf, :F
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasFillMode_t, Cint,
-                          Ptr{$elty}, Cint, Ref{Cint}),
+                          CuPtr{$elty}, Cint, Ptr{Cint}),
                          dense_handle(), cuuplo, n, A, lda, bufSize)
 
             buffer  = CuArray{$elty}(undef, bufSize[])
             devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasFillMode_t, Cint,
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{Cint}),
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, CuPtr{Cint}),
                          dense_handle(), cuuplo, n, A, lda, buffer,
                          bufSize[], devinfo)
             info = BlasInt(_getindex(devinfo, 1))
@@ -65,7 +65,7 @@ for (fname,elty) in ((:cusolverDnSpotrs, :Float32),
             devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasFillMode_t, Cint, Cint,
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{Cint}),
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, CuPtr{Cint}),
                          dense_handle(), cuuplo, n, nrhs, A, lda, B,
                          ldb, devinfo)
             info = _getindex(devinfo, 1)
@@ -86,16 +86,16 @@ for (bname, fname,elty) in ((:cusolverDnSgetrf_bufferSize, :cusolverDnSgetrf, :F
             lda     = max(1, stride(A, 2))
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
-                         (cusolverDnHandle_t, Cint, Cint, Ptr{$elty}, Cint,
-                          Ref{Cint}), dense_handle(), m, n, A, lda,
+                         (cusolverDnHandle_t, Cint, Cint, CuPtr{$elty}, Cint,
+                          Ptr{Cint}), dense_handle(), m, n, A, lda,
                          bufSize)
 
             buffer  = CuArray{$elty}(undef, bufSize[])
             devipiv = CuArray{Cint}(undef, min(m,n))
             devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
-                         (cusolverDnHandle_t, Cint, Cint, Ptr{$elty},
-                          Cint, Ptr{$elty}, Ptr{Cint}, Ptr{Cint}),
+                         (cusolverDnHandle_t, Cint, Cint, CuPtr{$elty},
+                          Cint, CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}),
                          dense_handle(), m, n, A, lda, buffer,
                          devipiv, devinfo)
             info = _getindex(devinfo, 1)
@@ -120,15 +120,15 @@ for (bname, fname,elty) in ((:cusolverDnSgeqrf_bufferSize, :cusolverDnSgeqrf, :F
             lda     = max(1, stride(A, 2))
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)),libcusolver), cusolverStatus_t,
-                         (cusolverDnHandle_t, Cint, Cint, Ptr{$elty}, Cint,
-                          Ref{Cint}), dense_handle(), m, n, A,
+                         (cusolverDnHandle_t, Cint, Cint, CuPtr{$elty}, Cint,
+                          Ptr{Cint}), dense_handle(), m, n, A,
                          lda, bufSize)
             buffer  = CuArray{$elty}(undef, bufSize[])
             tau  = CuArray{$elty}(undef, min(m, n))
             devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)),libcusolver), cusolverStatus_t,
-                         (cusolverDnHandle_t, Cint, Cint, Ptr{$elty},
-                          Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{Cint}),
+                         (cusolverDnHandle_t, Cint, Cint, CuPtr{$elty},
+                          Cint, CuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{Cint}),
                          dense_handle(), m, n, A, lda, tau, buffer,
                          bufSize[], devinfo)
             info = _getindex(devinfo, 1)
@@ -153,8 +153,8 @@ for (bname, fname,elty) in ((:cusolverDnSsytrf_bufferSize, :cusolverDnSsytrf, :F
             lda = max(1, stride(A, 2))
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)),libcusolver), cusolverStatus_t,
-                         (cusolverDnHandle_t, Cint, Ptr{$elty}, Cint,
-                          Ref{Cint}), dense_handle(), n, A, lda,
+                         (cusolverDnHandle_t, Cint, CuPtr{$elty}, Cint,
+                          Ptr{Cint}), dense_handle(), n, A, lda,
                          bufSize)
 
             buffer  = CuArray{$elty}(undef, bufSize[])
@@ -162,8 +162,8 @@ for (bname, fname,elty) in ((:cusolverDnSsytrf_bufferSize, :cusolverDnSsytrf, :F
             devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)),libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasFillMode_t, Cint,
-                          Ptr{$elty}, Cint, Ptr{Cint}, Ptr{$elty}, Cint,
-                          Ptr{Cint}), dense_handle(), cuuplo, n, A,
+                          CuPtr{$elty}, Cint, CuPtr{Cint}, CuPtr{$elty}, Cint,
+                          CuPtr{Cint}), dense_handle(), cuuplo, n, A,
                          lda, devipiv, buffer, bufSize[], devinfo)
             info = _getindex(devinfo, 1)
             if info < 0
@@ -201,8 +201,8 @@ for (fname,elty) in ((:cusolverDnSgetrs, :Float32),
             devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasOperation_t, Cint, Cint,
-                          Ptr{$elty}, Cint, Ptr{Cint}, Ptr{$elty}, Cint,
-                          Ptr{Cint}), dense_handle(), cutrans, n, nrhs,
+                          CuPtr{$elty}, Cint, CuPtr{Cint}, CuPtr{$elty}, Cint,
+                          CuPtr{Cint}), dense_handle(), cutrans, n, nrhs,
                          A, lda, ipiv, B, ldb, devinfo)
             info = _getindex(devinfo, 1)
             if info < 0
@@ -245,8 +245,8 @@ for (bname, fname, elty) in ((:cusolverDnSormqr_bufferSize, :cusolverDnSormqr, :
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)),libcusolver), cusolverStatus_t,
                           (cusolverDnHandle_t, cublasSideMode_t,
-                           cublasOperation_t, Cint, Cint, Cint, Ptr{$elty},
-                           Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ref{Cint}),
+                           cublasOperation_t, Cint, Cint, Cint, CuPtr{$elty},
+                           Cint, CuPtr{$elty}, CuPtr{$elty}, Cint, Ptr{Cint}),
                           dense_handle(), cuside,
                           cutrans, m, n, k, A,
                           lda, tau, C, ldc, bufSize)
@@ -254,9 +254,9 @@ for (bname, fname, elty) in ((:cusolverDnSormqr_bufferSize, :cusolverDnSormqr, :
             devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)),libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cublasSideMode_t,
-                          cublasOperation_t, Cint, Cint, Cint, Ptr{$elty},
-                          Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{$elty},
-                          Cint, Ptr{Cint}),
+                          cublasOperation_t, Cint, Cint, Cint, CuPtr{$elty},
+                          Cint, CuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{$elty},
+                          Cint, CuPtr{Cint}),
                          dense_handle(), cuside,
                          cutrans, m, n, k, A, lda, tau, C, ldc, buffer,
                          bufSize[], devinfo)
@@ -282,14 +282,14 @@ for (bname, fname, elty) in ((:cusolverDnSorgqr_bufferSize, :cusolverDnSorgqr, :
             k = length(tau)
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
-                          (cusolverDnHandle_t, Cint, Cint, Cint, Ptr{$elty}, Cint,
-                           Ptr{$elty}, Ref{Cint}),
+                          (cusolverDnHandle_t, Cint, Cint, Cint, CuPtr{$elty}, Cint,
+                           CuPtr{$elty}, Ptr{Cint}),
                           dense_handle(), m, n, k, A, lda, tau, bufSize)
             buffer  = CuArray{$elty}(undef, bufSize[])
             devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
-                         (cusolverDnHandle_t, Cint, Cint, Cint, Ptr{$elty},
-                          Cint, Ptr{$elty}, Ptr{$elty}, Cint, Ptr{Cint}),
+                         (cusolverDnHandle_t, Cint, Cint, Cint, CuPtr{$elty},
+                          Cint, CuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{Cint}),
                          dense_handle(), m, n, k, A,
                          lda, tau, buffer, bufSize[], devinfo)
             info = _getindex(devinfo, 1)
@@ -316,7 +316,7 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgebrd_bufferSize, :cusolverDnSg
             lda     = max(1, stride(A, 2))
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
-                         (cusolverDnHandle_t, Cint, Cint, Ref{Cint}),
+                         (cusolverDnHandle_t, Cint, Cint, Ptr{Cint}),
                         dense_handle(), m, n, bufSize)
             buffer  = CuArray{$elty}(undef, bufSize[])
             devinfo = CuArray{Cint}(undef, 1)
@@ -326,9 +326,9 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgebrd_bufferSize, :cusolverDnSg
             TAUQ    = CuArray{$elty}(undef, k)
             TAUP    = CuArray{$elty}(undef, k)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
-                         (cusolverDnHandle_t, Cint, Cint, Ptr{$elty},
-                          Cint, Ptr{$relty}, Ptr{$relty}, Ptr{$elty},
-                          Ptr{$elty}, Ptr{$elty}, Cint, Ptr{Cint}),
+                         (cusolverDnHandle_t, Cint, Cint, CuPtr{$elty},
+                          Cint, CuPtr{$relty}, CuPtr{$relty}, CuPtr{$elty},
+                          CuPtr{$elty}, CuPtr{$elty}, Cint, CuPtr{Cint}),
                          dense_handle(), m, n, A, lda, D, E, TAUQ,
                          TAUP, buffer, bufSize[], devinfo)
             info = _getindex(devinfo, 1)
@@ -355,7 +355,7 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgesvd_bufferSize, :cusolverDnSg
             lda     = max(1, stride(A, 2))
             lwork   = Ref{Cint}(0)
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
-                         (cusolverDnHandle_t, Cint, Cint, Ref{Cint}),
+                         (cusolverDnHandle_t, Cint, Cint, Ptr{Cint}),
                         dense_handle(), m, n, lwork)
 
             work    = CuArray{$elty}(undef, lwork[])
@@ -384,9 +384,9 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgesvd_bufferSize, :cusolverDnSg
 
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, Cuchar, Cuchar, Cint,
-                          Cint, Ptr{$elty}, Cint, Ptr{$relty},
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint,
-                          Ptr{$elty}, Cint, Ptr{$relty}, Ptr{Cint}),
+                          Cint, CuPtr{$elty}, Cint, CuPtr{$relty},
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint,
+                          CuPtr{$elty}, Cint, CuPtr{$relty}, CuPtr{Cint}),
                           dense_handle(), jobu, jobvt, m,
                           n, A, lda, S,
                           U, ldu, Vt, ldvt,
@@ -441,9 +441,9 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgesvdj_bufferSize, :cusolverDnS
 
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint,
-                          Cint, Ptr{$elty}, Cint, Ptr{$relty},
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint,
-                          Ref{Cint}, gesvdjInfo_t),
+                          Cint, CuPtr{$elty}, Cint, CuPtr{$relty},
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint,
+                          Ptr{Cint}, gesvdjInfo_t),
                          dense_handle(), cujobz, Cint(econ), m,
                          n, A, lda, S,
                          U, ldu, V, ldv,
@@ -454,9 +454,9 @@ for (bname, fname, elty, relty) in ((:cusolverDnSgesvdj_bufferSize, :cusolverDnS
 
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cusolverEigMode_t, Cint, Cint,
-                          Cint, Ptr{$elty}, Cint, Ptr{$relty},
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint,
-                          Ptr{$elty}, Cint, Ptr{Cint}, gesvdjInfo_t),
+                          Cint, CuPtr{$elty}, Cint, CuPtr{$relty},
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint,
+                          CuPtr{$elty}, Cint, CuPtr{Cint}, gesvdjInfo_t),
                          dense_handle(), cujobz, econ, m,
                          n, A, lda, S,
                          U, ldu, V, ldv,
@@ -487,15 +487,15 @@ for (jname, bname, fname, elty, relty) in ((:syevd!, :cusolverDnSsyevd_bufferSiz
             bufSize = Ref{Cint}(0)
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t,
-                          Cint, Ptr{$elty}, Cint, Ptr{$relty}, Ref{Cint}),
+                          Cint, CuPtr{$elty}, Cint, CuPtr{$relty}, Ptr{Cint}),
                         dense_handle(), cujobz, cuuplo, n, A, lda, W, bufSize)
 
             buffer  = CuArray{$elty}(undef, bufSize[])
             devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cusolverEigMode_t, cublasFillMode_t,
-                          Cint, Ptr{$elty}, Cint, Ptr{$relty}, Ptr{$elty},
-                          Cint, Ptr{Cint}), dense_handle(), cujobz, cuuplo,
+                          Cint, CuPtr{$elty}, Cint, CuPtr{$relty}, CuPtr{$elty},
+                          Cint, CuPtr{Cint}), dense_handle(), cujobz, cuuplo,
                          n, A, lda, W, buffer, bufSize[], devinfo)
             info = _getindex(devinfo, 1)
             if info < 0
@@ -534,7 +534,7 @@ for (jname, bname, fname, elty, relty) in ((:sygvd!, :cusolverDnSsygvd_bufferSiz
             cuitype = cusolverEigType_t(itype)
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t, cublasFillMode_t,
-                          Cint, Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$relty}, Ref{Cint}),
+                          Cint, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, CuPtr{$relty}, Ptr{Cint}),
                          dense_handle(), cuitype, cujobz, cuuplo, n, A, lda, B, ldb, W, bufSize)
 
             buffer  = CuArray{$elty}(undef, bufSize[])
@@ -542,8 +542,8 @@ for (jname, bname, fname, elty, relty) in ((:sygvd!, :cusolverDnSsygvd_bufferSiz
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cusolverEigType_t,
                           cusolverEigMode_t, cublasFillMode_t, Cint,
-                          Ptr{$elty}, Cint, Ptr{$elty}, Cint, Ptr{$relty},
-                          Ptr{$elty}, Cint, Ptr{Cint}), dense_handle(), cuitype,
+                          CuPtr{$elty}, Cint, CuPtr{$elty}, Cint, CuPtr{$relty},
+                          CuPtr{$elty}, Cint, CuPtr{Cint}), dense_handle(), cuitype,
                          cujobz, cuuplo, n, A, lda, B, ldb, W, buffer,
                          bufSize[], devinfo)
             info = _getindex(devinfo, 1)
@@ -588,16 +588,16 @@ for (jname, bname, fname, elty, relty) in ((:sygvj!, :cusolverDnSsygvj_bufferSiz
             cusolverDnXsyevjSetMaxSweeps(params[], max_sweeps)
             @check ccall(($(string(bname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
-                          cublasFillMode_t, Cint, Ptr{$elty}, Cint, Ptr{$elty},
-                          Cint, Ptr{$relty}, Ref{Cint}, syevjInfo_t),
+                          cublasFillMode_t, Cint, CuPtr{$elty}, Cint, CuPtr{$elty},
+                          Cint, CuPtr{$relty}, Ptr{Cint}, syevjInfo_t),
                          dense_handle(), Cint(itype), cujobz, cuuplo, n, A, lda, B,
                          ldb, W, bufSize, params[])
             buffer  = CuArray{$elty}(undef, bufSize[])
             devinfo = CuArray{Cint}(undef, 1)
             @check ccall(($(string(fname)), libcusolver), cusolverStatus_t,
                          (cusolverDnHandle_t, cusolverEigType_t, cusolverEigMode_t,
-                          cublasFillMode_t, Cint, Ptr{$elty}, Cint, Ptr{$elty},
-                          Cint, Ptr{$relty}, Ptr{$elty}, Cint, Ptr{Cint},
+                          cublasFillMode_t, Cint, CuPtr{$elty}, Cint, CuPtr{$elty},
+                          Cint, CuPtr{$relty}, CuPtr{$elty}, Cint, CuPtr{Cint},
                           syevjInfo_t), dense_handle(), Cint(itype), cujobz,
                          cuuplo, n, A, lda, B, ldb, W, buffer, bufSize[],
                          devinfo, params[])

--- a/src/solver/libcusolver.jl
+++ b/src/solver/libcusolver.jl
@@ -1,4 +1,4 @@
-# Julia wrapper for header: /usr/local/cuda/include/cusolver.h
+# low-level wrappers of the CUSOLVER library
 
 #helper functions
 function cusolverDnCreate()
@@ -9,24 +9,28 @@ function cusolverDnCreate()
                handle)
   return handle[]
 end
+
 function cusolverDnDestroy(handle)
   @check ccall((:cusolverDnDestroy, libcusolver),
                cusolverStatus_t,
                (cusolverDnHandle_t,),
                handle)
 end
+
 function cusolverDnSetStream(handle, streamId)
   @check ccall((:cusolverDnSetStream, libcusolver),
                cusolverStatus_t,
                (cusolverDnHandle_t, CuStream_t),
                handle, streamId)
 end
+
 function cusolverDnGetStream(handle, streamId)
   @check ccall((:cusolverDnGetStream, libcusolver),
                cusolverStatus_t,
                (cusolverDnHandle_t, Ptr{CuStream_t}),
                handle, streamId)
 end
+
 function cusolverSpCreate()
   handle = Ref{cusolverSpHandle_t}()
   @check ccall((:cusolverSpCreate, libcusolver),
@@ -35,102 +39,119 @@ function cusolverSpCreate()
                handle)
   return handle[]
 end
+
 function cusolverSpDestroy(handle)
   @check ccall((:cusolverSpDestroy, libcusolver),
                cusolverStatus_t,
                (cusolverSpHandle_t,),
                handle)
 end
+
 function cusolverSpSetStream(handle, streamId)
   @check ccall((:cusolverSpSetStream, libcusolver),
                cusolverStatus_t,
                (cusolverSpHandle_t, CuStream_t),
                handle, streamId)
 end
+
 function cusolverSpGetStream(handle, streamId)
   @check ccall((:cusolverSpGetStream, libcusolver),
                cusolverStatus_t,
                (cusolverSpHandle_t, Ptr{CuStream_t}),
                handle, streamId)
 end
+
 function cusolverSpCreateCsrqrInfo(info)
   @check ccall((:cusolverSpCreateCsrqrInfo, libcusolver),
                cusolverStatus_t,
                (Ptr{csrqrInfo_t},),
                info)
 end
+
 function cusolverSpDestroyCsrqrInfo(info)
   @check ccall((:cusolverDestroyCsrqrInfo, libcusolver),
                cusolverStatus_t,
                (csrqrInfo_t,),
                info)
 end
+
 function cusolverDnCreateGesvdjInfo(info)
   @check ccall((:cusolverDnCreateGesvdjInfo, libcusolver),
                cusolverStatus_t,
                (Ptr{gesvdjInfo_t},),
                info)
 end
+
 function cusolverDnDestroyGesvdjInfo(info)
   @check ccall((:cusolverDnDestroyGesvdjInfo, libcusolver),
                cusolverStatus_t,
                (gesvdjInfo_t,),
                info)
 end
+
 function cusolverDnXgesvdjSetTolerance(info, tolerance)
   @check ccall((:cusolverDnXgesvdjSetTolerance, libcusolver),
                cusolverStatus_t,
                (gesvdjInfo_t, Float64),
                info, Float64(tolerance))
 end
+
 function cusolverDnXgesvdjSetMaxSweeps(info, max_sweeps)
   @check ccall((:cusolverDnXgesvdjSetMaxSweeps, libcusolver),
                cusolverStatus_t,
                (gesvdjInfo_t, Cint),
                info, Cint(max_sweeps))
 end
+
 function cusolverDnCreateSyevjInfo(info)
   @check ccall((:cusolverDnCreateSyevjInfo, libcusolver),
                cusolverStatus_t,
                (Ptr{syevjInfo_t},),
                info)
 end
+
 function cusolverDnDestroySyevjInfo(info)
   @check ccall((:cusolverDnDestroySyevjInfo, libcusolver),
                cusolverStatus_t,
                (syevjInfo_t,),
                info)
 end
+
 function cusolverDnXsyevjSetTolerance(info, tolerance)
   @check ccall((:cusolverDnXsyevjSetTolerance, libcusolver),
                cusolverStatus_t,
                (syevjInfo_t, Float64),
                info, Float64(tolerance))
 end
+
 function cusolverDnXsyevjSetMaxSweeps(info, max_sweeps)
   @check ccall((:cusolverDnXsyevjSetMaxSweeps, libcusolver),
                cusolverStatus_t,
                (syevjInfo_t, Cint),
                info, Cint(max_sweeps))
 end
+
 function cusolverRfCreate(handle)
   @check ccall((:cusolverRfCreate, libcusolver),
                cusolverStatus_t,
                (Ptr{cusolverRfHandle_t},),
                handle)
 end
+
 function cusolverRfDestroy(handle)
   @check ccall((:cusolverRfDestroy, libcusolver),
                cusolverStatus_t,
                (cusolverRfHandle_t,),
                handle)
 end
+
 function cusolverRfSetStream(handle, streamId)
   @check ccall((:cusolverRfSetStream, libcusolver),
                cusolverStatus_t,
                (cusolverRfHandle_t, CuStream_t),
                handle, streamId)
 end
+
 function cusolverRfGetStream(handle, streamId)
   @check ccall((:cusolverRfGetStream, libcusolver),
                cusolverStatus_t,

--- a/src/solver/sparse.jl
+++ b/src/solver/sparse.jl
@@ -1,3 +1,7 @@
+# wrappers of the low-level sparse CUSOLVER functionality
+#
+# TODO: move raw ccall wrappers to libcusolver.jl
+
 import ..CuArrays.CUSPARSE: cusparseindex, cusparseMatDescr_t, CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_FILL_MODE_UPPER, CUSPARSE_DIAG_TYPE_NON_UNIT, CUSPARSE_DIAG_TYPE_UNIT
 import LinearAlgebra: SingularException
 #csrlsvlu 

--- a/src/solver/sparse.jl
+++ b/src/solver/sparse.jl
@@ -73,8 +73,8 @@ for (fname, elty, relty) in ((:cusolverSpScsrlsvqr, :Float32, :Float32),
             singularity = Ref{Cint}(1)
             @check ccall(($(string(fname)),libcusolver), cusolverStatus_t,
                               (cusolverSpHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, Ptr{$elty}, $relty, Cint, Ptr{$elty},
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, CuPtr{$elty}, $relty, Cint, CuPtr{$elty},
                                Ptr{Cint}),
                               sparse_handle(), n, A.nnz, rcudesca, A.nzVal,
                               A.rowPtr, A.colVal, b, tol, reorder, x, singularity)
@@ -115,8 +115,8 @@ for (fname, elty, relty) in ((:cusolverSpScsrlsvchol, :Float32, :Float32),
             singularity = zeros(Cint,1)
             @check ccall(($(string(fname)),libcusolver), cusolverStatus_t,
                               (cusolverSpHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, Ptr{$elty}, $relty, Cint, Ptr{$elty},
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, CuPtr{$elty}, $relty, Cint, CuPtr{$elty},
                                Ptr{Cint}),
                               sparse_handle(), n, A.nnz, rcudesca, A.nzVal,
                               A.rowPtr, A.colVal, b, tol, reorder, x, singularity)
@@ -197,9 +197,9 @@ for (fname, elty, relty) in ((:cusolverSpScsreigvsi, :Float32, :Float32),
             μ       = cuzeros($elty,1)
             @check ccall(($(string(fname)),libcusolver), cusolverStatus_t,
                               (cusolverSpHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, $elty, Ptr{$elty}, Cint,
-                               $relty, Ptr{$elty}, Ptr{$elty}),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, $elty, CuPtr{$elty}, Cint,
+                               $relty, CuPtr{$elty}, CuPtr{$elty}),
                               sparse_handle(), n, A.nnz, rcudesca, A.nzVal,
                               A.rowPtr, A.colVal, μ_0, x_0, maxite, tol, μ, x)
             collect(μ)[1], x

--- a/src/sparse/CUSPARSE.jl
+++ b/src/sparse/CUSPARSE.jl
@@ -1,6 +1,6 @@
 module CUSPARSE
 
-import CUDAdrv: CUDAdrv, CuContext, CuStream_t
+import CUDAdrv: CUDAdrv, CuContext, CuStream_t, CuPtr, PtrOrCuPtr, CU_NULL
 import CUDAapi
 
 using ..CuArrays

--- a/src/sparse/libcusparse.jl
+++ b/src/sparse/libcusparse.jl
@@ -1,4 +1,4 @@
-# Julia wrapper for header: /usr/local/cuda/include/cusparse.h
+# low-level wrappers of the CUSPARSE library
 
 #helper functions
 function cusparseCreate()
@@ -6,75 +6,99 @@ function cusparseCreate()
   @check ccall( (:cusparseCreate, libcusparse), cusparseStatus_t, (Ptr{cusparseHandle_t},), handle)
   handle[]
 end
+
 function cusparseDestroy(handle)
   @check ccall( (:cusparseDestroy, libcusparse), cusparseStatus_t, (cusparseHandle_t,), handle)
 end
+
 function cusparseGetVersion(handle, version)
   @check ccall( (:cusparseGetVersion, libcusparse), cusparseStatus_t, (cusparseHandle_t, Ptr{Cint}), handle, version)
 end
+
 function cusparseSetStream(handle, streamId)
   @check ccall( (:cusparseSetStream, libcusparse), cusparseStatus_t, (cusparseHandle_t, CuStream_t), handle, streamId)
 end
+
 function cusparseGetStream(handle, streamId)
   @check ccall( (:cusparseGetStream, libcusparse), cusparseStatus_t, (cusparseHandle_t, Ptr{CuStream_t}), handle, streamId)
 end
+
 function cusparseGetPointerMode(handle, mode)
   @check ccall( (:cusparseGetPointerMode, libcusparse), cusparseStatus_t, (cusparseHandle_t, Ptr{cusparsePointerMode_t}), handle, mode)
 end
+
 function cusparseSetPointerMode(handle, mode)
   @check ccall( (:cusparseSetPointerMode, libcusparse), cusparseStatus_t, (cusparseHandle_t, cusparsePointerMode_t), handle, mode)
 end
+
 function cusparseCreateHybMat(hybA)
   @check ccall( (:cusparseCreateHybMat, libcusparse), cusparseStatus_t, (Ptr{cusparseHybMat_t},), hybA)
 end
+
 function cusparseDestroyHybMat(hybA)
   @check ccall( (:cusparseDestroyHybMat, libcusparse), cusparseStatus_t, (cusparseHybMat_t,), hybA)
 end
+
 function cusparseCreateSolveAnalysisInfo(info)
   @check ccall( (:cusparseCreateSolveAnalysisInfo, libcusparse), cusparseStatus_t, (Ptr{cusparseSolveAnalysisInfo_t},), info)
 end
+
 function cusparseDestroySolveAnalysisInfo(info)
   @check ccall( (:cusparseDestroySolveAnalysisInfo, libcusparse), cusparseStatus_t, (cusparseSolveAnalysisInfo_t,), info)
 end
+
 function cusparseCreateBsrsm2Info(info)
   @check ccall( (:cusparseCreateBsrsm2Info, libcusparse), cusparseStatus_t, (Ptr{bsrsm2Info_t},), info)
 end
+
 function cusparseDestroyBsrsm2Info(info)
   @check ccall( (:cusparseDestroyBsrsm2Info, libcusparse), cusparseStatus_t, (bsrsm2Info_t,), info)
 end
+
 function cusparseCreateBsrsv2Info(info)
   @check ccall( (:cusparseCreateBsrsv2Info, libcusparse), cusparseStatus_t, (Ptr{bsrsv2Info_t},), info)
 end
+
 function cusparseDestroyBsrsv2Info(info)
   @check ccall( (:cusparseDestroyBsrsv2Info, libcusparse), cusparseStatus_t, (bsrsv2Info_t,), info)
 end
+
 function cusparseCreateCsrsv2Info(info)
   @check ccall( (:cusparseCreateCsrsv2Info, libcusparse), cusparseStatus_t, (Ptr{csrsv2Info_t},), info)
 end
+
 function cusparseDestroyCsrsv2Info(info)
   @check ccall( (:cusparseDestroyCsrsv2Info, libcusparse), cusparseStatus_t, (csrsv2Info_t,), info)
 end
+
 function cusparseCreateCsric02Info(info)
   @check ccall( (:cusparseCreateCsric02Info, libcusparse), cusparseStatus_t, (Ptr{csric02Info_t},), info)
 end
+
 function cusparseDestroyCsric02Info(info)
   @check ccall( (:cusparseDestroyCsric02Info, libcusparse), cusparseStatus_t, (csric02Info_t,), info)
 end
+
 function cusparseCreateCsrilu02Info(info)
   @check ccall( (:cusparseCreateCsrilu02Info, libcusparse), cusparseStatus_t, (Ptr{csrilu02Info_t},), info)
 end
+
 function cusparseDestroyCsrilu02Info(info)
   @check ccall( (:cusparseDestroyCsrilu02Info, libcusparse), cusparseStatus_t, (csrilu02Info_t,), info)
 end
+
 function cusparseCreateBsric02Info(info)
   @check ccall( (:cusparseCreateBsric02Info, libcusparse), cusparseStatus_t, (Ptr{bsric02Info_t},), info)
 end
+
 function cusparseDestroyBsric02Info(info)
   @check ccall( (:cusparseDestroyBsric02Info, libcusparse), cusparseStatus_t, (bsric02Info_t,), info)
 end
+
 function cusparseCreateBsrilu02Info(info)
   @check ccall( (:cusparseCreateBsrilu02Info, libcusparse), cusparseStatus_t, (Ptr{bsrilu02Info_t},), info)
 end
+
 function cusparseDestroyBsrilu02Info(info)
   @check ccall( (:cusparseDestroyBsrilu02Info, libcusparse), cusparseStatus_t, (bsrilu02Info_t,), info)
 end

--- a/src/sparse/util.jl
+++ b/src/sparse/util.jl
@@ -151,9 +151,9 @@ for (fname,elty) in ((:cusparseScsr2csc, :Float32),
             rowVal = cuzeros(Cint, csr.nnz)
             nzVal = cuzeros($elty, csr.nnz)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
-                              (cusparseHandle_t, Cint, Cint, Cint, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, cusparseAction_t, cusparseIndexBase_t),
+                              (cusparseHandle_t, Cint, Cint, Cint, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, cusparseAction_t, cusparseIndexBase_t),
                                handle(), m, n, csr.nnz, csr.nzVal,
                                csr.rowPtr, csr.colVal, nzVal, rowVal,
                                colPtr, CUSPARSE_ACTION_NUMERIC, cuind)
@@ -167,9 +167,9 @@ for (fname,elty) in ((:cusparseScsr2csc, :Float32),
             colVal = cuzeros(Cint,csc.nnz)
             nzVal = cuzeros($elty,csc.nnz)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
-                              (cusparseHandle_t, Cint, Cint, Cint, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, cusparseAction_t, cusparseIndexBase_t),
+                              (cusparseHandle_t, Cint, Cint, Cint, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, cusparseAction_t, cusparseIndexBase_t),
                                handle(), n, m, csc.nnz, csc.nzVal,
                                csc.colPtr, csc.rowVal, nzVal, colVal,
                                rowPtr, CUSPARSE_ACTION_NUMERIC, cuind)
@@ -201,19 +201,19 @@ for (fname,elty) in ((:cusparseScsr2bsr, :Float32),
             cudescc = cusparseMatDescr_t(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, cuindc)
             @check ccall((:cusparseXcsr2bsrNnz,libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{Cint},
-                               Ptr{Cint}, Cint, Ptr{cusparseMatDescr_t},
-                               Ptr{Cint}, Ptr{Cint}),
+                               Ptr{cusparseMatDescr_t}, CuPtr{Cint},
+                               CuPtr{Cint}, Cint, Ptr{cusparseMatDescr_t},
+                               CuPtr{Cint}, Ptr{Cint}),
                               handle(), cudir, m, n, Ref(cudesca), csr.rowPtr,
                               csr.colVal, blockDim, Ref(cudescc), bsrRowPtr, nnz)
             bsrNzVal = cuzeros($elty, nnz[] * blockDim * blockDim )
             bsrColInd = cuzeros(Cint, nnz[])
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t, Cint,
-                               Cint, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}), handle(), cudir, m, n,
+                               Cint, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Cint,
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}), handle(), cudir, m, n,
                                Ref(cudesca), csr.nzVal, csr.rowPtr, csr.colVal,
                                blockDim, Ref(cudescc), bsrNzVal, bsrRowPtr,
                                bsrColInd)
@@ -251,10 +251,10 @@ for (fname,elty) in ((:cusparseSbsr2csr, :Float32),
             csrNzVal  = cuzeros($elty, nnz)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t, Cint,
-                               Cint, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}), handle(), cudir, mb, nb,
+                               Cint, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Cint,
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}), handle(), cudir, mb, nb,
                                Ref(cudesca), bsr.nzVal, bsr.rowPtr, bsr.colVal,
                                bsr.blockDim, Ref(cudescc), csrNzVal, csrRowPtr,
                                csrColInd)
@@ -281,8 +281,8 @@ for (cname,rname,elty) in ((:cusparseScsc2dense, :cusparseScsr2dense, :Float32),
             cudesc = cusparseMatDescr_t(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, cuind)
             @check ccall(($(string(rname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{$elty}, Cint),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, CuPtr{$elty}, Cint),
                                handle(), m, n, Ref(cudesc), csr.nzVal,
                                csr.rowPtr, csr.colVal, denseA, lda)
             denseA
@@ -295,8 +295,8 @@ for (cname,rname,elty) in ((:cusparseScsc2dense, :cusparseScsr2dense, :Float32),
             cudesc = cusparseMatDescr_t(CUSPARSE_MATRIX_TYPE_GENERAL, CUSPARSE_FILL_MODE_LOWER, CUSPARSE_DIAG_TYPE_NON_UNIT, cuind)
             @check ccall(($(string(cname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{$elty}, Cint),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, CuPtr{$elty}, Cint),
                                handle(), m, n, Ref(cudesc), csc.nzVal,
                                csc.rowVal, csc.colPtr, denseA, lda)
             denseA
@@ -328,8 +328,8 @@ for (nname,cname,rname,hname,elty) in ((:cusparseSnnz, :cusparseSdense2csc, :cus
             nnzTotal = Ref{Cint}(1)
             @check ccall(($(string(nname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t,
-                               Cint, Cint, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Cint, Ptr{Cint}, Ptr{Cint}), handle(),
+                               Cint, Cint, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               Cint, CuPtr{Cint}, Ptr{Cint}), handle(),
                                cudir, m, n, Ref(cudesc), A, lda, nnzRowCol,
                                nnzTotal)
             nzVal = cuzeros($elty,nnzTotal[])
@@ -338,9 +338,9 @@ for (nname,cname,rname,hname,elty) in ((:cusparseSnnz, :cusparseSdense2csc, :cus
                 colInd = cuzeros(Cint,nnzTotal[])
                 @check ccall(($(string(rname)),libcusparse), cusparseStatus_t,
                                   (cusparseHandle_t, Cint, Cint,
-                                   Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                                   Cint, Ptr{Cint}, Ptr{$elty}, Ptr{Cint},
-                                   Ptr{Cint}), handle(), m, n, Ref(cudesc), A,
+                                   Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                                   Cint, CuPtr{Cint}, CuPtr{$elty}, CuPtr{Cint},
+                                   CuPtr{Cint}), handle(), m, n, Ref(cudesc), A,
                                    lda, nnzRowCol, nzVal, rowPtr, colInd)
                 return CuSparseMatrixCSR(rowPtr,colInd,nzVal,nnzTotal[],size(A))
             end
@@ -349,9 +349,9 @@ for (nname,cname,rname,hname,elty) in ((:cusparseSnnz, :cusparseSdense2csc, :cus
                 rowInd = cuzeros(Cint,nnzTotal[])
                 @check ccall(($(string(cname)),libcusparse), cusparseStatus_t,
                                   (cusparseHandle_t, Cint, Cint,
-                                   Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                                   Cint, Ptr{Cint}, Ptr{$elty}, Ptr{Cint},
-                                   Ptr{Cint}), handle(), m, n, Ref(cudesc), A,
+                                   Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                                   Cint, CuPtr{Cint}, CuPtr{$elty}, CuPtr{Cint},
+                                   CuPtr{Cint}), handle(), m, n, Ref(cudesc), A,
                                    lda, nnzRowCol, nzVal, rowInd, colPtr)
                 return CuSparseMatrixCSC(colPtr,rowInd,nzVal,nnzTotal[],size(A))
             end
@@ -364,8 +364,8 @@ for (nname,cname,rname,hname,elty) in ((:cusparseSnnz, :cusparseSdense2csc, :cus
                                   (Ptr{cusparseHybMat_t},), hyb)
                 @check ccall(($(string(hname)),libcusparse), cusparseStatus_t,
                                   (cusparseHandle_t, Cint, Cint,
-                                   Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                                   Cint, Ptr{Cint}, cusparseHybMat_t,
+                                   Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                                   Cint, CuPtr{Cint}, cusparseHybMat_t,
                                    Cint, cusparseHybPartition_t),
                                   handle(), m, n, Ref(cudesc), A, lda, nnzRowCol,
                                   hyb[1], 0, CUSPARSE_HYB_PARTITION_AUTO)
@@ -404,8 +404,8 @@ for (rname,cname,elty) in ((:cusparseScsr2hyb, :cusparseScsc2hyb, :Float32),
                               (Ptr{cusparseHybMat_t},), hyb)
             @check ccall(($(string(rname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, cusparseHybMat_t,
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, cusparseHybMat_t,
                                Cint, cusparseHybPartition_t), handle(),
                                m, n, Ref(cudesca), csr.nzVal, csr.rowPtr, csr.colVal,
                                hyb[1], 0, CUSPARSE_HYB_PARTITION_AUTO)
@@ -433,8 +433,8 @@ for (rname,cname,elty) in ((:cusparseShyb2csr, :cusparseShyb2csc, :Float32),
             csrNzVal = cuzeros($elty, hyb.nnz)
             @check ccall(($(string(rname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Ptr{cusparseMatDescr_t},
-                               cusparseHybMat_t, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}), handle(), Ref(cudesca),
+                               cusparseHybMat_t, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}), handle(), Ref(cudesca),
                                hyb.Mat, csrNzVal, csrRowPtr, csrColInd)
             CuSparseMatrixCSR(csrRowPtr, csrColInd, csrNzVal, hyb.nnz, hyb.dims)
         end

--- a/src/sparse/util.jl
+++ b/src/sparse/util.jl
@@ -1,3 +1,7 @@
+# utility functions for the CUSPARSE wrappers
+#
+# TODO: move raw ccall wrappers to libcusparse.jl
+
 """
 convert `SparseChar` {`N`,`T`,`C`} to `cusparseOperation_t`
 """

--- a/src/sparse/wrappers.jl
+++ b/src/sparse/wrappers.jl
@@ -31,8 +31,8 @@ for (fname,elty) in ((:cusparseSaxpyi, :Float32),
                         index::SparseChar)
             cuind = cusparseindex(index)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
-                              (cusparseHandle_t, Cint, Ptr{$elty}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{$elty}, cusparseIndexBase_t),
+                              (cusparseHandle_t, Cint, Ptr{$elty}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{$elty}, cusparseIndexBase_t),
                               handle(), X.nnz, [alpha], X.nzVal, X.iPtr,
                               Y, cuind)
             Y
@@ -77,8 +77,8 @@ for (jname,fname,elty) in ((:doti, :cusparseSdoti, :Float32),
             dot = Ref{$elty}(1)
             cuind = cusparseindex(index)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
-                              (cusparseHandle_t, Cint, Ptr{$elty}, Ptr{Cint},
-                               Ptr{$elty}, Ptr{$elty}, cusparseIndexBase_t),
+                              (cusparseHandle_t, Cint, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{$elty}, Ptr{$elty}, cusparseIndexBase_t),
                               handle(), X.nnz, X.nzVal, X.iPtr,
                               Y, dot, cuind)
             return dot[]
@@ -102,8 +102,8 @@ for (fname,elty) in ((:cusparseSgthr, :Float32),
                        index::SparseChar)
             cuind = cusparseindex(index)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
-                              (cusparseHandle_t, Cint, Ptr{$elty}, Ptr{$elty},
-                               Ptr{Cint}, cusparseIndexBase_t), handle(),
+                              (cusparseHandle_t, Cint, CuPtr{$elty}, CuPtr{$elty},
+                               CuPtr{Cint}, cusparseIndexBase_t), handle(),
                               X.nnz, Y, X.nzVal, X.iPtr, cuind)
             X
         end
@@ -131,8 +131,8 @@ for (fname,elty) in ((:cusparseSgthrz, :Float32),
                         index::SparseChar)
             cuind = cusparseindex(index)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
-                              (cusparseHandle_t, Cint, Ptr{$elty}, Ptr{$elty},
-                               Ptr{Cint}, cusparseIndexBase_t), handle(),
+                              (cusparseHandle_t, Cint, CuPtr{$elty}, CuPtr{$elty},
+                               CuPtr{Cint}, cusparseIndexBase_t), handle(),
                               X.nnz, Y, X.nzVal, X.iPtr, cuind)
             X,Y
         end
@@ -160,8 +160,8 @@ for (fname,elty) in ((:cusparseSroti, :Float32),
                        index::SparseChar)
             cuind = cusparseindex(index)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
-                              (cusparseHandle_t, Cint, Ptr{$elty}, Ptr{$Cint},
-                               Ptr{$elty}, Ptr{$elty}, Ptr{$elty}, cusparseIndexBase_t),
+                              (cusparseHandle_t, Cint, CuPtr{$elty}, CuPtr{$Cint},
+                               CuPtr{$elty}, Ptr{$elty}, Ptr{$elty}, cusparseIndexBase_t),
                               handle(), X.nnz, X.nzVal, X.iPtr, Y, [c], [s], cuind)
             X,Y
         end
@@ -192,8 +192,8 @@ for (fname,elty) in ((:cusparseSsctr, :Float32),
                        index::SparseChar)
             cuind = cusparseindex(index)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
-                              (cusparseHandle_t, Cint, Ptr{$elty}, Ptr{Cint},
-                               Ptr{$elty}, cusparseIndexBase_t),
+                              (cusparseHandle_t, Cint, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{$elty}, cusparseIndexBase_t),
                               handle(), X.nnz, X.nzVal, X.iPtr,
                               Y, cuind)
             Y
@@ -244,8 +244,8 @@ for (fname,elty) in ((:cusparseSbsrmv, :Float32),
                               (cusparseHandle_t, cusparseDirection_t,
                                cusparseOperation_t, Cint, Cint, Cint,
                                Ptr{$elty}, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}, Cint,
-                               Ptr{$elty}, Ptr{$elty}, Ptr{$elty}),
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}, Cint,
+                               CuPtr{$elty}, Ptr{$elty}, CuPtr{$elty}),
                               handle(), cudir, cutransa, mb, nb,
                               A.nnz, [alpha], Ref(cudesc), A.nzVal, A.rowPtr,
                               A.colVal, A.blockDim, X, [beta], Y)
@@ -282,8 +282,8 @@ for (fname,elty) in ((:cusparseScsrmv, :Float32),
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
                                Cint, Cint, Ptr{$elty}, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}, Ptr{$elty},
-                               Ptr{$elty}, Ptr{$elty}), handle(),
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}, CuPtr{$elty},
+                               Ptr{$elty}, CuPtr{$elty}), handle(),
                                cutransa, m, n, Mat.nnz, [alpha], Ref(cudesc), Mat.nzVal,
                                Mat.rowPtr, Mat.colVal, X, [beta], Y)
             Y
@@ -316,8 +316,8 @@ for (fname,elty) in ((:cusparseScsrmv, :Float32),
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
                                Cint, Cint, Ptr{$elty}, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}, Ptr{$elty},
-                               Ptr{$elty}, Ptr{$elty}), handle(),
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}, CuPtr{$elty},
+                               Ptr{$elty}, CuPtr{$elty}), handle(),
                                cutransa, m, n, Mat.nnz, [alpha], Ref(cudesc),
                                Mat.nzVal, Mat.colPtr, Mat.rowVal, X, [beta], Y)
             Y
@@ -365,8 +365,8 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsv2_bufferSize, :cusparseSbsrsv2_
             @check ccall(($(string(bname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t,
                                cusparseOperation_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, Cint, bsrsv2Info_t, Ptr{Cint}),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, Cint, bsrsv2Info_t, Ptr{Cint}),
                               handle(), cudir, cutransa, mb, A.nnz,
                               Ref(cudesc), A.nzVal, A.rowPtr, A.colVal,
                               A.blockDim, info[1], bufSize)
@@ -374,9 +374,9 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsv2_bufferSize, :cusparseSbsrsv2_
             @check ccall(($(string(aname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t,
                                cusparseOperation_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, Cint, bsrsv2Info_t,
-                               cusparseSolvePolicy_t, Ptr{Cvoid}),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, Cint, bsrsv2Info_t,
+                               cusparseSolvePolicy_t, CuPtr{Cvoid}),
                               handle(), cudir, cutransa, mb, A.nnz,
                               Ref(cudesc), A.nzVal, A.rowPtr, A.colVal, A.blockDim,
                               info[1], CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
@@ -390,9 +390,9 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsv2_bufferSize, :cusparseSbsrsv2_
             @check ccall(($(string(sname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t,
                                cusparseOperation_t, Cint, Cint, Ptr{$elty},
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, Cint, bsrsv2Info_t, Ptr{$elty},
-                               Ptr{$elty}, cusparseSolvePolicy_t, Ptr{Cvoid}),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, Cint, bsrsv2Info_t, CuPtr{$elty},
+                               CuPtr{$elty}, cusparseSolvePolicy_t, CuPtr{Cvoid}),
                               handle(), cudir, cutransa, mb, A.nnz,
                               [alpha], Ref(cudesc), A.nzVal, A.rowPtr, A.colVal,
                               A.blockDim, info[1], X, X,
@@ -477,7 +477,7 @@ for (fname,elty) in ((:cusparseScsrsv_analysis, :Float32),
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
                                Cint, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint},
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint},
                                cusparseSolveAnalysisInfo_t), handle(),
                                cutransa, m, A.nnz, Ref(cudesc), A.nzVal,
                                A.rowPtr, A.colVal, info[1])
@@ -518,7 +518,7 @@ for (fname,elty) in ((:cusparseScsrsv_analysis, :Float32),
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
                                Cint, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint},
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint},
                                cusparseSolveAnalysisInfo_t), handle(),
                                cutransa, m, A.nnz, Ref(cudesc), A.nzVal,
                                A.colPtr, A.rowVal, info[1])
@@ -558,9 +558,9 @@ for (fname,elty) in ((:cusparseScsrsv_solve, :Float32),
             end
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
-                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, cusparseSolveAnalysisInfo_t,
-                               Ptr{$elty}, Ptr{$elty}), handle(),
+                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, cusparseSolveAnalysisInfo_t,
+                               CuPtr{$elty}, CuPtr{$elty}), handle(),
                                cutransa, m, [alpha], Ref(cudesc), A.nzVal,
                                A.rowPtr, A.colVal, info, X, Y)
             Y
@@ -600,9 +600,9 @@ for (fname,elty) in ((:cusparseScsrsv_solve, :Float32),
             end
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
-                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, cusparseSolveAnalysisInfo_t,
-                               Ptr{$elty}, Ptr{$elty}), handle(),
+                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, cusparseSolveAnalysisInfo_t,
+                               CuPtr{$elty}, CuPtr{$elty}), handle(),
                                cutransa, m, [alpha], Ref(cudesc), A.nzVal,
                                A.colPtr, A.rowVal, info, X, Y)
             Y
@@ -639,17 +639,17 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsv2_bufferSize, :cusparseScsrsv2_
             bufSize = Ref{Cint}(1)
             @check ccall(($(string(bname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csrsv2Info_t, Ptr{Cint}),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csrsv2Info_t, Ptr{Cint}),
                               handle(), cutransa, m, A.nnz,
                               Ref(cudesc), A.nzVal, A.rowPtr, A.colVal,
                               info[1], bufSize)
             buffer = cuzeros(UInt8, bufSize[])
             @check ccall(($(string(aname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csrsv2Info_t, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), cutransa, m, A.nnz,
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csrsv2Info_t, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), cutransa, m, A.nnz,
                                Ref(cudesc), A.nzVal, A.rowPtr, A.colVal, info[1],
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             posit = Ref{Cint}(1)
@@ -662,9 +662,9 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsv2_bufferSize, :cusparseScsrsv2_
             @check ccall(($(string(sname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
                                Cint, Ptr{$elty}, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}, csrsv2Info_t,
-                               Ptr{$elty}, Ptr{$elty}, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), cutransa, m,
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t,
+                               CuPtr{$elty}, CuPtr{$elty}, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), cutransa, m,
                                A.nnz, [alpha], Ref(cudesc), A.nzVal, A.rowPtr,
                                A.colVal, info[1], X, X,
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
@@ -711,17 +711,17 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsv2_bufferSize, :cusparseScsrsv2_
             bufSize = Ref{Cint}(1)
             @check ccall(($(string(bname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csrsv2Info_t, Ptr{Cint}),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csrsv2Info_t, Ptr{Cint}),
                               handle(), cutransa, m, A.nnz,
                               Ref(cudesc), A.nzVal, A.colPtr, A.rowVal,
                               info[1], bufSize)
             buffer = cuzeros(UInt8, bufSize[])
             @check ccall(($(string(aname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csrsv2Info_t, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), cutransa, m, A.nnz,
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csrsv2Info_t, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), cutransa, m, A.nnz,
                                Ref(cudesc), A.nzVal, A.colPtr, A.rowVal, info[1],
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             posit = Ref{Cint}(1)
@@ -734,9 +734,9 @@ for (bname,aname,sname,elty) in ((:cusparseScsrsv2_bufferSize, :cusparseScsrsv2_
             @check ccall(($(string(sname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
                                Cint, Ptr{$elty}, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}, csrsv2Info_t,
-                               Ptr{$elty}, Ptr{$elty}, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), cutransa, m,
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}, csrsv2Info_t,
+                               CuPtr{$elty}, CuPtr{$elty}, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), cutransa, m,
                                A.nnz, [alpha], Ref(cudesc), A.nzVal, A.colPtr,
                                A.rowVal, info[1], X, X,
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
@@ -771,8 +771,8 @@ for (fname,elty) in ((:cusparseShybmv, :Float32),
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t,
                                Ptr{$elty}, Ptr{cusparseMatDescr_t},
-                               cusparseHybMat_t, Ptr{$elty},
-                               Ptr{$elty}, Ptr{$elty}), handle(),
+                               cusparseHybMat_t, CuPtr{$elty},
+                               Ptr{$elty}, CuPtr{$elty}), handle(),
                                cutransa, [alpha], Ref(cudesc), A.Mat, X, [beta], Y)
             Y
         end
@@ -885,7 +885,7 @@ for (fname,elty) in ((:cusparseShybsv_solve, :Float32),
                               (cusparseHandle_t, cusparseOperation_t,
                                Ptr{$elty}, Ptr{cusparseMatDescr_t},
                                cusparseHybMat_t, cusparseSolveAnalysisInfo_t,
-                               Ptr{$elty}, Ptr{$elty}), handle(),
+                               CuPtr{$elty}, CuPtr{$elty}), handle(),
                                cutransa, [alpha], Ref(cudesc), A.Mat, info, X, Y)
             Y
         end
@@ -999,9 +999,9 @@ for (fname,elty) in ((:cusparseSbsrmm, :Float32),
                               (cusparseHandle_t, cusparseDirection_t,
                                cusparseOperation_t, cusparseOperation_t, Cint,
                                Cint, Cint, Cint, Ptr{$elty},
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, Cint, Ptr{$elty}, Cint, Ptr{$elty},
-                               Ptr{$elty}, Cint), handle(), cudir,
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, Cint, CuPtr{$elty}, Cint, Ptr{$elty},
+                               CuPtr{$elty}, Cint), handle(), cudir,
                                cutransa, cutransb, mb, n, kb, A.nnz,
                                [alpha], Ref(cudesc), A.nzVal,A.rowPtr, A.colVal,
                                A.blockDim, B, ldb, [beta], C, ldc)
@@ -1049,8 +1049,8 @@ for (fname,elty) in ((:cusparseScsrmm, :Float32),
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint, Cint,
                                Cint, Cint, Ptr{$elty}, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}, Ptr{$elty},
-                               Cint, Ptr{$elty}, Ptr{$elty}, Cint),
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}, CuPtr{$elty},
+                               Cint, Ptr{$elty}, CuPtr{$elty}, Cint),
                                handle(), cutransa, m, n, k, Mat.nnz,
                                [alpha], Ref(cudesc), Mat.nzVal, Mat.rowPtr,
                                Mat.colVal, B, ldb, [beta], C, ldc)
@@ -1086,8 +1086,8 @@ for (fname,elty) in ((:cusparseScsrmm, :Float32),
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint, Cint,
                                Cint, Cint, Ptr{$elty}, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}, Ptr{$elty},
-                               Cint, Ptr{$elty}, Ptr{$elty}, Cint),
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}, CuPtr{$elty},
+                               Cint, Ptr{$elty}, CuPtr{$elty}, Cint),
                                handle(), cutransa, m, n, k, Mat.nnz,
                                [alpha], Ref(cudesc), Mat.nzVal, Mat.colPtr,
                                Mat.rowVal, B, ldb, [beta], C, ldc)
@@ -1180,9 +1180,9 @@ for (fname,elty) in ((:cusparseScsrmm2, :Float32),
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t,
                                cusparseOperation_t, Cint, Cint, Cint, Cint,
-                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{$elty}, Cint,
-                               Ptr{$elty}, Ptr{$elty}, Cint), handle(),
+                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, CuPtr{$elty}, Cint,
+                               Ptr{$elty}, CuPtr{$elty}, Cint), handle(),
                                cutransa, cutransb, m, n, k, A.nnz, [alpha], Ref(cudesc),
                                A.nzVal, A.rowPtr, A.colVal, B, ldb, [beta], C, ldc)
             C
@@ -1219,9 +1219,9 @@ for (fname,elty) in ((:cusparseScsrmm2, :Float32),
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t,
                                cusparseOperation_t, Cint, Cint, Cint, Cint,
-                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{$elty}, Cint,
-                               Ptr{$elty}, Ptr{$elty}, Cint), handle(),
+                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, CuPtr{$elty}, Cint,
+                               Ptr{$elty}, CuPtr{$elty}, Cint), handle(),
                                cutransa, cutransb, m, n, k, A.nnz, [alpha], Ref(cudesc),
                                A.nzVal, A.colPtr, A.rowVal, B, ldb, [beta], C, ldc)
             C
@@ -1310,8 +1310,8 @@ for (fname,elty) in ((:cusparseScsrsm_analysis, :Float32),
             cusparseCreateSolveAnalysisInfo(info)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
-                               Cint, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, cusparseSolveAnalysisInfo_t),
+                               Cint, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, cusparseSolveAnalysisInfo_t),
                               handle(), cutransa, m, A.nnz, Ref(cudesc),
                               A.nzVal, A.rowPtr, A.colVal, info[1])
             info[1]
@@ -1340,8 +1340,8 @@ for (fname,elty) in ((:cusparseScsrsm_analysis, :Float32),
             cusparseCreateSolveAnalysisInfo(info)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
-                               Cint, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, cusparseSolveAnalysisInfo_t),
+                               Cint, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, cusparseSolveAnalysisInfo_t),
                               handle(), cutransa, m, A.nnz, Ref(cudesc),
                               A.nzVal, A.colPtr, A.rowVal, info[1])
             info[1]
@@ -1385,9 +1385,9 @@ for (fname,elty) in ((:cusparseScsrsm_solve, :Float32),
             ldy = max(1,stride(Y,2))
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint, Cint,
-                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, cusparseSolveAnalysisInfo_t,
-                               Ptr{$elty}, Cint, Ptr{$elty}, Cint),
+                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, cusparseSolveAnalysisInfo_t,
+                               CuPtr{$elty}, Cint, CuPtr{$elty}, Cint),
                               handle(), cutransa, m, n, [alpha],
                               Ref(cudesc), A.nzVal, A.rowPtr, A.colVal, info, X, ldx,
                               Y, ldy)
@@ -1422,9 +1422,9 @@ for (fname,elty) in ((:cusparseScsrsm_solve, :Float32),
             ldy = max(1,stride(Y,2))
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint, Cint,
-                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, cusparseSolveAnalysisInfo_t,
-                               Ptr{$elty}, Cint, Ptr{$elty}, Cint),
+                               Ptr{$elty}, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, cusparseSolveAnalysisInfo_t,
+                               CuPtr{$elty}, Cint, CuPtr{$elty}, Cint),
                               handle(), cutransa, m, n, [alpha],
                               Ref(cudesc), A.nzVal, A.colPtr, A.rowVal, info, X, ldx,
                               Y, ldy)
@@ -1524,7 +1524,7 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsm2_bufferSize, :cusparseSbsrsm2_
                               (cusparseHandle_t, cusparseDirection_t,
                                cusparseOperation_t, cusparseOperation_t, Cint,
                                Cint, Cint, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}, Cint,
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}, Cint,
                                bsrsm2Info_t, Ptr{Cint}), handle(),
                                cudir, cutransa, cutransxy, mb, nX, A.nnz,
                                Ref(cudesc), A.nzVal, A.rowPtr, A.colVal,
@@ -1534,8 +1534,8 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsm2_bufferSize, :cusparseSbsrsm2_
                               (cusparseHandle_t, cusparseDirection_t,
                                cusparseOperation_t, cusparseOperation_t, Cint,
                                Cint, Cint, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}, Cint,
-                               bsrsm2Info_t, cusparseSolvePolicy_t, Ptr{Cvoid}),
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}, Cint,
+                               bsrsm2Info_t, cusparseSolvePolicy_t, CuPtr{Cvoid}),
                               handle(), cudir, cutransa, cutransxy,
                               mb, nX, A.nnz, Ref(cudesc), A.nzVal, A.rowPtr,
                               A.colVal, A.blockDim, info[1],
@@ -1551,9 +1551,9 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrsm2_bufferSize, :cusparseSbsrsm2_
                               (cusparseHandle_t, cusparseDirection_t,
                                cusparseOperation_t, cusparseOperation_t, Cint,
                                Cint, Cint, Ptr{$elty}, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}, Cint,
-                               bsrsm2Info_t, Ptr{$elty}, Cint, Ptr{$elty}, Cint,
-                               cusparseSolvePolicy_t, Ptr{Cvoid}),
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}, Cint,
+                               bsrsm2Info_t, CuPtr{$elty}, Cint, CuPtr{$elty}, Cint,
+                               cusparseSolvePolicy_t, CuPtr{Cvoid}),
                               handle(), cudir, cutransa, cutransxy, mb,
                               nX, A.nnz, [alpha], Ref(cudesc), A.nzVal, A.rowPtr,
                               A.colVal, A.blockDim, info[1], X, ldx, X, ldx,
@@ -1608,9 +1608,9 @@ for (fname,elty) in ((:cusparseScsrgeam, :Float32),
             rowPtrC = cuzeros(Cint,mA+1)
             @check ccall((:cusparseXcsrgeamNnz,libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Cint, Ptr{Cint},
-                               Ptr{Cint}, Ptr{cusparseMatDescr_t}, Cint, Ptr{Cint},
-                               Ptr{Cint}, Ptr{cusparseMatDescr_t}, Ptr{Cint},
+                               Ptr{cusparseMatDescr_t}, Cint, CuPtr{Cint},
+                               CuPtr{Cint}, Ptr{cusparseMatDescr_t}, Cint, CuPtr{Cint},
+                               CuPtr{Cint}, Ptr{cusparseMatDescr_t}, CuPtr{Cint},
                                Ptr{Cint}), handle(), mA, nA, Ref(cudesca),
                                A.nnz, A.rowPtr, A.colVal, Ref(cudescb), B.nnz,
                                B.rowPtr, B.colVal, Ref(cudescc), rowPtrC, nnzC)
@@ -1618,11 +1618,11 @@ for (fname,elty) in ((:cusparseScsrgeam, :Float32),
             C = CuSparseMatrixCSR(rowPtrC, cuzeros(Cint,nnz), cuzeros($elty,nnz), nnz, A.dims)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint, Ptr{$elty},
-                               Ptr{cusparseMatDescr_t}, Cint, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{$elty},
-                               Ptr{cusparseMatDescr_t}, Cint, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}),
+                               Ptr{cusparseMatDescr_t}, Cint, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Ptr{$elty},
+                               Ptr{cusparseMatDescr_t}, Cint, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Ptr{cusparseMatDescr_t},
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}),
                               handle(), mA, nA, [alpha], Ref(cudesca),
                               A.nnz, A.nzVal, A.rowPtr, A.colVal, [beta],
                               Ref(cudescb), B.nnz, B.nzVal, B.rowPtr, B.colVal,
@@ -1651,9 +1651,9 @@ for (fname,elty) in ((:cusparseScsrgeam, :Float32),
             rowPtrC = cuzeros(Cint, mA+1)
             @check ccall((:cusparseXcsrgeamNnz,libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Cint, Ptr{Cint},
-                               Ptr{Cint}, Ptr{cusparseMatDescr_t}, Cint, Ptr{Cint},
-                               Ptr{Cint}, Ptr{cusparseMatDescr_t}, Ptr{Cint},
+                               Ptr{cusparseMatDescr_t}, Cint, CuPtr{Cint},
+                               CuPtr{Cint}, Ptr{cusparseMatDescr_t}, Cint, CuPtr{Cint},
+                               CuPtr{Cint}, Ptr{cusparseMatDescr_t}, CuPtr{Cint},
                                Ptr{Cint}), handle(), mA, nA, Ref(cudesca),
                                A.nnz, A.colPtr, A.rowVal, Ref(cudescb), B.nnz,
                                B.colPtr, B.rowVal, Ref(cudescc), rowPtrC, nnzC)
@@ -1661,11 +1661,11 @@ for (fname,elty) in ((:cusparseScsrgeam, :Float32),
             C = CuSparseMatrixCSC(rowPtrC, cuzeros(Cint, nnz), cuzeros($elty, nnz), nnz, A.dims)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint, Ptr{$elty},
-                               Ptr{cusparseMatDescr_t}, Cint, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{$elty},
-                               Ptr{cusparseMatDescr_t}, Cint, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{cusparseMatDescr_t},
-                               Ptr{$elty}, Ptr{Cint}, Ptr{Cint}),
+                               Ptr{cusparseMatDescr_t}, Cint, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Ptr{$elty},
+                               Ptr{cusparseMatDescr_t}, Cint, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Ptr{cusparseMatDescr_t},
+                               CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint}),
                               handle(), mA, nA, [alpha], Ref(cudesca),
                               A.nnz, A.nzVal, A.colPtr, A.rowVal, [beta],
                               Ref(cudescb), B.nnz, B.nzVal, B.colPtr, B.rowVal,
@@ -1754,9 +1754,9 @@ for (fname,elty) in ((:cusparseScsrgemm, :Float32),
             @check ccall((:cusparseXcsrgemmNnz,libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t,
                                cusparseOperation_t, Cint, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Cint, Ptr{Cint},
-                               Ptr{Cint}, Ptr{cusparseMatDescr_t}, Cint, Ptr{Cint},
-                               Ptr{Cint}, Ptr{cusparseMatDescr_t}, Ptr{Cint},
+                               Ptr{cusparseMatDescr_t}, Cint, CuPtr{Cint},
+                               CuPtr{Cint}, Ptr{cusparseMatDescr_t}, Cint, CuPtr{Cint},
+                               CuPtr{Cint}, Ptr{cusparseMatDescr_t}, CuPtr{Cint},
                                Ptr{Cint}), handle(), cutransa, cutransb,
                                m, n, k, Ref(cudesca), A.nnz, A.rowPtr, A.colVal,
                                Ref(cudescb), B.nnz, B.rowPtr, B.colVal, Ref(cudescc),
@@ -1766,11 +1766,11 @@ for (fname,elty) in ((:cusparseScsrgemm, :Float32),
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t,
                                cusparseOperation_t, Cint, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Cint, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{cusparseMatDescr_t},
-                               Cint, Ptr{$elty}, Ptr{Cint}, Ptr{Cint},
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}), handle(), cutransa,
+                               Ptr{cusparseMatDescr_t}, Cint, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Ptr{cusparseMatDescr_t},
+                               Cint, CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint},
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}), handle(), cutransa,
                                cutransb, m, n, k, Ref(cudesca), A.nnz, A.nzVal,
                                A.rowPtr, A.colVal, Ref(cudescb), B.nnz, B.nzVal,
                                B.rowPtr, B.colVal, Ref(cudescc), C.nzVal,
@@ -1819,9 +1819,9 @@ for (fname,elty) in ((:cusparseScsrgemm, :Float32),
             @check ccall((:cusparseXcsrgemmNnz,libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t,
                                cusparseOperation_t, Cint, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Cint, Ptr{Cint},
-                               Ptr{Cint}, Ptr{cusparseMatDescr_t}, Cint, Ptr{Cint},
-                               Ptr{Cint}, Ptr{cusparseMatDescr_t}, Ptr{Cint},
+                               Ptr{cusparseMatDescr_t}, Cint, CuPtr{Cint},
+                               CuPtr{Cint}, Ptr{cusparseMatDescr_t}, Cint, CuPtr{Cint},
+                               CuPtr{Cint}, Ptr{cusparseMatDescr_t}, CuPtr{Cint},
                                Ptr{Cint}), handle(), cutransa, cutransb,
                                m, n, k, Ref(cudesca), A.nnz, A.colPtr, A.rowVal,
                                Ref(cudescb), B.nnz, B.colPtr, B.rowVal, Ref(cudescc),
@@ -1831,11 +1831,11 @@ for (fname,elty) in ((:cusparseScsrgemm, :Float32),
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t,
                                cusparseOperation_t, Cint, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Cint, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Ptr{cusparseMatDescr_t},
-                               Cint, Ptr{$elty}, Ptr{Cint}, Ptr{Cint},
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}), handle(), cutransa,
+                               Ptr{cusparseMatDescr_t}, Cint, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Ptr{cusparseMatDescr_t},
+                               Cint, CuPtr{$elty}, CuPtr{Cint}, CuPtr{Cint},
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}), handle(), cutransa,
                                cutransb, m, n, k, Ref(cudesca), A.nnz, A.nzVal,
                                A.colPtr, A.rowVal, Ref(cudescb), B.nnz, B.nzVal,
                                B.colPtr, B.rowVal, Ref(cudescc), C.nzVal,
@@ -1890,8 +1890,8 @@ for (fname,elty) in ((:cusparseScsric0, :Float32),
             valPtr   = typeof(Mat) == CuSparseMatrixCSC{$elty} ? Mat.rowVal : Mat.colVal
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, cusparseSolveAnalysisInfo_t),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, cusparseSolveAnalysisInfo_t),
                               handle(), cutransa, m, Ref(cudesc), Mat.nzVal,
                               indPtr, valPtr, info)
             Mat
@@ -1931,16 +1931,16 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
             bufSize = Ref{Cint}(1)
             @check ccall(($(string(bname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csric02Info_t, Ptr{Cint}),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csric02Info_t, Ptr{Cint}),
                               handle(), m, A.nnz, Ref(cudesc), A.nzVal,
                               A.rowPtr, A.colVal, info[1], bufSize)
             buffer = CuArray(zeros(UInt8, bufSize[]))
             @check ccall(($(string(aname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), m, A.nnz, Ref(cudesc),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), m, A.nnz, Ref(cudesc),
                                A.nzVal, A.rowPtr, A.colVal, info[1],
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             posit = Ref{Cint}(1)
@@ -1952,9 +1952,9 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
             end
             @check ccall(($(string(sname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), m, A.nnz,
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), m, A.nnz,
                                Ref(cudesc), A.nzVal, A.rowPtr, A.colVal, info[1],
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             cusparseDestroyCsric02Info(info[1])
@@ -1982,16 +1982,16 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
             bufSize = Ref{Cint}(1)
             @check ccall(($(string(bname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csric02Info_t, Ptr{Cint}),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csric02Info_t, Ptr{Cint}),
                               handle(), m, A.nnz, Ref(cudesc), A.nzVal,
                               A.colPtr, A.rowVal, info[1], bufSize)
             buffer = CuArray(zeros(UInt8, bufSize[]))
             @check ccall(($(string(aname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), m, A.nnz, Ref(cudesc),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), m, A.nnz, Ref(cudesc),
                                A.nzVal, A.colPtr, A.rowVal, info[1],
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             posit = Ref{Cint}(1)
@@ -2003,9 +2003,9 @@ for (bname,aname,sname,elty) in ((:cusparseScsric02_bufferSize, :cusparseScsric0
             end
             @check ccall(($(string(sname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), m, A.nnz,
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csric02Info_t, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), m, A.nnz,
                                Ref(cudesc), A.nzVal, A.colPtr, A.rowVal, info[1],
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             cusparseDestroyCsric02Info(info[1])
@@ -2048,8 +2048,8 @@ for (fname,elty) in ((:cusparseScsrilu0, :Float32),
             valPtr   = typeof(Mat) == CuSparseMatrixCSC{$elty} ? Mat.rowVal : Mat.colVal
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseOperation_t, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, cusparseSolveAnalysisInfo_t),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, cusparseSolveAnalysisInfo_t),
                               handle(), cutransa, m, Ref(cudesc), Mat.nzVal,
                               indPtr, valPtr, info)
             Mat
@@ -2088,16 +2088,16 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
             bufSize = Ref{Cint}(1)
             @check ccall(($(string(bname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csrilu02Info_t, Ptr{Cint}),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csrilu02Info_t, Ptr{Cint}),
                               handle(), m, A.nnz, Ref(cudesc), A.nzVal,
                               A.rowPtr, A.colVal, info[1], bufSize)
             buffer = CuArray(zeros(UInt8, bufSize[]))
             @check ccall(($(string(aname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), m, A.nnz, Ref(cudesc),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), m, A.nnz, Ref(cudesc),
                                A.nzVal, A.rowPtr, A.colVal, info[1],
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             posit = Ref{Cint}(1)
@@ -2109,9 +2109,9 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
             end
             @check ccall(($(string(sname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), m, A.nnz,
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), m, A.nnz,
                                Ref(cudesc), A.nzVal, A.rowPtr, A.colVal, info[1],
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             cusparseDestroyCsrilu02Info(info[1])
@@ -2139,16 +2139,16 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
             bufSize = Ref{Cint}(1)
             @check ccall(($(string(bname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csrilu02Info_t, Ptr{Cint}),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csrilu02Info_t, Ptr{Cint}),
                               handle(), m, A.nnz, Ref(cudesc), A.nzVal,
                               A.colPtr, A.rowVal, info[1], bufSize)
             buffer = CuArray(zeros(UInt8, bufSize[]))
             @check ccall(($(string(aname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), m, A.nnz, Ref(cudesc),
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), m, A.nnz, Ref(cudesc),
                                A.nzVal, A.colPtr, A.rowVal, info[1],
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             posit = Ref{Cint}(1)
@@ -2160,9 +2160,9 @@ for (bname,aname,sname,elty) in ((:cusparseScsrilu02_bufferSize, :cusparseScsril
             end
             @check ccall(($(string(sname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, Cint, Cint,
-                               Ptr{cusparseMatDescr_t}, Ptr{$elty}, Ptr{Cint},
-                               Ptr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
-                               Ptr{Cvoid}), handle(), m, A.nnz,
+                               Ptr{cusparseMatDescr_t}, CuPtr{$elty}, CuPtr{Cint},
+                               CuPtr{Cint}, csrilu02Info_t, cusparseSolvePolicy_t,
+                               CuPtr{Cvoid}), handle(), m, A.nnz,
                                Ref(cudesc), A.nzVal, A.colPtr, A.rowVal, info[1],
                                CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
             cusparseDestroyCsrilu02Info(info[1])
@@ -2192,17 +2192,17 @@ for (bname,aname,sname,elty) in ((:cusparseSbsric02_bufferSize, :cusparseSbsric0
             bufSize = Ref{Cint}(1)
             @check ccall(($(string(bname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t, Cint,
-                               Cint, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Cint, bsric02Info_t,
+                               Cint, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
                                Ptr{Cint}), handle(), cudir, mb, A.nnz,
                                Ref(cudesc), A.nzVal, A.rowPtr, A.colVal,
                                A.blockDim, info[1], bufSize)
             buffer = CuArray(zeros(UInt8, bufSize[]))
             @check ccall(($(string(aname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t, Cint,
-                               Cint, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Cint, bsric02Info_t,
-                               cusparseSolvePolicy_t, Ptr{Cvoid}),
+                               Cint, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Cint, bsric02Info_t,
+                               cusparseSolvePolicy_t, CuPtr{Cvoid}),
                               handle(), cudir, mb, A.nnz, Ref(cudesc),
                               A.nzVal, A.rowPtr, A.colVal, A.blockDim, info[1],
                               CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
@@ -2215,9 +2215,9 @@ for (bname,aname,sname,elty) in ((:cusparseSbsric02_bufferSize, :cusparseSbsric0
             end
             @check ccall(($(string(sname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t, Cint,
-                               Cint, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Cint,bsric02Info_t,
-                               cusparseSolvePolicy_t, Ptr{Cvoid}),
+                               Cint, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Cint,bsric02Info_t,
+                               cusparseSolvePolicy_t, CuPtr{Cvoid}),
                               handle(), cudir, mb, A.nnz, Ref(cudesc),
                               A.nzVal, A.rowPtr, A.colVal, A.blockDim, info[1],
                               CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
@@ -2248,17 +2248,17 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrilu02_bufferSize, :cusparseSbsril
             bufSize = Ref{Cint}(1)
             @check ccall(($(string(bname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t, Cint,
-                               Cint, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Cint, bsrilu02Info_t,
+                               Cint, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
                                Ptr{Cint}), handle(), cudir, mb, A.nnz,
                                Ref(cudesc), A.nzVal, A.rowPtr, A.colVal,
                                A.blockDim, info[1], bufSize)
             buffer = CuArray(zeros(UInt8, bufSize[]))
             @check ccall(($(string(aname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t, Cint,
-                               Cint, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Cint, bsrilu02Info_t,
-                               cusparseSolvePolicy_t, Ptr{Cvoid}),
+                               Cint, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Cint, bsrilu02Info_t,
+                               cusparseSolvePolicy_t, CuPtr{Cvoid}),
                               handle(), cudir, mb, A.nnz, Ref(cudesc),
                               A.nzVal, A.rowPtr, A.colVal, A.blockDim, info[1],
                               CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
@@ -2271,9 +2271,9 @@ for (bname,aname,sname,elty) in ((:cusparseSbsrilu02_bufferSize, :cusparseSbsril
             end
             @check ccall(($(string(sname)),libcusparse), cusparseStatus_t,
                               (cusparseHandle_t, cusparseDirection_t, Cint,
-                               Cint, Ptr{cusparseMatDescr_t}, Ptr{$elty},
-                               Ptr{Cint}, Ptr{Cint}, Cint,bsrilu02Info_t,
-                               cusparseSolvePolicy_t, Ptr{Cvoid}),
+                               Cint, Ptr{cusparseMatDescr_t}, CuPtr{$elty},
+                               CuPtr{Cint}, CuPtr{Cint}, Cint,bsrilu02Info_t,
+                               cusparseSolvePolicy_t, CuPtr{Cvoid}),
                               handle(), cudir, mb, A.nnz, Ref(cudesc),
                               A.nzVal, A.rowPtr, A.colVal, A.blockDim, info[1],
                               CUSPARSE_SOLVE_POLICY_USE_LEVEL, buffer)
@@ -2324,8 +2324,8 @@ for (fname,elty) in ((:cusparseSgtsv, :Float32),
             m,n = B.dims
             ldb = max(1,stride(B,2))
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
-                              (cusparseHandle_t, Cint, Cint, Ptr{$elty},
-                               Ptr{$elty}, Ptr{$elty}, Ptr{$elty}, Cint),
+                              (cusparseHandle_t, Cint, Cint, CuPtr{$elty},
+                               CuPtr{$elty}, CuPtr{$elty}, CuPtr{$elty}, Cint),
                               handle(), m, n, dl, d, du, B, ldb)
             B
         end
@@ -2357,8 +2357,8 @@ for (fname,elty) in ((:cusparseSgtsv_nopivot, :Float32),
             m,n = B.dims
             ldb = max(1,stride(B,2))
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
-                              (cusparseHandle_t, Cint, Cint, Ptr{$elty},
-                               Ptr{$elty}, Ptr{$elty}, Ptr{$elty}, Cint),
+                              (cusparseHandle_t, Cint, Cint, CuPtr{$elty},
+                               CuPtr{$elty}, CuPtr{$elty}, CuPtr{$elty}, Cint),
                               handle(), m, n, dl, d, du, B, ldb)
             B
         end
@@ -2393,8 +2393,8 @@ for (fname,elty) in ((:cusparseSgtsvStridedBatch, :Float32),
                                    batchStride::Integer)
             m = div(length(X),batchCount)
             @check ccall(($(string(fname)),libcusparse), cusparseStatus_t,
-                              (cusparseHandle_t, Cint, Ptr{$elty}, Ptr{$elty},
-                               Ptr{$elty}, Ptr{$elty}, Cint, Cint),
+                              (cusparseHandle_t, Cint, CuPtr{$elty}, CuPtr{$elty},
+                               CuPtr{$elty}, CuPtr{$elty}, Cint, Cint),
                               handle(), m, dl, d, du, X,
                               batchCount, batchStride)
             X

--- a/src/sparse/wrappers.jl
+++ b/src/sparse/wrappers.jl
@@ -1,3 +1,7 @@
+# wrappers of the low-level CUSPARSE functionality
+#
+# TODO: move raw ccall wrappers to libcusparse.jl
+
 #utilities
 import LinearAlgebra: SingularException, HermOrSym, AbstractTriangular, *, +, -, \, mul!
 

--- a/test/base.jl
+++ b/test/base.jl
@@ -3,6 +3,7 @@ using LinearAlgebra
 using Adapt: adapt
 
 import CUDAdrv
+import CUDAdrv: CuPtr, CU_NULL
 
 @testset "GPUArrays test suite" begin
   GPUArrays.test(CuArray)
@@ -17,7 +18,7 @@ end
   @test isa(ret, CuArray{Int32})
   @test occursin("1 GPU allocation: 4 bytes", out)
 
-  ret, out = @grab_output CuArrays.@time Base.unsafe_wrap(CuArray, Ptr{Int32}(12345678), (2, 3))
+  ret, out = @grab_output CuArrays.@time Base.unsafe_wrap(CuArray, CuPtr{Int32}(12345678), (2, 3))
   @test isa(ret, CuArray{Int32})
   @test !occursin("GPU allocation", out)
 end
@@ -35,16 +36,15 @@ end
   @test_throws ErrorException xs[1] = 1
 
   # unsafe_wrap
-  ptr = C_NULL
-  buf = CUDAdrv.Mem.Buffer(C_NULL, 2, CUDAdrv.CuCurrentContext())
-  @test Base.unsafe_wrap(CuArray, C_NULL, 1; own=false).own == false
-  @test Base.unsafe_wrap(CuArray, C_NULL, 1; ctx=CUDAdrv.CuCurrentContext()).buf.ctx == CUDAdrv.CuCurrentContext()
-  @test Base.unsafe_wrap(CuArray, C_NULL, 2)            == CuArray{Nothing,1}(buf, (2,))
-  @test Base.unsafe_wrap(CuArray{Nothing}, C_NULL, 2)   == CuArray{Nothing,1}(buf, (2,))
-  @test Base.unsafe_wrap(CuArray{Nothing,1}, C_NULL, 2) == CuArray{Nothing,1}(buf, (2,))
-  @test Base.unsafe_wrap(CuArray, C_NULL, (1,2))            == CuArray{Nothing,2}(buf, (1,2))
-  @test Base.unsafe_wrap(CuArray{Nothing}, C_NULL, (1,2))   == CuArray{Nothing,2}(buf, (1,2))
-  @test Base.unsafe_wrap(CuArray{Nothing,2}, C_NULL, (1,2)) == CuArray{Nothing,2}(buf, (1,2))
+  buf = CUDAdrv.Mem.Buffer(CU_NULL, 2, CUDAdrv.CuCurrentContext())
+  @test Base.unsafe_wrap(CuArray, CU_NULL, 1; own=false).own == false
+  @test Base.unsafe_wrap(CuArray, CU_NULL, 1; ctx=CUDAdrv.CuCurrentContext()).buf.ctx == CUDAdrv.CuCurrentContext()
+  @test Base.unsafe_wrap(CuArray, CU_NULL, 2)            == CuArray{Nothing,1}(buf, (2,))
+  @test Base.unsafe_wrap(CuArray{Nothing}, CU_NULL, 2)   == CuArray{Nothing,1}(buf, (2,))
+  @test Base.unsafe_wrap(CuArray{Nothing,1}, CU_NULL, 2) == CuArray{Nothing,1}(buf, (2,))
+  @test Base.unsafe_wrap(CuArray, CU_NULL, (1,2))            == CuArray{Nothing,2}(buf, (1,2))
+  @test Base.unsafe_wrap(CuArray{Nothing}, CU_NULL, (1,2))   == CuArray{Nothing,2}(buf, (1,2))
+  @test Base.unsafe_wrap(CuArray{Nothing,2}, CU_NULL, (1,2)) == CuArray{Nothing,2}(buf, (1,2))
 
   @test collect(cuzeros(2, 2)) == zeros(Float32, 2, 2)
   @test collect(cuones(2, 2)) == ones(Float32, 2, 2)


### PR DESCRIPTION
See https://github.com/JuliaGPU/CUDAdrv.jl/pull/125

I'd appreciate some help on this; it's a pretty mechanical change: run the test-suite, spot conversion errors, have a look at the underlying `ccall` and change `Ptr` arguments to `CuDevicePtr` arguments when if they pass an `CuArray`.