### PR TITLE
Add an exported function for checking library availability.

### DIFF
--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -45,6 +45,10 @@ let
         # or a run-time error if the library is not available (for use in ccall expressions)
         exception = :(error($"Your installation does not provide $lib, CuArrays.$(uppercase(name)) is unavailable"))
         @eval macro $lib() $lib === nothing ? $(QuoteNode(exception)) : $lib end
+
+        # provide a function for external use (a la CUDAapi.has_cuda)
+        fn = Symbol("has_$name")
+        @eval (export $fn; $fn() = $lib !== nothing)
     end
 end
 

--- a/test/dnn.jl
+++ b/test/dnn.jl
@@ -7,6 +7,8 @@ if CuArrays.libcudnn === nothing
 else
 @info "Testing CUDNN $(CUDNN.version())"
 
+@test has_cudnn()
+
 @testset "NNlib" begin
   using NNlib
   using NNlib: ∇conv_data, ∇conv_filter,


### PR DESCRIPTION
Avoid Flux using the `libcudnn` handle directly.