### PR TITLE
RFC: Allow cu to operate on Array types

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -286,7 +286,8 @@ end
 ## utilities
 
 cu(xs) = adapt(CuArray{Float32}, xs)
-cu(::Type{Array{T,N}}) where {T,N} = CuArray{T,N}
+cu(::Type{Array{T,N}}) where {T,N} = CuArray{T,N,Nothing}
+cu(::Type{Array{T}}) where {T} = CuArray{T}
 Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
 
 zeros(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 0)

--- a/src/array.jl
+++ b/src/array.jl
@@ -286,6 +286,7 @@ end
 ## utilities
 
 cu(xs) = adapt(CuArray{Float32}, xs)
+cu(::Type{Array{T,N}}) where {T,N} = CuArray{T,N}
 Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
 
 zeros(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 0)

--- a/test/base.jl
+++ b/test/base.jl
@@ -39,8 +39,8 @@ end
   @test cu(1:3) === 1:3
   @test Base.elsize(xs) == sizeof(Int)
   @test CuArray{Int, 2}(xs) === xs
-  @test cu(Array{Float64,1}) == CuArray{Float64,1}
-  @test cu(Array{Float64,4}) == CuArray{Float64,4}
+  @test cu(Array{Float64,1}) == CuArray{Float64,1, Nothing}
+  @test cu(Array{Float64,4}) == CuArray{Float64,4, Nothing}
   @test cu(Array{Float64}) == CuArray{Float64}
 
   @test_throws ArgumentError Base.unsafe_convert(Ptr{Int}, xs)

--- a/test/base.jl
+++ b/test/base.jl
@@ -39,6 +39,9 @@ end
   @test cu(1:3) === 1:3
   @test Base.elsize(xs) == sizeof(Int)
   @test CuArray{Int, 2}(xs) === xs
+  @test cu(Array{Float64,1}) == CuArray{Float64,1}
+  @test cu(Array{Float64,4}) == CuArray{Float64,4}
+  @test cu(Array{Float64}) == CuArray{Float64}
 
   @test_throws ArgumentError Base.unsafe_convert(Ptr{Int}, xs)
   @test_throws ArgumentError Base.unsafe_convert(Ptr{Float32}, xs)


### PR DESCRIPTION
With this pr we have
```
julia> a = randn(2,2)
2×2 Array{Float64,2}:
 0.393718  -1.0575  
 2.1653    -0.835585

julia> cu(a)
2×2 CuArray{Float32,2,Nothing}:
 0.393718  -1.0575  
 2.1653    -0.835585

julia> cu(typeof(a))
CuArray{Float64,2,P} where P
```
Would it perhaps be better to have `CuArray{Float64,2,Nothing}`?