### PR TITLE
Revert to simpler GC.gc API.

### DIFF
--- a/src/memory/binned.jl
+++ b/src/memory/binned.jl
@@ -201,7 +201,7 @@ function pool_alloc(bytes, pid=-1)
   end
 
   @pool_timeit "2. gc (incremental)" begin
-    GC.gc(VERSION >= v"1.4.0-DEV.257" ? GC.Incremental : false)
+    GC.gc(false)
   end
 
   if pid != -1 && !isempty(pools_avail[pid])
@@ -222,7 +222,7 @@ function pool_alloc(bytes, pid=-1)
   end
 
   @pool_timeit "5. gc (full)" begin
-    GC.gc(VERSION >= v"1.4.0-DEV.257" ? GC.Full : true)
+    GC.gc(true)
   end
 
   if pid != -1 && !isempty(pools_avail[pid])

--- a/src/memory/dummy.jl
+++ b/src/memory/dummy.jl
@@ -14,9 +14,9 @@ function alloc(sz)
     ptr = nothing
     for phase in 1:3
         if phase == 2
-            @pool_timeit "$phase.0 gc (incremental)" GC.gc(VERSION >= v"1.4.0-DEV.257" ? GC.Incremental : false)
+            @pool_timeit "$phase.0 gc (incremental)" GC.gc(false)
         elseif phase == 3
-            @pool_timeit "$phase.0 gc (full)" GC.gc(VERSION >= v"1.4.0-DEV.257" ? GC.Full : true)
+            @pool_timeit "$phase.0 gc (full)" GC.gc(true)
         end
 
         @pool_timeit "$phase.1 alloc" begin

--- a/src/memory/simple.jl
+++ b/src/memory/simple.jl
@@ -74,9 +74,9 @@ function pool_alloc(sz)
     block = nothing
     for phase in 1:3
         if phase == 2
-            @pool_timeit "$phase.0 gc (incremental)" GC.gc(VERSION >= v"1.4.0-DEV.257" ? GC.Incremental : false)
+            @pool_timeit "$phase.0 gc (incremental)" GC.gc(false)
         elseif phase == 3
-            @pool_timeit "$phase.0 gc (full)" GC.gc(VERSION >= v"1.4.0-DEV.257" ? GC.Full : true)
+            @pool_timeit "$phase.0 gc (full)" GC.gc(true)
         end
 
         @pool_timeit "$phase.1 scan" begin

--- a/src/memory/split.jl
+++ b/src/memory/split.jl
@@ -328,9 +328,9 @@ function pool_alloc(sz)
     block = nothing
     for phase in 1:3
         if phase == 2
-            @pool_timeit "$phase.0 gc (incremental)" GC.gc(VERSION >= v"1.4.0-DEV.257" ? GC.Incremental : false)
+            @pool_timeit "$phase.0 gc (incremental)" GC.gc(false)
         elseif phase == 3
-            @pool_timeit "$phase.0 gc (full)" GC.gc(VERSION >= v"1.4.0-DEV.257" ? GC.Full : true)
+            @pool_timeit "$phase.0 gc (full)" GC.gc(true)
         end
 
         if !isempty(freed)


### PR DESCRIPTION
On the latest Julia this API is equivalent to the explicit use.
Ref JuliaLang/julia#34303