### PR TITLE
Optimize accumulate

### DIFF
--- a/src/accumulate.jl
+++ b/src/accumulate.jl
@@ -137,10 +137,14 @@ function Base._accumulate!(f::Function, output::CuArray{T,N}, input::CuArray{T,N
     kernel_config = launch_configuration(kernel.fun; shmem=(threads)->2*threads*sizeof(T))
 
     # determine the grid layout to cover the other dimensions
-    dev = CUDAdrv.device(kernel.fun.mod.ctx)
-    max_other_blocks = attribute(dev, CUDAdrv.MAX_GRID_DIM_Y)
-    blocks_other = (min(length(Rother), max_other_blocks),
-                    cld(length(Rother), max_other_blocks))
+    if length(Rother) > 1
+        dev = CUDAdrv.device(kernel.fun.mod.ctx)
+        max_other_blocks = attribute(dev, CUDAdrv.MAX_GRID_DIM_Y)
+        blocks_other = (min(length(Rother), max_other_blocks),
+                        cld(length(Rother), max_other_blocks))
+    else
+        blocks_other = (1, 1)
+    end
 
     # does that suffice to scan the array in one go?
     full = nextpow(2, length(Rdim))

--- a/src/accumulate.jl
+++ b/src/accumulate.jl
@@ -56,7 +56,7 @@ function partial_scan(op::Function, input::CuDeviceArray{T,N}, output::CuDeviceA
 
     # clear the last element
     @inbounds if thread == 1
-        temp[threads] = 0
+        temp[threads] = zero(T)
     end
 
     # traverse down tree & build scan

--- a/src/accumulate.jl
+++ b/src/accumulate.jl
@@ -186,4 +186,11 @@ function Base._accumulate!(op::Function, vout::CuVector{T}, v::CuVector{T}, dims
     return Base._accumulate!(op::Function, vout, v, 1, init)
 end
 
+function Base._accumulate!(op::Function, vout::CuVector{T}, v::CuVector, dims::Nothing,
+                           init::Nothing) where {T}
+    vin = T.(v)  # convert to vector with eltype T
+
+    return Base._accumulate!(op::Function, vout, vin, 1, init)
+end
+
 Base.accumulate_pairwise!(op, result::CuVector, v::CuVector) = accumulate!(op, result, v)

--- a/src/accumulate.jl
+++ b/src/accumulate.jl
@@ -95,6 +95,8 @@ end
 
 function Base._accumulate!(f::Function, output::CuVector{T}, input::CuVector{T},
                            dims::Nothing, init::Nothing) where {T}
+    length(input) == 0 && return output
+
     # determine how many threads we can launch for the scan kernel
     args = (+, input, output)
     kernel_args = cudaconvert.(args)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -35,11 +35,12 @@ function Base.getindex(xs::CuArray{T}, bools::CuArray{Bool}) where {T}
     end
 
     function configurator(kernel)
-        fun = kernel.fun
-        config = launch_configuration(fun)
-        blocks = cld(length(indices), config.threads)
+        config = launch_configuration(kernel.fun)
 
-        return (threads=config.threads, blocks=blocks)
+        threads = min(length(indices), config.threads)
+        blocks = cld(length(indices), threads)
+
+        return (threads=threads, blocks=blocks)
     end
 
     @cuda name="logical_getindex" config=configurator kernel(ys, xs, bools, indices)
@@ -75,11 +76,12 @@ function Base.findall(bools::CuArray{Bool})
         end
 
         function configurator(kernel)
-            fun = kernel.fun
-            config = launch_configuration(fun)
-            blocks = cld(length(indices), config.threads)
+            config = launch_configuration(kernel.fun)
 
-            return (threads=config.threads, blocks=blocks)
+            threads = min(length(indices), config.threads)
+            blocks = cld(length(indices), threads)
+
+            return (threads=threads, blocks=blocks)
         end
 
         @cuda name="findall" config=configurator kernel(ys, bools, indices)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -26,10 +26,9 @@ function Base.getindex(xs::CuArray{T}, bools::CuArray{Bool}) where {T}
     function kernel(ys::CuDeviceArray{T}, xs::CuDeviceArray{T}, bools, indices)
         i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
 
-        if i <= length(xs) && bools[i]
+        @inbounds if i <= length(xs) && bools[i]
             b = indices[i]   # new position
             ys[b] = xs[i]
-
         end
 
         return
@@ -43,7 +42,7 @@ function Base.getindex(xs::CuArray{T}, bools::CuArray{Bool}) where {T}
         return (threads=config.threads, blocks=blocks)
     end
 
-    @cuda config=configurator kernel(ys, xs, bools, indices)
+    @cuda name="logical_getindex" config=configurator kernel(ys, xs, bools, indices)
   end
 
   unsafe_free!(indices)
@@ -67,10 +66,9 @@ function Base.findall(bools::CuArray{Bool})
         function kernel(ys::CuDeviceArray{Int}, bools, indices)
             i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
 
-            if i <= length(bools) && bools[i]
+            @inbounds if i <= length(bools) && bools[i]
                 b = indices[i]   # new position
                 ys[b] = i
-
             end
 
             return
@@ -84,7 +82,7 @@ function Base.findall(bools::CuArray{Bool})
             return (threads=config.threads, blocks=blocks)
         end
 
-        @cuda config=configurator kernel(ys, bools, indices)
+        @cuda name="findall" config=configurator kernel(ys, bools, indices)
     end
 
     unsafe_free!(indices)

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -42,8 +42,8 @@ _cuview(A, I, ::NonContiguous) where {N} = invoke(view, Tuple{AbstractArray, typ
 
 # copyto! doesn't know how to deal with SubArrays, but broadcast does
 # FIXME: use the rules from Adapt.jl to define copyto! methods in GPUArrays.jl
-function Base.copyto!(dest::GPUArray{T,N}, src::SubArray{T,N,<:GPUArray{T,N}}) where {T,N}
-    dest .= src
+function Base.copyto!(dest::GPUArray{T,N}, src::SubArray{T,N,<:GPUArray{T}}) where {T,N}
+    view(dest, axes(src)...) .= src
     dest
 end
 

--- a/test/base.jl
+++ b/test/base.jl
@@ -268,7 +268,9 @@ end
   @test cumsum(CuArray{Int}(undef, 2)) isa CuVector
   @test cumprod(CuArray{Int}(undef, 2)) isa CuVector
 
-  @test testf(x->accumulate(+, x), rand(2))
+  for n in (0, 1, 2, 3, 10, 10_000, 16384, 16384+1) # small, large, odd & even, pow2 and not
+    @test testf(x->accumulate(+, x), rand(n))
+  end
   @test testf(x->accumulate(+, x; dims=2), rand(2))
   @test testf(x->(accumulate!(+, x, copy(x)); x), rand(2))
   @test testf(cumsum, rand(2))

--- a/test/base.jl
+++ b/test/base.jl
@@ -270,17 +270,26 @@ end
 end
 
 @testset "accumulate" begin
-  @test accumulate(+, CuArray{Int}(undef, 2)) isa CuVector
-  @test cumsum(CuArray{Int}(undef, 2)) isa CuVector
-  @test cumprod(CuArray{Int}(undef, 2)) isa CuVector
-
   for n in (0, 1, 2, 3, 10, 10_000, 16384, 16384+1) # small, large, odd & even, pow2 and not
     @test testf(x->accumulate(+, x), rand(n))
   end
-  @test testf(x->accumulate(+, x; dims=2), rand(2))
+
+  # multidimensional
+  for (sizes, dims) in ((2,) => 2,
+                        (3,4,5) => 2,
+                        (1, 70, 50, 20) => 3)
+    @test testf(x->accumulate(+, x; dims=dims), rand(Int, sizes))
+  end
+
+  # using initializer
+  # TODO
+
+  # in place
   @test testf(x->(accumulate!(+, x, copy(x)); x), rand(2))
+
+  # specialized
   @test testf(cumsum, rand(2))
-  @test testf(cumprod, rand(2))
+  @test_broken testf(cumprod, rand(2))  # TODO
 end
 
 @testset "logical indexing" begin

--- a/test/base.jl
+++ b/test/base.jl
@@ -289,7 +289,7 @@ end
 
   # specialized
   @test testf(cumsum, rand(2))
-  @test_broken testf(cumprod, rand(2))  # TODO
+  @test testf(cumprod, rand(2))
 end
 
 @testset "logical indexing" begin

--- a/test/base.jl
+++ b/test/base.jl
@@ -234,6 +234,12 @@ end
     x[1,:] .= 42
     @test Array(x)[1,1] == 42
   end
+
+  # bug in copyto!
+  ## needless N type parameter
+  @test testf((x,y)->copyto!(y, selectdim(x, 2, 1)), ones(2,2,2), zeros(2,2))
+  ## inability to copyto! smaller destination
+  @test testf((x,y)->copyto!(y, selectdim(x, 2, 1)), ones(2,2,2), zeros(3,3))
 end
 
 @testset "reshape" begin

--- a/test/base.jl
+++ b/test/base.jl
@@ -282,7 +282,11 @@ end
   end
 
   # using initializer
-  # TODO
+  for (sizes, dims) in ((2,) => 2,
+                        (3,4,5) => 2,
+                        (1, 70, 50, 20) => 3)
+    @test testf(x->accumulate(+, x; dims=dims, init=100.), rand(Int, sizes))
+  end
 
   # in place
   @test testf(x->(accumulate!(+, x, copy(x)); x), rand(2))


### PR DESCRIPTION
Ref https://github.com/JuliaGPU/CuArrays.jl/issues/445

Greatly improves performance (CPU vs reference GPU vs optimized GPU):

```
i = 10
  8.239 ns (0 allocations: 0 bytes)
  74.607 μs (305 allocations: 9.88 KiB)
  5.928 μs (22 allocations: 768 bytes)
i = 100
  85.683 ns (0 allocations: 0 bytes)
  114.921 μs (462 allocations: 14.81 KiB)
  6.047 μs (23 allocations: 784 bytes)
i = 1000
  1.040 μs (0 allocations: 0 bytes)
  154.329 μs (629 allocations: 19.91 KiB)
  5.966 μs (28 allocations: 864 bytes)
i = 10000
  10.284 μs (0 allocations: 0 bytes)
  198.071 μs (861 allocations: 26.84 KiB)
  67.132 μs (236 allocations: 7.53 KiB)
i = 100000
  102.629 μs (0 allocations: 0 bytes)
  237.085 μs (1035 allocations: 32.05 KiB)
  66.363 μs (246 allocations: 7.69 KiB)
i = 1000000
  1.056 ms (0 allocations: 0 bytes)
  286.495 μs (1234 allocations: 37.64 KiB)
  68.353 μs (255 allocations: 7.83 KiB)
i = 10000000
  10.783 ms (0 allocations: 0 bytes)
  334.199 μs (1570 allocations: 46.20 KiB)
  129.853 μs (469 allocations: 14.61 KiB)
i = 100000000
  110.446 ms (0 allocations: 0 bytes)
  1.001 ms (1763 allocations: 51.72 KiB)
  130.578 μs (479 allocations: 14.77 KiB)
```

Most important contribution is reducing the amount of kernels to 1 for small arrays (N=500 to 1000, depending on the GPU), and to 4 for most other arrays, but the kernels themselves are much faster too. However, our kernel launching code paths have slowed down over the course of the years, so we're paying a significant penalty (multiple 10s of μs) for every kernel launch.

As this kernel is used by a bunch of other operations, this also speeds up e.g. `findall` (https://github.com/JuliaGPU/CuArrays.jl/pull/446#issue-326569062):

```
# GPU reference
julia> for i in (100, 1_000, 10_000, 100_000)
       @btime findall($(CuArray(rand(Bool, i))));
       end
  127.818 μs (505 allocations: 16.27 KiB)
  162.533 μs (672 allocations: 21.36 KiB)
  210.293 μs (900 allocations: 28.23 KiB)
  243.953 μs (1071 allocations: 33.39 KiB)

# GPU optimized
julia> for i in (100, 1_000, 10_000, 100_000)
       @btime findall($(CuArray(rand(Bool, i))));
       end
  38.430 μs (128 allocations: 4.16 KiB)
  43.782 μs (136 allocations: 4.28 KiB)
  105.097 μs (338 allocations: 10.88 KiB)
  103.674 μs (348 allocations: 11.03 KiB)
```

cc @ChrisRackauckas 