### PR TITLE
Sprinkle some TimerOutputs dust on the memory allocator.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [extras]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,4 +33,7 @@ include("fft.jl")
 include("rand.jl")
 include("sparse_solver.jl")
 
+CuArrays.pool_status()
+CuArrays.pool_timings()
+
 end


### PR DESCRIPTION
Overhead should be pretty minimal, not warranting a conditional mode. For example, using @KristofferC ResNet model I'm getting 38.4k allocations, each performing 10 measurements, times 0.25us overhead according to the TimerOutpouts.jl README yields about 96ms overhead on a total run time of 184s.

```
 ─────────────────────────────────────────────────────────────────────────────
                                      Time                   Allocations      
                              ──────────────────────   ───────────────────────
       Tot / % measured:            184s / 60.0%           14.4GiB / 0.16%    

 Section              ncalls     time   %tot     avg     alloc   %tot      avg
 ─────────────────────────────────────────────────────────────────────────────
 pooled alloc          38.4k     110s   100%  2.88ms   23.1MiB  99.4%        -
   4 try alloc         2.66k    41.9s  37.9%  15.8ms    164KiB  0.69%        -
   5 gc(true)            145    25.2s  22.8%   174ms   10.1MiB  43.3%  71.2KiB
   1 try alloc         19.5k    16.6s  15.0%   853μs   3.45MiB  14.8%        -
   2 gc(false)         3.50k    15.1s  13.7%  4.32ms   8.05MiB  34.6%  2.35KiB
   3 reclaim unused    2.66k    11.0s  10.0%  4.15ms    957KiB  4.01%        -
     reclaim           2.66k    11.0s  10.0%  4.14ms         -  0.00%        -
     scan              2.66k   3.08ms  0.00%  1.16μs    872KiB  3.66%        -
   7 try alloc            29    502ms  0.45%  17.3ms   1.81KiB  0.01%        -
   6 reclaim unused       29   87.1ms  0.08%  3.00ms   12.1KiB  0.05%        -
     reclaim              29   87.0ms  0.08%  3.00ms         -  0.00%        -
     scan                 29   14.1μs  0.00%   487ns   9.52KiB  0.04%        -
 background task          32    164ms  0.15%  5.11ms    143KiB  0.60%  4.48KiB
   scan                   32   68.3μs  0.00%  2.13μs   10.5KiB  0.04%        -
   reclaim                32   46.8μs  0.00%  1.46μs         -  0.00%        -
 ─────────────────────────────────────────────────────────────────────────────
```

bors try