### PR TITLE
cu(xs) respects DataType of xs.

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -205,7 +205,7 @@ end
 
 ## utilities
 
-cu(xs) = adapt(CuArray{Float32}, xs)
+cu(xs) = adapt(CuArray{eltype(xs)}, xs)
 Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
 
 cuzeros(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 0)


### PR DESCRIPTION
I feel like having `cu(xs)` always return a `CuArray{Float32}` defied my expectations of what the function should do. If `xs` is an `Array{Float64}` or `Array{Complex{Float32}}` then the output of `cu(xs)` should reflect that.

This is especially helpful for doing mixed-precision GPGPU programming or for generically switching between `Float32` and `Float64`.