### PR TITLE
Add deterministic option

### DIFF
--- a/src/dnn/CUDNN.jl
+++ b/src/dnn/CUDNN.jl
@@ -36,6 +36,8 @@ function handle()
     return _handle[]
 end
 
+isdeterministic() = true
+
 include("base.jl")
 include("libcudnn.jl")
 


### PR DESCRIPTION
Some of the commonly used kernels (conv and maxpool) are not deterministic by default. This hurts reproducibility a lot - when fix random seed (e.g. by `seed!(1)`) users cannot reproduce the results.

I added an option to provide default and check if a mode/algo is deterministic.