### PR TITLE
Use the memory pool for CUFFT workarea allocation.

### DIFF
--- a/src/fft/CUFFT.jl
+++ b/src/fft/CUFFT.jl
@@ -4,6 +4,7 @@ using CUDAapi
 
 using ..CuArrays
 using ..CuArrays: libcufft
+import ..CuArrays: unsafe_free!
 
 using CUDAdrv
 using CUDAdrv: CuStream_t


### PR DESCRIPTION
Fix https://github.com/JuliaGPU/CuArrays.jl/issues/130 (or at least for CUFFT). Remainder of that issue can be tracked at https://github.com/JuliaGPU/CuArrays.jl/issues/426