### PR TITLE
Work around / ignore cuFFT issues.

### DIFF
--- a/res/wrap/wrap.jl
+++ b/res/wrap/wrap.jl
@@ -105,13 +105,22 @@ mutable struct State
     edits::Vector{Edit}
 end
 
-# insert `@check` before each `ccall` when it returns a xxxStatus_t
+# insert `@check` before each `ccall` when it returns a checked type
+const checked_types = [
+    "cublasStatus_t",
+    "cudnnStatus_t",
+    "cufftResult",
+    "curandStatus_t",
+    "cusolverStatus_t",
+    "cusparseStatus_t",
+    "cutensorStatus_t",
+]
 function insert_check(x, state)
     if x isa CSTParser.EXPR && x.typ == CSTParser.Call && x.args[1].val == "ccall"
         # get the ccall return type
         rv = x.args[5]
 
-        if endswith(rv.val, "Status_t")
+        if rv.val in checked_types
             push!(state.edits, Edit(state.offset, "@check "))
         end
     end

--- a/src/fft/error.jl
+++ b/src/fft/error.jl
@@ -12,39 +12,39 @@ function CUFFTError(code::cufftResult)
 end
 
 function status_message(status)
-    if status == CUFFT_STATUS_SUCCESS
+    if status == CUFFT_SUCCESS
         return "the operation completed successfully"
-    elseif status == CUFFT_STATUS_INVALID_PLAN
+    elseif status == CUFFT_INVALID_PLAN
         return "cuFFT was passed an invalid plan handle"
-    elseif status == CUFFT_STATUS_ALLOC_FAILED
+    elseif status == CUFFT_ALLOC_FAILED
         return "cuFFT failed to allocate GPU or CPU memory"
-    elseif status == CUFFT_STATUS_INVALID_TYPE
+    elseif status == CUFFT_INVALID_TYPE
         return "cuFFT invalid type " # No longer used
-    elseif status == CUFFT_STATUS_INVALID_VALUE
+    elseif status == CUFFT_INVALID_VALUE
         return "User specified an invalid pointer or parameter"
-    elseif status == CUFFT_STATUS_INTERNAL_ERROR
+    elseif status == CUFFT_INTERNAL_ERROR
         return "Driver or internal cuFFT library error"
-    elseif status == CUFFT_STATUS_EXEC_FAILED
+    elseif status == CUFFT_EXEC_FAILED
         return "Failed to execute an FFT on the GPU"
-    elseif status == CUFFT_STATUS_SETUP_FAILED
+    elseif status == CUFFT_SETUP_FAILED
         return "The cuFFT library failed to initialize"
-    elseif status == CUFFT_STATUS_INVALID_SIZE
+    elseif status == CUFFT_INVALID_SIZE
         return "User specified an invalid transform size"
-    elseif status == CUFFT_STATUS_UNALIGNED_DATA
+    elseif status == CUFFT_UNALIGNED_DATA
         return "cuFFT unaligned data" # No longer used
-    elseif status == CUFFT_STATUS_INCOMPLETE_PARAMETER_LIST
+    elseif status == CUFFT_INCOMPLETE_PARAMETER_LIST
         return "Missing parameters in call"
-    elseif status == CUFFT_STATUS_INVALID_DEVICE
+    elseif status == CUFFT_INVALID_DEVICE
         return "Execution of a plan was on different GPU than plan creation"
-    elseif status == CUFFT_STATUS_PARSE_ERROR
+    elseif status == CUFFT_PARSE_ERROR
         return "Internal plan database error"
-    elseif status == CUFFT_STATUS_NO_WORKSPACE
+    elseif status == CUFFT_NO_WORKSPACE
         return "No workspace has been provided prior to plan execution"
-    elseif status == CUFFT_STATUS_NOT_IMPLEMENTED
+    elseif status == CUFFT_NOT_IMPLEMENTED
         return "Function does not implement functionality for parameters given."
-    elseif status == CUFFT_STATUS_LICENSE_ERROR
+    elseif status == CUFFT_LICENSE_ERROR
         return "cuFFT license error" # Used in previous versions.
-    elseif status == CUFFT_STATUS_NOT_SUPPORTED
+    elseif status == CUFFT_NOT_SUPPORTED
         return "Operation is not supported for parameters given."
     else
         return "unknown status"
