### PR TITLE
Fix #463

### DIFF
--- a/res/wrap/pointers.json
+++ b/res/wrap/pointers.json
@@ -94,8 +94,8 @@
         "bnScaleBiasMeanVarDesc": null,
         "bnScale": "CuPtr",
         "bnBias": "CuPtr",
-        "estimatedMean": "Ptr",
-        "estimatedVariance": "Ptr",
+        "estimatedMean": "CuPtr",
+        "estimatedVariance": "CuPtr",
         "epsilon": null
     },
     "cudnnCreateTensorTransformDescriptor": {

--- a/src/dnn/libcudnn.jl
+++ b/src/dnn/libcudnn.jl
@@ -1017,7 +1017,7 @@ function cudnnBatchNormalizationForwardInference(handle, mode, alpha, beta, xDes
                  (cudnnHandle_t, cudnnBatchNormMode_t, Ptr{Cvoid}, Ptr{Cvoid},
                   cudnnTensorDescriptor_t, CuPtr{Cvoid}, cudnnTensorDescriptor_t,
                   CuPtr{Cvoid}, cudnnTensorDescriptor_t, CuPtr{Cvoid}, CuPtr{Cvoid},
-                  Ptr{Cvoid}, Ptr{Cvoid}, Cdouble),
+                  CuPtr{Cvoid}, CuPtr{Cvoid}, Cdouble),
                  handle, mode, alpha, beta, xDesc, x, yDesc, y, bnScaleBiasMeanVarDesc,
                  bnScale, bnBias, estimatedMean, estimatedVariance, epsilon)
 end

--- a/test/dnn.jl
+++ b/test/dnn.jl
@@ -80,6 +80,14 @@ end
   @test testf(CuArrays.CUDNN.cudnnActivationBackward, cu(rand(Float64, 10, 10, 3, 1)), cu(rand(Float64, 10, 10, 3, 1)), cu(rand(Float64, 10, 10, 3, 1)), cu(rand(Float64, 10, 10, 3, 1)))
 end
 
+@testset "Batchnorm" begin
+  v = rand(2) |> cu
+  m = rand(2, 5) |> cu
+  for training in (false, true)
+    CuArrays.CUDNN.batchnorm(v, v, m, v, v, 1.0; training=training)
+  end
+end
+
 end
 
 end


### PR DESCRIPTION
Related issue
- `batchnorm` throws error when `training=false` #463
- Batchnorm fails on GPU https://github.com/FluxML/Flux.jl/issues/385