### PR TITLE
WIP: Add wrapper functions for setting/getting convolution group count

### DIFF
--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -126,6 +126,20 @@ function cudnnSetConvolutionMathType(convDesc, mathType)
                  convDesc, mathType)
 end
 
+function cudnnSetConvolutionGroupCount(convDesc,groupCount)
+    @check ccall((:cudnnSetConvolutionGroupCount,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnConvolutionDescriptor_t,Cint),
+                 convDesc,groupCount)
+end
+
+function cudnnGetConvolutionGroupCount(convDesc,groupCount)
+    @check ccall((:cudnnSetConvolutionGroupCount,libcudnn),
+                 cudnnStatus_t,
+                 (cudnnConvolutionDescriptor_t,Ptr{Cint}),
+                 convDesc,groupCount)
+end
+
 function cudnnCreatePoolingDescriptor(poolingDesc)
     @check ccall((:cudnnCreatePoolingDescriptor,libcudnn),
                  cudnnStatus_t,

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -134,7 +134,7 @@ function cudnnSetConvolutionGroupCount(convDesc,groupCount)
 end
 
 function cudnnGetConvolutionGroupCount(convDesc,groupCount)
-    @check ccall((:cudnnSetConvolutionGroupCount,libcudnn),
+    @check ccall((:cudnnGetConvolutionGroupCount,libcudnn),
                  cudnnStatus_t,
                  (cudnnConvolutionDescriptor_t,Ptr{Cint}),
                  convDesc,groupCount)


### PR DESCRIPTION
Based on a discussion over at Flux ( https://github.com/FluxML/Flux.jl/issues/459 and https://github.com/FluxML/Flux.jl/issues/330 ) @avik-pal proposed the inclusion of new functions in libcudnn.jl, namely to set the group count for a group convolution.

Further changes to other functions to actually enable group convolutions  (and by that depthwise conv on the gpu), could be added to this PR based on discussion and support.
The latter because this is prolly out of depth at this point in time and will require some more diggin in.

Hopefully @avik-pal can add some more hints on what should be done :).