### PR TITLE
Fix ambiguity in _reshape when dims is Tuple{Int}

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -129,7 +129,11 @@ function Base._reshape(parent::CuArray, dims::Dims)
   return CuArray{eltype(parent),length(dims)}(parent.buf, dims;
                                               offset=parent.offset, own=parent.own)
 end
-
+function Base._reshape(parent::CuArray{T,1}, dims::Tuple{Int}) where T
+  n = length(parent)
+  prod(dims) == n || throw(DimensionMismatch("parent has $n elements, which is incompatible with size $dims"))
+  return parent
+end
 
 
 ## interop with C libraries


### PR DESCRIPTION
Since it's just the identity, the same array is just returned. Handles https://github.com/JuliaGPU/CuArrays.jl/issues/161 , https://github.com/JuliaDiffEq/DiffEqFlux.jl/issues/21 .

@vchuravy 