### PR TITLE
Implement a few sparse array basics

### DIFF
--- a/src/sparse/array.jl
+++ b/src/sparse/array.jl
@@ -14,7 +14,7 @@ import LinearAlgebra: BlasFloat, Hermitian, HermOrSym, issymmetric, Transpose, A
     ishermitian, istriu, istril, Symmetric, UpperTriangular, LowerTriangular
 
 using SparseArrays
-import SparseArrays: sparse, SparseMatrixCSC
+import SparseArrays: sparse, SparseMatrixCSC, nnz, nonzeros, nonzeroinds
 
 abstract type AbstractCuSparseArray{Tv, N} <: AbstractSparseArray{Tv, Cint, N} end
 const AbstractCuSparseVector{Tv} = AbstractCuSparseArray{Tv,1}
@@ -165,6 +165,11 @@ function size(g::CuSparseMatrix, d::Integer)
         throw(ArgumentError("dimension must be ≥ 1, got $d"))
     end
 end
+
+nnz(g::AbstractCuSparseArray) = g.nnz
+nonzeros(g::AbstractCuSparseArray) = g.nzVal
+
+nonzeroinds(g::AbstractCuSparseVector) = g.iPtr
 
 issymmetric(M::Union{CuSparseMatrixCSC,CuSparseMatrixCSR}) = false
 ishermitian(M::Union{CuSparseMatrixCSC,CuSparseMatrixCSR}) = false

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -18,6 +18,10 @@ blockdim = 5
     @test size(d_x,1) == m
     @test size(d_x,2) == 1
     @test ndims(d_x)  == 1
+    @test nnz(d_x)    == nnz(x)
+    @test Array(nonzeros(d_x)) == nonzeros(x)
+    @test Array(SparseArrays.nonzeroinds(d_x)) == SparseArrays.nonzeroinds(x)
+    @test nnz(d_x)    == length(nonzeros(d_x))
     x = sprand(m,n,0.2)
     d_x = CuSparseMatrixCSC(x)
     @test length(d_x) == m*n
@@ -26,6 +30,9 @@ blockdim = 5
     @test size(d_x,2) == n
     @test size(d_x,3) == 1
     @test ndims(d_x)  == 2
+    @test nnz(d_x)    == nnz(x)
+    @test Array(nonzeros(d_x)) == nonzeros(x)
+    @test nnz(d_x)    == length(nonzeros(d_x))
     @test !issymmetric(d_x)
     @test !ishermitian(d_x)
     @test_throws ArgumentError size(d_x,0)

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -18,6 +18,15 @@ blockdim = 5
     @test size(d_x,1) == m
     @test size(d_x,2) == 1
     @test ndims(d_x)  == 1
+    CuArrays.@allowscalar begin
+        @test Array(d_x[:])        == x[:]
+        @test d_x[firstindex(d_x)] == x[firstindex(x)]
+        @test d_x[div(end, 2)]     == x[div(end, 2)]
+        @test d_x[end]             == x[end]
+        @test Array(d_x[firstindex(d_x):end]) == x[firstindex(x):end]
+    end
+    @test_throws BoundsError d_x[firstindex(d_x) - 1]
+    @test_throws BoundsError d_x[end + 1]
     @test nnz(d_x)    == nnz(x)
     @test Array(nonzeros(d_x)) == nonzeros(x)
     @test Array(SparseArrays.nonzeroinds(d_x)) == SparseArrays.nonzeroinds(x)
@@ -30,6 +39,26 @@ blockdim = 5
     @test size(d_x,2) == n
     @test size(d_x,3) == 1
     @test ndims(d_x)  == 2
+    CuArrays.@allowscalar begin
+        @test Array(d_x[:])        == x[:]
+        @test d_x[firstindex(d_x)] == x[firstindex(x)]
+        @test d_x[div(end, 2)]     == x[div(end, 2)]
+        @test d_x[end]             == x[end]
+        @test d_x[firstindex(d_x), firstindex(d_x)] == x[firstindex(x), firstindex(x)]
+        @test d_x[div(end, 2), div(end, 2)]         == x[div(end, 2), div(end, 2)]
+        @test d_x[end, end]        == x[end, end]
+        @test Array(d_x[firstindex(d_x):end, firstindex(d_x):end]) == x[:, :]
+    end
+    @test_throws BoundsError d_x[firstindex(d_x) - 1]
+    @test_throws BoundsError d_x[end + 1]
+    @test_throws BoundsError d_x[firstindex(d_x) - 1, firstindex(d_x) - 1]
+    @test_throws BoundsError d_x[end + 1, end + 1]
+    @test_throws BoundsError d_x[firstindex(d_x) - 1:end + 1, :]
+    @test_throws BoundsError d_x[firstindex(d_x) - 1, :]
+    @test_throws BoundsError d_x[end + 1, :]
+    @test_throws BoundsError d_x[:, firstindex(d_x) - 1:end + 1]
+    @test_throws BoundsError d_x[:, firstindex(d_x) - 1]
+    @test_throws BoundsError d_x[:, end + 1]
     @test nnz(d_x)    == nnz(x)
     @test Array(nonzeros(d_x)) == nonzeros(x)
     @test nnz(d_x)    == length(nonzeros(d_x))


### PR DESCRIPTION
Namely `getindex`, `nnz`, `nonzeros` and `nonzeroinds`. These also fix the `show` methods for `SparseCuVector` and `SparseCuMatrixCS{C,R}` (albeit using scalar indexing). 

#451