### PR TITLE
Don't export cu-prefixed functions, module prefix instead.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CuArrays"
 uuid = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
-version = "1.0.2"
+version = "2.0.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/docs/src/tutorials/intro.jl
+++ b/docs/src/tutorials/intro.jl
@@ -114,8 +114,8 @@ using BenchmarkTools
 
 using CuArrays
 
-x_d = cufill(1.0f0, N)  # a vector stored on the GPU filled with 1.0 (Float32)
-y_d = cufill(2.0f0, N)  # a vector stored on the GPU filled with 2.0
+x_d = CuArrays.fill(1.0f0, N)  # a vector stored on the GPU filled with 1.0 (Float32)
+y_d = CuArrays.fill(2.0f0, N)  # a vector stored on the GPU filled with 2.0
 
 # Here the `d` means "device," in contrast with "host". Now let's do the increment:
 
@@ -220,8 +220,8 @@ CUDAdrv.@profile bench_gpu1!(y_d, x_d)
 
 # You can see that 100% of the time was spent in `ptxcall_gpu_add1__1`, the name of the
 # kernel that `CUDAnative` assigned when compiling `gpu_add1!` for these inputs. (Had you
-# created arrays of multiple data types, e.g., `xu_d = cufill(0x01, N)`, you might have
-# also seen `ptxcall_gpu_add1__2` and so on. Like the rest of Julia, you can define a
+# created arrays of multiple data types, e.g., `xu_d = CuArrays.fill(0x01, N)`, you might
+# have also seen `ptxcall_gpu_add1__2` and so on. Like the rest of Julia, you can define a
 # single method and it will be specialized at compile time for the particular data types
 # you're using.)
 

--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -6,7 +6,7 @@ using CUDAdrv, CUDAnative
 
 using GPUArrays
 
-export CuArray, CuVector, CuMatrix, CuVecOrMat, cu, cuzeros, cuones, cufill
+export CuArray, CuVector, CuMatrix, CuVecOrMat, cu
 
 import LinearAlgebra
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -214,12 +214,12 @@ end
 cu(xs) = adapt(CuArray{Float32}, xs)
 Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
 
-cuzeros(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 0)
-cuones(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 1)
-cuzeros(dims...) = cuzeros(Float32, dims...)
-cuones(dims...) = cuones(Float32, dims...)
-cufill(v, dims...) = fill!(CuArray{typeof(v)}(undef, dims...), v)
-cufill(v, dims::Dims) = fill!(CuArray{typeof(v)}(undef, dims...), v)
+zeros(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 0)
+ones(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 1)
+zeros(dims...) = CuArrays.zeros(Float32, dims...)
+ones(dims...) = CuArrays.ones(Float32, dims...)
+fill(v, dims...) = fill!(CuArray{typeof(v)}(undef, dims...), v)
+fill(v, dims::Dims) = fill!(CuArray{typeof(v)}(undef, dims...), v)
 
 # optimized implementation of `fill!` for types that are directly supported by memset
 const MemsetTypes = Dict(1=>UInt8, 2=>UInt16, 4=>UInt32)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -4,3 +4,7 @@ import Base: @deprecate_binding
 
 @deprecate_binding BLAS CUBLAS
 @deprecate_binding FFT CUFFT
+
+@deprecate cuzeros CuArrays.zeros
+@deprecate cuones CuArrays.ones
+@deprecate cufill CuArrays.fill

--- a/src/rand/CURAND.jl
+++ b/src/rand/CURAND.jl
@@ -10,10 +10,7 @@ using GPUArrays
 
 using Random
 
-export curand,
-       curandn,
-       curand_logn, rand_logn!, rand_logn,
-       curand_poisson, rand_poisson!, rand_poisson
+export rand_logn!, rand_poisson!
 
 include("libcurand_types.jl")
 include("error.jl")
@@ -44,3 +41,11 @@ version() = VersionNumber(curandGetProperty(CUDAapi.MAJOR_VERSION),
                           curandGetProperty(CUDAapi.PATCH_LEVEL))
 
 end
+
+const rand = CURAND.rand
+const randn = CURAND.randn
+const rand_logn = CURAND.rand_logn
+const rand_poisson = CURAND.rand_poisson
+
+@deprecate curand CuArrays.rand
+@deprecate curandn CuArrays.randn

