### PR TITLE
Integrate with ForwardDiff through Requires.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,21 +8,21 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDAapi = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
 CUDAdrv = "c5f51814-7f29-56b8-a69c-e4d8f6be1fde"
 CUDAnative = "be33ccc6-a3ff-5ff2-a52e-74243cff1e17"
-DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [extras]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "FFTW", "Pkg"]
+test = ["Test", "FFTW", "Pkg", "ForwardDiff"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,6 +7,4 @@ GPUArrays 0.5
 Adapt 0.4
 AbstractFFTs
 MacroTools
-ForwardDiff
-DiffRules
 TimerOutputs

--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -12,6 +12,8 @@ import LinearAlgebra
 
 using Adapt
 
+using Requires
+
 const ext = joinpath(dirname(@__DIR__), "deps", "ext.jl")
 isfile(ext) || error("CuArrays.jl has not been built, please run Pkg.build(\"CuArrays\").")
 include(ext)
@@ -72,6 +74,9 @@ function __init__()
     check_library("CUFFT", libcufft)
     check_library("CURAND", libcurand)
     check_library("CUDNN", libcudnn)
+
+    # package integrations
+    @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" include("forwarddiff.jl")
 
     # update the active context when we switch devices
     callback = (::CuDevice, ctx::CuContext) -> begin

--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -1,0 +1,15 @@
+# ForwardDiff integration
+
+for f in libdevice
+  if haskey(ForwardDiff.DiffRules.DEFINED_DIFFRULES, (:Base,f,1))
+    f == :tanh && continue
+    diffrule = ForwardDiff.DiffRules.DEFINED_DIFFRULES[(:Base,f,1)]
+    ForwardDiff.DiffRules.DEFINED_DIFFRULES[(:CUDAnative,f,1)] =
+      (args...) -> replace_device(diffrule(args...))
+    eval(ForwardDiff.unary_dual_definition(:CUDAnative, f))
+  end
+end
+
+ForwardDiff.DiffRules.DEFINED_DIFFRULES[(:CUDAnative, :tanh, 1)] = x ->
+  replace_device(:(1-tanh(x)^2))
+eval(ForwardDiff.unary_dual_definition(:CUDAnative, :tanh))


### PR DESCRIPTION
Fix #301. Gets rid of the following dependencies:

```
[9e28174c] - BinDeps v0.8.10
[bbf7d656] - CommonSubexpressions v0.2.0
[163ba53b] - DiffResults v0.0.4
[b552c78f] - DiffRules v0.0.10
[f6369f11] - ForwardDiff v0.10.3
[77ba4419] - NaNMath v0.3.2
[276daf66] - SpecialFunctions v0.7.2
[30578b45] - URIParser v0.4.0
```

I was specially annoyed by `SpecialFunctions`, which downloads openspecfun and is often incompatible with source builds.