### PR TITLE
WIP: prepare cuArray for latest cuTENSOR version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 include:
   - 'https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/templates/v6.yml'
 
-image: juliagpu/cuda:10.1-cudnn7-cutensor-devel-ubuntu18.04
+image: juliagpu/cuda:10.1-cudnn7-cutensor3-devel-ubuntu18.04
 
 variables:
   JULIA_CUDA_VERBOSE: 'true'

--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -102,8 +102,8 @@ function __init__()
         # library compatibility
         if has_cutensor()
             ver = CUTENSOR.version()
-            if ver.major != 0 || ver.minor != 2
-                error("CuArrays.jl only supports CUTENSOR 0.2")
+            if ver.major != 1 || ver.minor != 0
+                error("CuArrays.jl only supports CUTENSOR 1.0")
             end
         end
 

--- a/src/tensor/CUTENSOR.jl
+++ b/src/tensor/CUTENSOR.jl
@@ -48,7 +48,7 @@ function handle()
         _handle[] = get!(_handles, active_context[]) do
             context = active_context[]
             handle = cutensorCreate()
-            atexit(()->CUDAdrv.isvalid(context) && cutensorDestroy(handle))
+            atexit(()->CUDAdrv.isvalid(context))
             handle
         end
     end

--- a/src/tensor/libcutensor.jl
+++ b/src/tensor/libcutensor.jl
@@ -6,89 +6,125 @@
 
 
 function cutensorCreate(handle)
