### PR TITLE
Implement findall

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -43,3 +43,51 @@ function Base.getindex(xs::CuArray{T}, bools::CuArray{Bool}) where {T}
 
   return ys
 end
+
+
+## findall
+
+function Base.findall(bools::CuArray{Bool})
+    indices = cumsum(bools)
+
+    n = _getindex(indices, length(indices))
+    ys = CuArray{Int}(undef, n)
+
+    if n > 0
+        num_threads = min(n, 256)
+        num_blocks = ceil(Int, length(indices) / num_threads)
+
+        function kernel(ys::CuDeviceArray{Int}, bools, indices)
+            i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+
+            if i <= length(bools) && bools[i]
+                b = indices[i]   # new position
+                ys[b] = i
+
+            end
+
+            return
+        end
+
+        function configurator(kernel)
+            fun = kernel.fun
+            config = launch_configuration(fun)
+            blocks = cld(length(indices), config.threads)
+
+            return (threads=config.threads, blocks=blocks)
+        end
+
+        @cuda config=configurator kernel(ys, bools, indices)
+    end
+
+    unsafe_free!(indices)
+
+    return ys
+end
+
+function Base.findall(f::Function, A::CuArray)
+    bools = map(f, A)
+    ys = findall(bools)
+    unsafe_free!(bools)
+    return ys
+end

--- a/test/base.jl
+++ b/test/base.jl
@@ -359,3 +359,8 @@ end
     inds = rand(1:100, 150, 150)
     @test testf(x->permutedims(view(x, inds, :), (3, 2, 1)), rand(100, 100))
 end
+
+@testset "findall" begin
+    @test testf(x->findall(x), rand(Bool, 100))
+    @test testf(x->findall(y->y>0.5, x), rand(100))
+end


### PR DESCRIPTION
Not a very fast implementation (see https://github.com/JuliaGPU/CuArrays.jl/issues/445), but a big improvement over scalar indexing nonetheless:

```
# CPU
julia> for i in (100, 1_000, 10_000, 100_000)
       @btime findall($(rand(Bool, i)));
       end
  120.487 ns (1 allocation: 496 bytes)
  1.131 μs (1 allocation: 4.06 KiB)
  36.526 μs (2 allocations: 38.64 KiB)
  392.674 μs (2 allocations: 389.20 KiB)

# GPU
julia> for i in (100, 1_000, 10_000, 100_000)
       @btime findall($(CuArray(rand(Bool, i))));
       end
  127.818 μs (505 allocations: 16.27 KiB)
  162.533 μs (672 allocations: 21.36 KiB)
  210.293 μs (900 allocations: 28.23 KiB)
  243.953 μs (1071 allocations: 33.39 KiB)

# GPU (scalar version)
julia> for i in (100, 1_000, 10_000, 100_000)
       @btime findall($(CuArray(rand(Bool, i))));
       end
  517.373 μs (308 allocations: 16.44 KiB)
  5.182 ms (3496 allocations: 168.83 KiB)
  53.216 ms (39498 allocations: 1.72 MiB)
  538.223 ms (399573 allocations: 17.16 MiB)

```

cc @ChrisRackauckas 