--- a/src/rand/highlevel.jl
+++ b/src/rand/highlevel.jl
@@ -77,19 +77,13 @@ rand_poisson!(A::CuArray; kwargs...) = rand_poisson!(poisson_rng(A), A; kwargs..
 rand_logn(A::CuArray; kwargs...) = rand_logn!(logn_rng(A), A; kwargs...)
 rand_poisson(A::CuArray; kwargs...) = rand_poisson!(poisson_rng(A), A; kwargs...)
 
-
-# need to prefix with `cu` to disambiguate from Random functions that return an Array
-# TODO: `@gpu rand` with Cassette
-curand(::Type{X}, args...; kwargs...) where {X} = rand!(CuArray{X}(undef, args...); kwargs...)
-curandn(::Type{X}, args...; kwargs...) where {X} = randn!(CuArray{X}(undef, args...); kwargs...)
-curand_logn(::Type{X}, args...; kwargs...) where {X} = rand_logn!(CuArray{X}(undef, args...); kwargs...)
-curand_poisson(::Type{X}, args...; kwargs...) where {X} = rand_poisson!(CuArray{X}(undef, args...); kwargs...)
-
+rand(::Type{X}, args...; kwargs...) where {X} = rand!(CuArray{X}(undef, args...); kwargs...)
+randn(::Type{X}, args...; kwargs...) where {X} = randn!(CuArray{X}(undef, args...); kwargs...)
 rand_logn(::Type{X}, args...; kwargs...) where {X} = rand_logn!(CuArray{X}(undef, args...); kwargs...)
 rand_poisson(::Type{X}, args...; kwargs...) where {X} = rand_poisson!(CuArray{X}(undef, args...); kwargs...)
 
 # specify default types
-curand(args...; kwargs...) where {X} = curand(Float32, args...; kwargs...)
-curandn(args...; kwargs...) where {X} = curandn(Float32, args...; kwargs...)
-curand_logn(args...; kwargs...) where {X} = curand_logn(Float32, args...; kwargs...)
-curand_poisson(args...; kwargs...) where {X} = curand_poisson(Cuint, args...; kwargs...)
+rand(args...; kwargs...) where {X} = rand(Float32, args...; kwargs...)
+randn(args...; kwargs...) where {X} = randn(Float32, args...; kwargs...)
+rand_logn(args...; kwargs...) where {X} = rand_logn(Float32, args...; kwargs...)
+rand_poisson(args...; kwargs...) where {X} = rand_poisson(Cuint, args...; kwargs...)

--- a/test/base.jl
+++ b/test/base.jl
@@ -50,11 +50,11 @@ end
   @test Base.unsafe_wrap(CuArray{Nothing}, CU_NULL, (1,2))   == CuArray{Nothing,2}(buf, (1,2))
   @test Base.unsafe_wrap(CuArray{Nothing,2}, CU_NULL, (1,2)) == CuArray{Nothing,2}(buf, (1,2))
 
-  @test collect(cuzeros(2, 2)) == zeros(Float32, 2, 2)
-  @test collect(cuones(2, 2)) == ones(Float32, 2, 2)
+  @test collect(CuArrays.zeros(2, 2)) == zeros(Float32, 2, 2)
+  @test collect(CuArrays.ones(2, 2)) == ones(Float32, 2, 2)
 
-  @test collect(cufill(0, 2, 2)) == zeros(Float32, 2, 2)
-  @test collect(cufill(1, 2, 2)) == ones(Float32, 2, 2)
+  @test collect(CuArrays.fill(0, 2, 2)) == zeros(Float32, 2, 2)
+  @test collect(CuArrays.fill(1, 2, 2)) == ones(Float32, 2, 2)
 end
 
 @testset "Adapt" begin

--- a/test/rand.jl
+++ b/test/rand.jl
@@ -15,26 +15,27 @@ for (f,T) in ((rand!,Float32),
 end
 
 # out-of-place, with implicit type
-for (f,T) in ((curand,Float32), (curandn,Float32), (curand_logn,Float32),
-              (curand_poisson,Cuint),(rand,Float64), (randn,Float64)),
+for (f,T) in ((CuArrays.rand,Float32), (CuArrays.randn,Float32),
+              (CuArrays.rand_logn,Float32), (CuArrays.rand_poisson,Cuint),
+              (rand,Float64), (randn,Float64)),
     args in ((2,), (2, 2))
     A = f(args...)
     @test eltype(A) == T
 end
 
 # out-of-place, with type specified
-for (f,T) in ((curand,Float32), (curandn,Float32), (curand_logn,Float32),
-              (curand,Float64), (curandn,Float64), (curand_logn,Float64),
-              (curand_poisson,Cuint), (rand,Float32), (randn,Float32),
-              (rand_logn,Float32), (rand,Float64), (randn,Float64),
-              (rand_logn,Float64), (rand_poisson,Cuint)),
+for (f,T) in ((CuArrays.rand,Float32), (CuArrays.randn,Float32), (CuArrays.rand_logn,Float32),
+              (CuArrays.rand,Float64), (CuArrays.randn,Float64), (CuArrays.rand_logn,Float64),
+              (CuArrays.rand_poisson,Cuint),
+              (rand,Float32), (randn,Float32),
+              (rand,Float64), (randn,Float64)),
     args in ((T, 2), (T, 2, 2), (T, (2, 2)))
     A = f(args...)
     @test eltype(A) == T
 end
 
 # unsupported types that fall back to GPUArrays
-for (f,T) in ((curand,Int64),),
+for (f,T) in ((CuArrays.rand,Int64),),
     args in ((T, 2), (T, 2, 2), (T, (2, 2)))
     A = f(args...)
     @test eltype(A) == T

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -295,7 +295,7 @@ k = 1
     end
     # Check that constant propagation works
     _svd(A) = svd(A, CUSOLVER.QRAlgorithm)
-    @inferred _svd(CuArrays.CURAND.curand(Float32, 4, 4))
+    @inferred _svd(CuArrays.rand(Float32, 4, 4))
 
 
     @testset "qr" begin


### PR DESCRIPTION
implement https://github.com/JuliaGPU/CuArrays.jl/issues/310

Basically, instead of `cu{ones,zeros,fill,rand,randn}` we now have `CuArrays.{ones,zeros,fill,rand,randn}`.