### PR TITLE
Upsampling GPU Kernel for Flux

### DIFF
--- a/src/dnn/CUDNN.jl
+++ b/src/dnn/CUDNN.jl
@@ -30,6 +30,7 @@ end
 include("libcudnn.jl")
 include("helpers.jl")
 include("nnlib.jl")
+include("upsample.jl")
 
 version() = VersionNumber(cudnnGetProperty(CUDAapi.MAJOR_VERSION),
                           cudnnGetProperty(CUDAapi.MINOR_VERSION),

--- a/src/dnn/upsample.jl
+++ b/src/dnn/upsample.jl
@@ -1,0 +1,59 @@
+function upsample_kernel(state, y, x, height, width, channels, batch, stride, scale)
+    i = @linearidx y state
+    
+    y_idx = i
+    y_h = (i - 1) % (height * stride[1]) + 1
+    i = (i - 1) ÷ (height * stride[1])
+    y_w = i % (width * stride[2]) + 1
+    i = i ÷ (width * stride[2])
+    y_c = i % channels + 1
+    i = i ÷ channels
+    y_b = i % batch + 1
+    
+    x_h = (y_h - 1) ÷ stride[1] + 1
+    x_w = (y_w - 1) ÷ stride[2] + 1
+    x_c = y_c
+    x_idx = (y_b - 1) * width * height * channels + (x_c - 1) * width * height + (x_w - 1) * height + x_h
+    
+    @inbounds y[y_idx] = scale * x[x_idx]
+    
+    return nothing
+end
+
+function upsample(x::CuArray, stride, scale = 1)
+    (height, width, channels, batch) = size(x)
+    y = similar(x, (height * stride[1], width * stride[2], channels, batch))
+    gpu_call(upsample_kernel, y, (y, x, height, width, channels, batch, stride, scale))
+    return y
+end
+
+function ∇upsample_kernel(state, y, x, height, width, channels, batch, stride, scale)
+    i = @linearidx y state
+
+    y_idx = i
+    y_h = (i - 1) % (height * stride[1]) + 1
+    i = (i - 1) ÷ (height * stride[1])
+    y_w = i % (width * stride[2]) + 1
+    i = i ÷ (width * stride[2])
+    y_c = i % channels + 1
+    i = i ÷ channels
+    y_b = i % batch + 1
+
+    x_h = (y_h - 1) ÷ stride[1] + 1
+    x_w = (y_w - 1) ÷ stride[2] + 1
+    x_c = y_c
+    x_idx = (y_b - 1) * width * height * channels + (x_c - 1) * width * height + (x_w - 1) * height + x_h
+
+    @inbounds x[x_idx] += y[y_idx] / scale
+
+    return nothing
+end
+
+function ∇upsample(dy::CuArray, stride, scale = 1)
+    (height, width, channels, batch) = size(dy)
+    @assert height % stride[1] == 0
+    @assert width % stride[2] == 0
+    dx = similar(dy, (height ÷ stride[1], width ÷ stride[2], channels, batch))
+    gpu_call(∇upsample_kernel, dy, (dy, dx, height, width, channels, batch, stride, scale))
+    return dx
+end


### PR DESCRIPTION
## Current Issues:
- [ ] Line 47 in upsample.jl is not a safe operation without atomic addition. It results in incorrect and inconsistent answers in the backward pass.

@maleadt suggested using CUDAatomics for now, but I could not get it working. Concerns regarding that
1. It needs CuDeviceArray, I am not entirely sure how to pass CuArray to it.
2. Should we be adding a dependency on a package which is not recommended.

## Stuff to handle before it is ready for merging:
- [ ] Open the corresponding pull requests in Flux.jl and NNlib.jl to test the complete working
- [ ] Add tests to verify for the correctness of the code.

I am not entirely sure if this kernel belongs at this location (inside CUDNN). I can shift it to any other location if needed.

cc @MikeInnes 