### PR TITLE
remove redundant global annotation on TimerOutput in function

### DIFF
--- a/src/memory.jl
+++ b/src/memory.jl
@@ -58,7 +58,6 @@ using TimerOutputs
 const to = Ref{TimerOutput}()
 
 function pool_timings!(new=TimerOutput())
-  global to
   to[] = new
   return
 end


### PR DESCRIPTION
This doesn't seem to do anything.