@@ -55,7 +55,7 @@ macro check(fft_func)
     quote
         local err::cufftResult
         err = $(esc(fft_func::Expr))
-        if err != CUFFT_STATUS_SUCCESS
+        if err != CUFFT_SUCCESS
             throw(CUFFTError(err))
         end
         err

--- a/src/fft/fft.jl
+++ b/src/fft/fft.jl
@@ -381,20 +381,20 @@ function unsafe_execute!(plan::cCuFFTPlan{cufftComplex,K,false,N},
                          x::CuArray{cufftComplex,N}, y::CuArray{cufftComplex}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_C2C
-    cufftExecC2C(plan, copy(x), y, K)
+    cufftExecC2C(plan, copy(x), y, K)   # JuliaGPU/CuArrays.jl#345, NVIDIA/cuFFT#2714055
 end
 function unsafe_execute!(plan::rCuFFTPlan{cufftComplex,K,false,N},
                          x::CuArray{cufftComplex,N}, y::CuArray{cufftReal}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_C2R
-    cufftExecC2R(plan, copy(x), y)
+    cufftExecC2R(plan, copy(x), y)  # JuliaGPU/CuArrays.jl#345, NVIDIA/cuFFT#2714055
 end
 
 function unsafe_execute!(plan::rCuFFTPlan{cufftReal,K,false,N},
                          x::CuArray{cufftReal,N}, y::CuArray{cufftComplex,N}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_R2C
-    cufftExecR2C(plan, copy(x), y)
+    cufftExecR2C(plan, copy(x), y)  # JuliaGPU/CuArrays.jl#345, NVIDIA/cuFFT#2714055
 end
 
 function unsafe_execute!(plan::cCuFFTPlan{cufftDoubleComplex,K,true,N},
@@ -412,20 +412,20 @@ function unsafe_execute!(plan::cCuFFTPlan{cufftDoubleComplex,K,false,N},
                          x::CuArray{cufftDoubleComplex,N}, y::CuArray{cufftDoubleComplex}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_Z2Z
-    cufftExecZ2Z(plan, copy(x), y, K)
+    cufftExecZ2Z(plan, copy(x), y, K)   # JuliaGPU/CuArrays.jl#345, NVIDIA/cuFFT#2714055
 end
 function unsafe_execute!(plan::rCuFFTPlan{cufftDoubleComplex,K,false,N},
                          x::CuArray{cufftDoubleComplex,N}, y::CuArray{cufftDoubleReal}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_Z2D
-    cufftExecZ2D(plan, copy(x), y)
+    cufftExecZ2D(plan, copy(x), y)  # JuliaGPU/CuArrays.jl#345, NVIDIA/cuFFT#2714055
 end
 
 function unsafe_execute!(plan::rCuFFTPlan{cufftDoubleReal,K,false,N},
                          x::CuArray{cufftDoubleReal,N}, y::CuArray{cufftDoubleComplex,N}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_D2Z
-    cufftExecD2Z(plan, copy(x), y)
+    cufftExecD2Z(plan, copy(x), y)  # JuliaGPU/CuArrays.jl#345, NVIDIA/cuFFT#2714055
 end
 
 function LinearAlgebra.mul!(y::CuArray{Ty}, p::CuFFTPlan{T,K,false}, x::CuArray{T}

--- a/src/fft/fft.jl
+++ b/src/fft/fft.jl
@@ -381,20 +381,20 @@ function unsafe_execute!(plan::cCuFFTPlan{cufftComplex,K,false,N},
                          x::CuArray{cufftComplex,N}, y::CuArray{cufftComplex}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_C2C
-    cufftExecC2C(plan, x, y, K)
+    cufftExecC2C(plan, copy(x), y, K)
 end
 function unsafe_execute!(plan::rCuFFTPlan{cufftComplex,K,false,N},
                          x::CuArray{cufftComplex,N}, y::CuArray{cufftReal}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_C2R
-    cufftExecC2R(plan, x, y)
+    cufftExecC2R(plan, copy(x), y)
 end
 
 function unsafe_execute!(plan::rCuFFTPlan{cufftReal,K,false,N},
                          x::CuArray{cufftReal,N}, y::CuArray{cufftComplex,N}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_R2C
-    cufftExecR2C(plan, x, y)
+    cufftExecR2C(plan, copy(x), y)
 end
 
 function unsafe_execute!(plan::cCuFFTPlan{cufftDoubleComplex,K,true,N},
@@ -412,20 +412,20 @@ function unsafe_execute!(plan::cCuFFTPlan{cufftDoubleComplex,K,false,N},
                          x::CuArray{cufftDoubleComplex,N}, y::CuArray{cufftDoubleComplex}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_Z2Z
-    cufftExecZ2Z(plan, x, y, K)
+    cufftExecZ2Z(plan, copy(x), y, K)
 end
 function unsafe_execute!(plan::rCuFFTPlan{cufftDoubleComplex,K,false,N},
                          x::CuArray{cufftDoubleComplex,N}, y::CuArray{cufftDoubleReal}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_Z2D
-    cufftExecZ2D(plan, x, y)
+    cufftExecZ2D(plan, copy(x), y)
 end
 
 function unsafe_execute!(plan::rCuFFTPlan{cufftDoubleReal,K,false,N},
                          x::CuArray{cufftDoubleReal,N}, y::CuArray{cufftDoubleComplex,N}
                          ) where {K,N}
     @assert plan.xtype == CUFFT_D2Z
-    cufftExecD2Z(plan, x, y)
+    cufftExecD2Z(plan, copy(x), y)
 end
 
 function LinearAlgebra.mul!(y::CuArray{Ty}, p::CuFFTPlan{T,K,false}, x::CuArray{T}

--- a/src/fft/libcufft.jl
+++ b/src/fft/libcufft.jl
@@ -3,209 +3,211 @@
 
 
 function cufftPlan1d(plan, nx, type, batch)
-    ccall((:cufftPlan1d, libcufft), cufftResult,
-          (Ptr{cufftHandle}, Cint, cufftType, Cint),
-          plan, nx, type, batch)
+    @check ccall((:cufftPlan1d, libcufft), cufftResult,
+                 (Ptr{cufftHandle}, Cint, cufftType, Cint),
+                 plan, nx, type, batch)
 end
 
 function cufftPlan2d(plan, nx, ny, type)
-    ccall((:cufftPlan2d, libcufft), cufftResult,
-          (Ptr{cufftHandle}, Cint, Cint, cufftType),
-          plan, nx, ny, type)
+    @check ccall((:cufftPlan2d, libcufft), cufftResult,
+                 (Ptr{cufftHandle}, Cint, Cint, cufftType),
+                 plan, nx, ny, type)
 end
 
 function cufftPlan3d(plan, nx, ny, nz, type)
-    ccall((:cufftPlan3d, libcufft), cufftResult,
-          (Ptr{cufftHandle}, Cint, Cint, Cint, cufftType),
-          plan, nx, ny, nz, type)
+    @check ccall((:cufftPlan3d, libcufft), cufftResult,
+                 (Ptr{cufftHandle}, Cint, Cint, Cint, cufftType),
+                 plan, nx, ny, nz, type)
 end
 
 function cufftPlanMany(plan, rank, n, inembed, istride, idist, onembed, ostride, odist,
                        type, batch)
-    ccall((:cufftPlanMany, libcufft), cufftResult,
-          (Ptr{cufftHandle}, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint}, Cint,
-           Cint, cufftType, Cint),
-          plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch)
+    @check ccall((:cufftPlanMany, libcufft), cufftResult,
+                 (Ptr{cufftHandle}, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint},
+                  Cint, Cint, cufftType, Cint),
+                 plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type,
+                 batch)
 end
 
 function cufftMakePlan1d(plan, nx, type, batch, workSize)
-    ccall((:cufftMakePlan1d, libcufft), cufftResult,
-          (cufftHandle, Cint, cufftType, Cint, Ptr{Csize_t}),
-          plan, nx, type, batch, workSize)
+    @check ccall((:cufftMakePlan1d, libcufft), cufftResult,
+                 (cufftHandle, Cint, cufftType, Cint, Ptr{Csize_t}),
+                 plan, nx, type, batch, workSize)
 end
 
 function cufftMakePlan2d(plan, nx, ny, type, workSize)
-    ccall((:cufftMakePlan2d, libcufft), cufftResult,
-          (cufftHandle, Cint, Cint, cufftType, Ptr{Csize_t}),
-          plan, nx, ny, type, workSize)
+    @check ccall((:cufftMakePlan2d, libcufft), cufftResult,
+                 (cufftHandle, Cint, Cint, cufftType, Ptr{Csize_t}),
+                 plan, nx, ny, type, workSize)
 end
 
 function cufftMakePlan3d(plan, nx, ny, nz, type, workSize)
-    ccall((:cufftMakePlan3d, libcufft), cufftResult,
-          (cufftHandle, Cint, Cint, Cint, cufftType, Ptr{Csize_t}),
-          plan, nx, ny, nz, type, workSize)
+    @check ccall((:cufftMakePlan3d, libcufft), cufftResult,
+                 (cufftHandle, Cint, Cint, Cint, cufftType, Ptr{Csize_t}),
+                 plan, nx, ny, nz, type, workSize)
 end
 
 function cufftMakePlanMany(plan, rank, n, inembed, istride, idist, onembed, ostride, odist,
                            type, batch, workSize)
-    ccall((:cufftMakePlanMany, libcufft), cufftResult,
-          (cufftHandle, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint}, Cint, Cint,
-           cufftType, Cint, Ptr{Csize_t}),
-          plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch,
-          workSize)
+    @check ccall((:cufftMakePlanMany, libcufft), cufftResult,
+                 (cufftHandle, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint}, Cint,
+                  Cint, cufftType, Cint, Ptr{Csize_t}),
+                 plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type,
+                 batch, workSize)
 end
 
 function cufftMakePlanMany64(plan, rank, n, inembed, istride, idist, onembed, ostride,
                              odist, type, batch, workSize)
-    ccall((:cufftMakePlanMany64, libcufft), cufftResult,
-          (cufftHandle, Cint, Ptr{Clonglong}, Ptr{Clonglong}, Clonglong, Clonglong,
-           Ptr{Clonglong}, Clonglong, Clonglong, cufftType, Clonglong, Ptr{Csize_t}),
-          plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch,
-          workSize)
+    @check ccall((:cufftMakePlanMany64, libcufft), cufftResult,
+                 (cufftHandle, Cint, Ptr{Clonglong}, Ptr{Clonglong}, Clonglong, Clonglong,
+                  Ptr{Clonglong}, Clonglong, Clonglong, cufftType, Clonglong, Ptr{Csize_t}),
+                 plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type,
+                 batch, workSize)
 end
 
 function cufftGetSizeMany64(plan, rank, n, inembed, istride, idist, onembed, ostride,
                             odist, type, batch, workSize)
-    ccall((:cufftGetSizeMany64, libcufft), cufftResult,
-          (cufftHandle, Cint, Ptr{Clonglong}, Ptr{Clonglong}, Clonglong, Clonglong,
-           Ptr{Clonglong}, Clonglong, Clonglong, cufftType, Clonglong, Ptr{Csize_t}),
-          plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch,
-          workSize)
+    @check ccall((:cufftGetSizeMany64, libcufft), cufftResult,
+                 (cufftHandle, Cint, Ptr{Clonglong}, Ptr{Clonglong}, Clonglong, Clonglong,
+                  Ptr{Clonglong}, Clonglong, Clonglong, cufftType, Clonglong, Ptr{Csize_t}),
+                 plan, rank, n, inembed, istride, idist, onembed, ostride, odist, type,
+                 batch, workSize)
 end
 
 function cufftEstimate1d(nx, type, batch, workSize)
-    ccall((:cufftEstimate1d, libcufft), cufftResult,
-          (Cint, cufftType, Cint, Ptr{Csize_t}),
-          nx, type, batch, workSize)
+    @check ccall((:cufftEstimate1d, libcufft), cufftResult,
+                 (Cint, cufftType, Cint, Ptr{Csize_t}),
+                 nx, type, batch, workSize)
 end
 
 function cufftEstimate2d(nx, ny, type, workSize)
-    ccall((:cufftEstimate2d, libcufft), cufftResult,
-          (Cint, Cint, cufftType, Ptr{Csize_t}),
-          nx, ny, type, workSize)
+    @check ccall((:cufftEstimate2d, libcufft), cufftResult,
+                 (Cint, Cint, cufftType, Ptr{Csize_t}),
+                 nx, ny, type, workSize)
 end
 
 function cufftEstimate3d(nx, ny, nz, type, workSize)
-    ccall((:cufftEstimate3d, libcufft), cufftResult,
-          (Cint, Cint, Cint, cufftType, Ptr{Csize_t}),
-          nx, ny, nz, type, workSize)
+    @check ccall((:cufftEstimate3d, libcufft), cufftResult,
+                 (Cint, Cint, Cint, cufftType, Ptr{Csize_t}),
+                 nx, ny, nz, type, workSize)
 end
 
 function cufftEstimateMany(rank, n, inembed, istride, idist, onembed, ostride, odist, type,
                            batch, workSize)
-    ccall((:cufftEstimateMany, libcufft), cufftResult,
-          (Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint}, Cint, Cint, cufftType, Cint,
-           Ptr{Csize_t}),
-          rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch, workSize)
+    @check ccall((:cufftEstimateMany, libcufft), cufftResult,
+                 (Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint}, Cint, Cint,
+                  cufftType, Cint, Ptr{Csize_t}),
+                 rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch,
+                 workSize)
 end
 
 function cufftCreate(handle)
-    ccall((:cufftCreate, libcufft), cufftResult,
-          (Ptr{cufftHandle},),
-          handle)
+    @check ccall((:cufftCreate, libcufft), cufftResult,
+                 (Ptr{cufftHandle},),
+                 handle)
 end
 
 function cufftGetSize1d(handle, nx, type, batch, workSize)
-    ccall((:cufftGetSize1d, libcufft), cufftResult,
-          (cufftHandle, Cint, cufftType, Cint, Ptr{Csize_t}),
-          handle, nx, type, batch, workSize)
+    @check ccall((:cufftGetSize1d, libcufft), cufftResult,
+                 (cufftHandle, Cint, cufftType, Cint, Ptr{Csize_t}),
+                 handle, nx, type, batch, workSize)
 end
 
 function cufftGetSize2d(handle, nx, ny, type, workSize)
-    ccall((:cufftGetSize2d, libcufft), cufftResult,
-          (cufftHandle, Cint, Cint, cufftType, Ptr{Csize_t}),
-          handle, nx, ny, type, workSize)
+    @check ccall((:cufftGetSize2d, libcufft), cufftResult,
+                 (cufftHandle, Cint, Cint, cufftType, Ptr{Csize_t}),
+                 handle, nx, ny, type, workSize)
 end
 
 function cufftGetSize3d(handle, nx, ny, nz, type, workSize)
-    ccall((:cufftGetSize3d, libcufft), cufftResult,
-          (cufftHandle, Cint, Cint, Cint, cufftType, Ptr{Csize_t}),
-          handle, nx, ny, nz, type, workSize)
+    @check ccall((:cufftGetSize3d, libcufft), cufftResult,
+                 (cufftHandle, Cint, Cint, Cint, cufftType, Ptr{Csize_t}),
+                 handle, nx, ny, nz, type, workSize)
 end
 
 function cufftGetSizeMany(handle, rank, n, inembed, istride, idist, onembed, ostride,
                           odist, type, batch, workArea)
-    ccall((:cufftGetSizeMany, libcufft), cufftResult,
-          (cufftHandle, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint}, Cint, Cint,
-           cufftType, Cint, Ptr{Csize_t}),
-          handle, rank, n, inembed, istride, idist, onembed, ostride, odist, type, batch,
-          workArea)
+    @check ccall((:cufftGetSizeMany, libcufft), cufftResult,
+                 (cufftHandle, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Cint, Ptr{Cint}, Cint,
+                  Cint, cufftType, Cint, Ptr{Csize_t}),
+                 handle, rank, n, inembed, istride, idist, onembed, ostride, odist, type,
+                 batch, workArea)
 end
 
 function cufftGetSize(handle, workSize)
-    ccall((:cufftGetSize, libcufft), cufftResult,
-          (cufftHandle, Ptr{Csize_t}),
-          handle, workSize)
+    @check ccall((:cufftGetSize, libcufft), cufftResult,
+                 (cufftHandle, Ptr{Csize_t}),
+                 handle, workSize)
 end
 
 function cufftSetWorkArea(plan, workArea)
-    ccall((:cufftSetWorkArea, libcufft), cufftResult,
-          (cufftHandle, CuPtr{Cvoid}),
-          plan, workArea)
+    @check ccall((:cufftSetWorkArea, libcufft), cufftResult,
+                 (cufftHandle, CuPtr{Cvoid}),
+                 plan, workArea)
 end
 
 function cufftSetAutoAllocation(plan, autoAllocate)
-    ccall((:cufftSetAutoAllocation, libcufft), cufftResult,
-          (cufftHandle, Cint),
-          plan, autoAllocate)
+    @check ccall((:cufftSetAutoAllocation, libcufft), cufftResult,
+                 (cufftHandle, Cint),
+                 plan, autoAllocate)
 end
 
 function cufftExecC2C(plan, idata, odata, direction)
-    ccall((:cufftExecC2C, libcufft), cufftResult,
-          (cufftHandle, CuPtr{cufftComplex}, CuPtr{cufftComplex}, Cint),
-          plan, idata, odata, direction)
+    @check ccall((:cufftExecC2C, libcufft), cufftResult,
+                 (cufftHandle, CuPtr{cufftComplex}, CuPtr{cufftComplex}, Cint),
+                 plan, idata, odata, direction)
 end
 
 function cufftExecR2C(plan, idata, odata)
-    ccall((:cufftExecR2C, libcufft), cufftResult,
-          (cufftHandle, CuPtr{cufftReal}, CuPtr{cufftComplex}),
-          plan, idata, odata)
+    @check ccall((:cufftExecR2C, libcufft), cufftResult,
+                 (cufftHandle, CuPtr{cufftReal}, CuPtr{cufftComplex}),
+                 plan, idata, odata)
 end
 
 function cufftExecC2R(plan, idata, odata)
-    ccall((:cufftExecC2R, libcufft), cufftResult,
-          (cufftHandle, CuPtr{cufftComplex}, CuPtr{cufftReal}),
-          plan, idata, odata)
+    @check ccall((:cufftExecC2R, libcufft), cufftResult,
+                 (cufftHandle, CuPtr{cufftComplex}, CuPtr{cufftReal}),
+                 plan, idata, odata)
 end
 
 function cufftExecZ2Z(plan, idata, odata, direction)
-    ccall((:cufftExecZ2Z, libcufft), cufftResult,
-          (cufftHandle, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleComplex}, Cint),
-          plan, idata, odata, direction)
+    @check ccall((:cufftExecZ2Z, libcufft), cufftResult,
+                 (cufftHandle, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleComplex}, Cint),
+                 plan, idata, odata, direction)
 end
 
 function cufftExecD2Z(plan, idata, odata)
-    ccall((:cufftExecD2Z, libcufft), cufftResult,
-          (cufftHandle, CuPtr{cufftDoubleReal}, CuPtr{cufftDoubleComplex}),
-          plan, idata, odata)
+    @check ccall((:cufftExecD2Z, libcufft), cufftResult,
+                 (cufftHandle, CuPtr{cufftDoubleReal}, CuPtr{cufftDoubleComplex}),
+                 plan, idata, odata)
 end
 
 function cufftExecZ2D(plan, idata, odata)
-    ccall((:cufftExecZ2D, libcufft), cufftResult,
-          (cufftHandle, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleReal}),
-          plan, idata, odata)
+    @check ccall((:cufftExecZ2D, libcufft), cufftResult,
+                 (cufftHandle, CuPtr{cufftDoubleComplex}, CuPtr{cufftDoubleReal}),
+                 plan, idata, odata)
 end
 
 function cufftSetStream(plan, stream)
-    ccall((:cufftSetStream, libcufft), cufftResult,
-          (cufftHandle, CuStream_t),
-          plan, stream)
+    @check ccall((:cufftSetStream, libcufft), cufftResult,
+                 (cufftHandle, CuStream_t),
+                 plan, stream)
 end
 
 function cufftDestroy(plan)
-    ccall((:cufftDestroy, libcufft), cufftResult,
-          (cufftHandle,),
-          plan)
+    @check ccall((:cufftDestroy, libcufft), cufftResult,
+                 (cufftHandle,),
+                 plan)
 end
 
 function cufftGetVersion(version)
-    ccall((:cufftGetVersion, libcufft), cufftResult,
-          (Ptr{Cint},),
-          version)
+    @check ccall((:cufftGetVersion, libcufft), cufftResult,
+                 (Ptr{Cint},),
+                 version)
 end
 
 function cufftGetProperty(type, value)
-    ccall((:cufftGetProperty, libcufft), cufftResult,
-          (libraryPropertyType, Ptr{Cint}),
-          type, value)
+    @check ccall((:cufftGetProperty, libcufft), cufftResult,
+                 (libraryPropertyType, Ptr{Cint}),
+                 type, value)
 end

--- a/test/fft.jl
+++ b/test/fft.jl
@@ -163,11 +163,13 @@ function out_of_place(X::AbstractArray{T,N}) where {T <: Real,N}
     d_Z = pinv2 * d_Y
     Z = collect(d_Z)
     @test_maybe_broken isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
+    # JuliaGPU/CuArrays.jl#345, NVIDIA/cuFFT#2714102
 
     pinv3 = inv(pinv)
     d_W = pinv3 * d_X
     W = collect(d_W)
     @test isapprox(W, Y, rtol = MYRTOL, atol = MYATOL)
+    # JuliaGPU/CuArrays.jl#345, NVIDIA/cuFFT#2714102
 end
 
 function batched(X::AbstractArray{T,N},region) where {T <: Real,N}

--- a/test/util.jl
+++ b/test/util.jl
@@ -12,26 +12,21 @@ macro grab_output(ex)
     end
 end
 
-# some tests are mysteriously broken on CI, but nowhere else...
+# some tests are mysteriously broken with certain hardware/software.
 # use a horrible macro to mark those tests as "potentially broken"
 @eval Test begin
     export @test_maybe_broken
 
-    const broken = haskey(ENV, "CI")
     macro test_maybe_broken(ex, kws...)
         test_expr!("@test_maybe_broken", ex, kws...)
         orig_ex = Expr(:inert, ex)
         result = get_test_result(ex, __source__)
-        if !broken
-            :(do_test($result, $orig_ex))
-        else
-            quote
-                x = $result
-                if x.value
-                    do_test(x, $orig_ex)
-                else
-                    do_broken_test(x, $orig_ex)
-                end
+        quote
+            x = $result
+            if x.value
+                do_test(x, $orig_ex)
+            else
+                do_broken_test(x, $orig_ex)
             end
         end
     end


### PR DESCRIPTION
Try to fix https://github.com/JuliaGPU/CuArrays.jl/issues/345

Something iffy is going on here, it looks like CUFFT changes inputs that it really shouldn't:

```julia
function fail1()
    T = Float32

    Random.seed!(1)
    X = rand(T, 2, 2)

    Y = rfft(X)
    d_X = CuArray(X)
    d_Y = CuArray(Y)

    pinv = plan_brfft(d_Y,size(X,1))
    bak = copy(d_Y)
    d_Z = pinv * d_Y
    @assert Array(d_Y) == Array(bak)
end

# cufftExecC2R in fft/libcufft.jl: @show idata round ccall
```
```
idata = Complex{Float32}[2.49235+0.0im 0.242207+0.0im; -0.26089+0.0im -0.281692+0.0im]
idata = Complex{Float32}[2.73456+0.0im 2.25014+0.0im; -0.542582+0.0im 0.020802+0.0im]
```

@kshyatt, I think you wrote most of these wrappers, any ideas? It should be out-of-place as per the docs, as `idata != odata`. Looks like other people have similar issues though: https://devtalk.nvidia.com/default/topic/475992/cufftexecc2r-altering-input-data-after-call-input-data-changes-after-cufftexecc2r-is-called-for-non-/ https://devtalk.nvidia.com/default/topic/460195/cufft-out-of-place-transform-destroys-input-/

To make matters worse, replicating this issue is tricky. Doesn't reproduce on my system (CUDA 10.1, GTX 970), but does on the CI system (CUDA 10.1, GTX 2080 Ti), so it's hard to figure out when we need to copy. Doing so unconditionally seems unacceptable to me.

Remaining CUFFT issues:

```julia
function fail2()
    T = ComplexF32

    dims = (8, 32, 64, 8)
    for region in [(1,4)]
        X = rand(T, dims)

        fftw_X = fft(X,region)
        d_X = CuArray(X)
        p = plan_fft(d_X,region)
        d_Y = p * d_X
        Y = collect(d_Y)
        @test isapprox(Y, fftw_X, rtol = MYRTOL, atol = MYATOL)
    end
end
```