-    @check @runtime_ccall((:cutensorCreate, libcutensor), cutensorStatus_t,
+    @check @runtime_ccall((:cutensorInit, libcutensor), cutensorStatus_t,
                  (Ptr{cutensorHandle_t},),
                  handle)
 end
 
-function cutensorDestroy(handle)
-    @check @runtime_ccall((:cutensorDestroy, libcutensor), cutensorStatus_t,
-                 (cutensorHandle_t,),
-                 handle)
+function cutensorCreateTensorDescriptor(handle, desc, numModes, extent, stride, dataType, unaryOp)
+    @check @runtime_ccall((:cutensorInitTensorDescriptor, libcutensor), cutensorStatus_t,
+                 (Ptr{cutensorHandle_t}, Ptr{cutensorTensorDescriptor_t}, UInt32, Ptr{Int64}, Ptr{Int64},
+                  cudaDataType_t, cutensorOperator_t),
+                 handle, desc, numModes, extent, stride, dataType, unaryOp)
 end
 
-function cutensorCreateTensorDescriptor(desc, numModes, extent, stride, dataType, unaryOp,
-                                        vectorWidth, vectorModeIndex)
-    @check @runtime_ccall((:cutensorCreateTensorDescriptor, libcutensor), cutensorStatus_t,
-                 (Ptr{cutensorTensorDescriptor_t}, UInt32, Ptr{Int64}, Ptr{Int64},
-                  cudaDataType_t, cutensorOperator_t, UInt32, UInt32),
-                 desc, numModes, extent, stride, dataType, unaryOp, vectorWidth,
-                 vectorModeIndex)
-end
 
-function cutensorDestroyTensorDescriptor(desc)
-    @check @runtime_ccall((:cutensorDestroyTensorDescriptor, libcutensor), cutensorStatus_t,
-                 (cutensorTensorDescriptor_t,),
-                 desc)
-end
-
-function cutensorElementwiseTrinary(handle, alpha, A, descA, modeA, beta, B, descB, modeB,
-                                    gamma, C, descC, modeC, D, descD, modeD, opAB, opABC,
-                                    typeCompute, stream)
+function cutensorElementwiseTrinary(handle,
+                                    alpha, A, descA, modeA,
+                                    beta,  B, descB, modeB,
+                                    gamma, C, descC, modeC,
+                                           D, descD, modeD,
+                                    opAB, opABC, typeCompute, stream)
     @check @runtime_ccall((:cutensorElementwiseTrinary, libcutensor), cutensorStatus_t,
-                 (cutensorHandle_t, Ptr{Cvoid}, CuPtr{Cvoid}, cutensorTensorDescriptor_t,
-                  Ptr{Int32}, Ptr{Cvoid}, CuPtr{Cvoid}, cutensorTensorDescriptor_t,
-                  Ptr{Int32}, Ptr{Cvoid}, CuPtr{Cvoid}, cutensorTensorDescriptor_t,
-                  Ptr{Int32}, CuPtr{Cvoid}, cutensorTensorDescriptor_t, Ptr{Int32},
+                 (Ptr{cutensorHandle_t},
+                  Ptr{Cvoid}, CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                  Ptr{Cvoid}, CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                  Ptr{Cvoid}, CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                              CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
                   cutensorOperator_t, cutensorOperator_t, cudaDataType_t, CUstream),
                  handle, alpha, A, descA, modeA, beta, B, descB, modeB, gamma, C, descC,
                  modeC, D, descD, modeD, opAB, opABC, typeCompute, stream)
 end
 
-function cutensorElementwiseBinary(handle, alpha, A, descA, modeA, gamma, C, descC, modeC,
-                                   D, descD, modeD, opAC, typeCompute, stream)
+function cutensorElementwiseBinary(handle,
+                                   alpha, A, descA, modeA,
+                                   gamma, C, descC, modeC,
+                                          D, descD, modeD,
+                                   opAC, typeCompute, stream)
     @check @runtime_ccall((:cutensorElementwiseBinary, libcutensor), cutensorStatus_t,
-                 (cutensorHandle_t, Ptr{Cvoid}, CuPtr{Cvoid}, cutensorTensorDescriptor_t,
-                  Ptr{Int32}, Ptr{Cvoid}, CuPtr{Cvoid}, cutensorTensorDescriptor_t,
-                  Ptr{Int32}, CuPtr{Cvoid}, cutensorTensorDescriptor_t, Ptr{Int32},
+                 (Ptr{cutensorHandle_t},
+                  Ptr{Cvoid}, CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                  Ptr{Cvoid}, CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                              CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
                   cutensorOperator_t, cudaDataType_t, CUstream),
                  handle, alpha, A, descA, modeA, gamma, C, descC, modeC, D, descD, modeD,
                  opAC, typeCompute, stream)
 end
 
-function cutensorPermutation(handle, alpha, A, descA, modeA, B, descB, modeB, typeCompute,
-                             stream)
+function cutensorPermutation(handle,
+                             alpha, A, descA, modeA,
+                                    B, descB, modeB,
+                             typeCompute, stream)
     @check @runtime_ccall((:cutensorPermutation, libcutensor), cutensorStatus_t,
-                 (cutensorHandle_t, Ptr{Cvoid}, CuPtr{Cvoid}, cutensorTensorDescriptor_t,
-                  Ptr{Int32}, CuPtr{Cvoid}, cutensorTensorDescriptor_t, Ptr{Int32},
+                 (Ptr{cutensorHandle_t},
+                  Ptr{Cvoid}, CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                              CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
                   cudaDataType_t, CUstream),
                  handle, alpha, A, descA, modeA, B, descB, modeB, typeCompute, stream)
 end
 
-function cutensorContraction(handle, alpha, A, descA, modeA, B, descB, modeB, beta, C,
-                             descC, modeC, D, descD, modeD, opOut, typeCompute, algo,
-                             workspace, workspaceSize, stream)
-    @check @runtime_ccall((:cutensorContraction, libcutensor), cutensorStatus_t,
-                 (cutensorHandle_t, Ptr{Cvoid}, CuPtr{Cvoid}, cutensorTensorDescriptor_t,
-                  Ptr{Int32}, CuPtr{Cvoid}, cutensorTensorDescriptor_t, Ptr{Int32},
-                  Ptr{Cvoid}, CuPtr{Cvoid}, cutensorTensorDescriptor_t, Ptr{Int32},
-                  CuPtr{Cvoid}, cutensorTensorDescriptor_t, Ptr{Int32}, cutensorOperator_t,
-                  cudaDataType_t, cutensorAlgo_t, CuPtr{Cvoid}, UInt64, CUstream),
-                 handle, alpha, A, descA, modeA, B, descB, modeB, beta, C, descC, modeC, D,
-                 descD, modeD, opOut, typeCompute, algo, workspace, workspaceSize, stream)
+function cutensorInitContractionDescriptor(handle,
+                   desc,
+                   descA, modeA, alignmentRequirementA,
+                   descB, modeB, alignmentRequirementB,
+                   descC, modeC, alignmentRequirementC,
+                   descD, modeD, alignmentRequirementD,
+                   computeType)
+    @check @runtime_ccall((:cutensorInitContractionDescriptor, libcutensor), cutensorStatus_t,
+                  (Ptr{cutensorHandle_t}, Ptr{cutensorContractionDescriptor_t},
+                  Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, UInt32,
+                  Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, UInt32,
+                  Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, UInt32,
+                  Ptr{cutensorTensorDescriptor_t}, Ptr{Int32}, UInt32,
+                  cutensorComputeType_t), handle,
+                   desc,
+                   descA, modeA, alignmentRequirementA,
+                   descB, modeB, alignmentRequirementB,
+                   descC, modeC, alignmentRequirementC,
+                   descD, modeD, alignmentRequirementD,
+                   computeType)
+
 end
 
-function cutensorContractionGetWorkspace(handle, A, descA, modeA, B, descB, modeB, C,
-                                         descC, modeC, D, descD, modeD, opOut, typeCompute,
-                                         algo, pref, workspaceSize)
+function cutensorInitContractionFind(handle, find, algo)
+    @check @runtime_ccall((:cutensorInitContractionFind, libcutensor), cutensorStatus_t,
+                 (Ptr{cutensorHandle_t},
+                  Ptr{cutensorContractionFind_t},
+                  cutensorAlgo_t), handle, find, algo)
+end
+
+function cutensorContractionGetWorkspace(handle, desc, find, pref, workspaceSize)
     @check @runtime_ccall((:cutensorContractionGetWorkspace, libcutensor), cutensorStatus_t,
-                 (cutensorHandle_t, CuPtr{Cvoid}, cutensorTensorDescriptor_t, Ptr{Int32},
-                  CuPtr{Cvoid}, cutensorTensorDescriptor_t, Ptr{Int32}, CuPtr{Cvoid},
-                  cutensorTensorDescriptor_t, Ptr{Int32}, CuPtr{Cvoid},
-                  cutensorTensorDescriptor_t, Ptr{Int32}, cutensorOperator_t,
-                  cudaDataType_t, cutensorAlgo_t, cutensorWorksizePreference_t, Ptr{UInt64}),
-                 handle, A, descA, modeA, B, descB, modeB, C, descC, modeC, D, descD,
-                 modeD, opOut, typeCompute, algo, pref, workspaceSize)
+                          (Ptr{cutensorHandle_t},
+                           Ptr{cutensorContractionDescriptor_t},
+                           Ptr{cutensorContractionFind_t}, cutensorWorksizePreference_t, Ptr{UInt64}),
+                 handle, desc, find, pref, workspaceSize)
+end
+
+function cutensorInitContractionPlan(handle, plan, desc, find, workspaceSize)
+    @check @runtime_ccall((:cutensorInitContractionPlan, libcutensor), cutensorStatus_t,
+                          (Ptr{cutensorHandle_t},
+                           Ptr{cutensorContractionPlan_t},
+                           Ptr{cutensorContractionDescriptor_t},
+                           Ptr{cutensorContractionFind_t},
+                           UInt64), handle, plan, desc, find, workspaceSize)
+end
+
+function cutensorContraction(handle, plan,
+                             alpha, A, B,
+                             beta,  C, D,
+                             workspace, workspaceSize, stream)
+    @check @runtime_ccall((:cutensorContraction, libcutensor), cutensorStatus_t,
+                          (Ptr{cutensorHandle_t},
+                           Ptr{cutensorContractionPlan_t},
+                           Ptr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid},
+                           Ptr{Cvoid}, CuPtr{Cvoid}, CuPtr{Cvoid},
+                           CuPtr{Cvoid}, UInt64, CUstream),
+                             handle, plan,
+                             alpha, A, B,
+                             beta,  C, D,
+                             workspace, workspaceSize, stream)
+
 end
 
 function cutensorContractionMaxAlgos(maxNumAlgos)
@@ -97,12 +133,16 @@ function cutensorContractionMaxAlgos(maxNumAlgos)
                  maxNumAlgos)
 end
 
-function cutensorReduction(handle, alpha, A, descA, modeA, beta, C, descC, modeC, D, descD,
-                           modeD, opReduce, typeCompute, workspace, workspaceSize, stream)
+function cutensorReduction(handle,
+                           alpha, A, descA, modeA,
+                           beta,  C, descC, modeC,
+                                  D, descD, modeD,
+                           opReduce, typeCompute, workspace, workspaceSize, stream)
     @check @runtime_ccall((:cutensorReduction, libcutensor), cutensorStatus_t,
-                 (cutensorHandle_t, Ptr{Cvoid}, CuPtr{Cvoid}, cutensorTensorDescriptor_t,
-                  Ptr{Int32}, Ptr{Cvoid}, CuPtr{Cvoid}, cutensorTensorDescriptor_t,
-                  Ptr{Int32}, CuPtr{Cvoid}, cutensorTensorDescriptor_t, Ptr{Int32},
+                  (Ptr{cutensorHandle_t},
+                   Ptr{Cvoid}, CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                   Ptr{Cvoid}, CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                               CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
                   cutensorOperator_t, cudaDataType_t, CuPtr{Cvoid}, UInt64, CUstream),
                  handle, alpha, A, descA, modeA, beta, C, descC, modeC, D, descD, modeD,
                  opReduce, typeCompute, workspace, workspaceSize, stream)
@@ -111,12 +151,20 @@ end
 function cutensorReductionGetWorkspace(handle, A, descA_, modeA, C, descC_, modeC, D,
                                        descD_, modeD, opReduce, typeCompute, workspaceSize)
     @check @runtime_ccall((:cutensorReductionGetWorkspace, libcutensor), cutensorStatus_t,
-                 (cutensorHandle_t, CuPtr{Cvoid}, cutensorTensorDescriptor_t, Ptr{Int32},
-                  CuPtr{Cvoid}, cutensorTensorDescriptor_t, Ptr{Int32}, CuPtr{Cvoid},
-                  cutensorTensorDescriptor_t, Ptr{Int32}, cutensorOperator_t,
-                  cudaDataType_t, Ptr{UInt64}),
-                 handle, A, descA_, modeA, C, descC_, modeC, D, descD_, modeD, opReduce,
-                 typeCompute, workspaceSize)
+                  (Ptr{cutensorHandle_t},
+                  CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                  CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                  CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{Int32},
+                  cutensorOperator_t, cudaDataType_t, Ptr{UInt64}),
+                 handle, A, descA_, modeA,
+                         C, descC_, modeC,
+                         D, descD_, modeD, opReduce, typeCompute, workspaceSize)
+end
+
+function cutensorGetAlignmentRequirement(handle, ptr, desc, alignmentRequirement)
+    @check @runtime_ccall((:cutensorGetAlignmentRequirement, libcutensor), cutensorStatus_t,
+                 (Ptr{cutensorHandle_t},
+                  CuPtr{Cvoid}, Ptr{cutensorTensorDescriptor_t}, Ptr{UInt32}), handle, ptr,desc, alignmentRequirement)
 end
 
 function cutensorGetErrorString(error)

--- a/src/tensor/libcutensor_common.jl
+++ b/src/tensor/libcutensor_common.jl
@@ -32,13 +32,23 @@ end
 end
 
 @cenum cutensorAlgo_t::Int32 begin
-    CUTENSOR_ALGO_TGETT = -7
-    CUTENSOR_ALGO_GETT = -6
-    CUTENSOR_ALGO_LOG_TENSOR_OP = -5
-    CUTENSOR_ALGO_LOG = -4
-    CUTENSOR_ALGO_TTGT_TENSOR_OP = -3
+    CUTENSOR_ALGO_GETT = -4
+    CUTENSOR_ALGO_TGETT = -3
     CUTENSOR_ALGO_TTGT = -2
     CUTENSOR_ALGO_DEFAULT = -1
+end
+
+@cenum cutensorComputeType_t::Int32 begin
+    CUTENSOR_R_MIN_16F = 1
+    CUTENSOR_C_MIN_16F = 2
+    CUTENSOR_R_MIN_32F = 4
+    CUTENSOR_C_MIN_32F = 8
+    CUTENSOR_R_MIN_64F = 16
+    CUTENSOR_C_MIN_64F = 32
+    CUTENSOR_R_MIN_8U  = 64
+    CUTENSOR_R_MIN_32U = 128
+    CUTENSOR_R_MIN_8I  = 256
+    CUTENSOR_R_MIN_32I = 512
 end
 
 @cenum cutensorWorksizePreference_t::UInt32 begin
@@ -50,6 +60,6 @@ end
 
 const cutensorHandle_t = Ptr{Cvoid}
 const cutensorTensorDescriptor_t = Ptr{Cvoid}
-const CUTENSOR_MAJOR = 0
-const CUTENSOR_MINOR = 2
-const CUTENSOR_PATCH = 2
+const CUTENSOR_MAJOR = 1
+const CUTENSOR_MINOR = 0
+const CUTENSOR_PATCH = 0


### PR DESCRIPTION
This PR is work-in-progress.

@maleadt @kshyatt @Jutho  could you please have a look at the tensor/wrapper.jl (especially the contraction function)?

I'm fully aware that this is not yet working, however, I think that I've wrapped the latest API properly and also updated the contraction function to reflect the new API.

The one thing that stands out most w.r.t. the latest cuTENSOR version is that all types no longer are pointers but structs of a fixed size. This requires that all those arguments must be passed in as pointers now.