### PR TITLE
Added in-place ND reverse

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -322,9 +322,7 @@ function reverse_by_moving(data::CuArray{T, N}, dims::Integer=1) where {T, N}
     nblocks = ceil(Int, length(data) / nthreads)
     #shmem = nthreads * sizeof(T)
 
-    CuArrays.@sync begin
-        @cuda threads=nthreads blocks=nblocks kernel(data)
-    end
+    @cuda threads=nthreads blocks=nblocks kernel(data)
 end
 
 #=

--- a/src/array.jl
+++ b/src/array.jl
@@ -288,7 +288,7 @@ end
 # pos [i1, i2, i3, ... , d{x} - i{x} + 1, ..., i{n}], where d{x} is the size of the xth
 # dimension.
 
-# in-place version, using shared memory to buffer temporary values
+# in-place version
 function reverse_by_moving(data::CuArray{T, N}, dims::Integer=1) where {T, N}
     shape = [size(data)...]
     numelemsinprevdims = prod(shape[1:dims-1])
@@ -302,11 +302,11 @@ function reverse_by_moving(data::CuArray{T, N}, dims::Integer=1) where {T, N}
         # Each thread is responsible for swapping an element with another element
         # that is currently in its destination position.
 
-        # Copy the block as is into shared memory...
+        # Calculate the index of the element to swapped.
         offset_in = blockDim().x * (blockIdx().x - 1)
         index_in  = offset_in + threadIdx().x
 
-        # Calculate the index of the new position...
+        # Calculate its destination...
         ik = ((ceil(Int, index_in / numelemsinprevdims) - 1) % numelemsincurrdim) + 1
         index_out = index_in + (numelemsincurrdim - 2ik + 1) * numelemsinprevdims
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -378,8 +378,9 @@ function Base.reverse(input::CuArray{T, N}; dims::Integer) where {T, N}
         index_in = offset_in + threadIdx().x
 
         # the index of an element in the original array along dimension that we will flip
-        ik = ((UInt32(ceil(index_in / numelemsinprevdims)) - 1) % numelemsincurrdim) + 1
-        index_out = UInt32(index_in + (numelemsincurrdim - 2ik + 1) * numelemsinprevdims)
+        ik = ((ceil(index_in / numelemsinprevdims) - 1) % numelemsincurrdim) + 1
+
+        index_out = index_in + (numelemsincurrdim - 2ik + 1) * numelemsinprevdims
 
         if 1 ≤ index_in ≤ length(input) && 1 ≤ index_out ≤ length(output)
             @inbounds output[index_out] = input[index_in]

--- a/test/base.jl
+++ b/test/base.jl
@@ -343,7 +343,7 @@ end
       # TODO: Better tests for inplace ND reverse
       # Reverse an array twice and see if it's still the same array...
       x_h = rand(shape...)
-      x_d = cu(x_d)
+      x_d = cu(x_h)
       reverse!(x_d, dim)
       reverse!(x_d, dim)
       @test all(cu(x_h) .== x_d)

--- a/test/base.jl
+++ b/test/base.jl
@@ -339,6 +339,14 @@ end
     for shape in ([1, 2, 4, 3], [4, 2], [5], [2^5, 2^5, 2^5]),
         dim in 1:length(shape)
       @test testf(x->reverse(x; dims=dim), rand(shape...))
+
+      # TODO: Better tests for inplace ND reverse
+      # Reverse an array twice and see if it's still the same array...
+      x_h = rand(shape...)
+      x_d = cu(x_d)
+      reverse!(x_d, dim)
+      reverse!(x_d, dim)
+      @test all(cu(x_h) .== x_d)
     end
 end
 


### PR DESCRIPTION
For an array of shape `[3, 4, 4, 3, 6, 5]`,

```
julia> @btime reverse_by_moving(v_d, 3)
  31.330 μs (26 allocations: 1.11 KiB)
```
cc @maleadt