### PR TITLE
Adding missing `cudnnSetConvolutionGroupCount` to pointers.json

### DIFF
--- a/res/wrap/pointers.json
+++ b/res/wrap/pointers.json
@@ -1695,6 +1695,10 @@
         "convDesc": null,
         "groupCount": "Ptr"
     },
+    "cudnnSetConvolutionGroupCount": {
+        "convDesc": null,
+        "groupCount": null
+    },
     "cublasCreate_v2": {
         "handle": "Ptr"
     },


### PR DESCRIPTION
This change is necessary for setting `groupcount` incase of depthwise and groupwise convolutions.

The original cudnn api is as follows:

`cudnnStatus_t cudnnSetConvolutionGroupCount(  `
`  cudnnConvolutionDescriptor_t    convDesc,  ` 
` int                             groupCount)`