### PR TITLE
WIP/RFC: Use unified memory for array allocations.

### DIFF
--- a/src/memory.jl
+++ b/src/memory.jl
@@ -241,7 +241,7 @@ function try_cuda_alloc(bytes)
   buf = nothing
   try
     stats.cuda_time += Base.@elapsed begin
-      buf = Mem.alloc(Mem.Device, bytes)
+      buf = Mem.alloc(Mem.Unified, bytes)
     end
     stats.actual_nalloc += 1
     stats.actual_alloc += bytes

--- a/src/solver/CUSOLVER.jl
+++ b/src/solver/CUSOLVER.jl
@@ -4,7 +4,8 @@ import CUDAdrv: CUDAdrv, CuContext, CuStream_t, CuPtr, PtrOrCuPtr, CU_NULL
 import CUDAapi
 
 using ..CuArrays
-using ..CuArrays: libcusolver, active_context, _getindex, unsafe_free!
+using ..CuArrays: libcusolver, active_context, unsafe_free!
+using GPUArrays: _getindex
 
 using LinearAlgebra
 using SparseArrays 


### PR DESCRIPTION
Massively speeds up host operations, without losing `assertscalar`-like functionality.

Doesn't properly works right now, due to the coherency requirements of unified memory on pre-sm_60 hardware. Basically, we'd need to synchronize the device before doing any load from unified memory to make sure there's no kernel running (which claims ownership of the unified memory). That would wreck performance again.

I had hoped that https://github.com/JuliaGPU/CUDAdrv.jl/pull/141 would fix this, but that only works around the issue when doing explicit copies (doing a `cudaMemcpy` instead of just loading from the memory). When indexing, we of course still do a regular memory load, running into the above issue.

If and when we solve this problem, host/unified<->unified transfers should probably do a regular `memcpy` again (ie. what https://github.com/JuliaGPU/CUDAdrv.jl/pull/141 reverted, but for good reasons).