### PR TITLE
Preserve the pooled property when deriving a CuArray.

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -27,7 +27,7 @@ end
 
 # derived array (e.g. view, reinterpret, ...)
 function CuArray{T,N}(ptr::CuPtr{T}, dims::Dims{N}, parent::P) where {T,N,P<:CuArray}
-  self = CuArray{T,N,P}(ptr, dims, parent, false, parent.ctx)
+  self = CuArray{T,N,P}(ptr, dims, parent, parent.pooled, parent.ctx)
   retain(self)
   retain(parent)
   finalizer(unsafe_free!, self)


### PR DESCRIPTION
Not currently used, but seems consistent.