### PR TITLE
Don't needlessly populate the DL_LOAD_PATH.

### DIFF
--- a/src/CuArrays.jl
+++ b/src/CuArrays.jl
@@ -78,10 +78,16 @@ function __init__()
             lib = Symbol("lib$name")
             path = find_cuda_library(name, toolkit)
             libraries[name] = path
+
+            # only push the load path if we couldn't find the library
             if path !== nothing
-                dir = dirname(path)
-                if !(dir in Libdl.DL_LOAD_PATH)
-                    push!(Libdl.DL_LOAD_PATH, dir)
+                file = basename(path)
+                handle = first(split(file,'.'))
+                if Libdl.dlopen_e(handle) == C_NULL
+                    dir = dirname(path)
+                    if !(dir in Libdl.DL_LOAD_PATH)
+                        push!(Libdl.DL_LOAD_PATH, dir)
+                    end
                 end
             end
         end


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/CuArrays.jl/issues/498

```
julia> using CUDAdrv

julia> using Libdl

julia> Libdl.dlpath(Libdl.dlopen(:libcuda))
"/.singularity.d/libs/libcuda.so"

julia> ENV["JULIA_CUDA_VERBOSE"] = true
true

julia> using CuArrays
[ Info: Precompiling CuArrays [3a865a2d-5b23-5a0f-bc46-62713ec82fae]

julia> Libdl.dlpath(Libdl.dlopen(:libcuda))
"/.singularity.d/libs/libcuda.so"

julia> CuArray([1])
1-element CuArray{Int64,1,Nothing}:
 1

```

@oschulz I suggest you get rid of the multiple `libcuda.so`'s though :-)