### PR TITLE
Nerf cu

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -312,8 +312,6 @@ end
 ## utilities
 
 cu(xs) = adapt(CuArray{Float32}, xs)
-cu(::Type{Array{T,N}}) where {T,N} = CuArray{T,N,Nothing}
-cu(::Type{Array{T}}) where {T} = CuArray{T}
 Base.getindex(::typeof(cu), xs...) = CuArray([xs...])
 
 zeros(T::Type, dims...) = fill!(CuArray{T}(undef, dims...), 0)

--- a/src/dnn/rnn.jl
+++ b/src/dnn/rnn.jl
@@ -8,7 +8,7 @@
 # GRU: [weight, bias] × [input, hidden] × [reset, update, newmem]
 # LSTM: [weight, bias] × [input, hidden] × [input, forget, newmem, output]
 
-using LinearAlgebra: copy_transpose!
+using LinearAlgebra
 
 function params(w::CuVector, input, hidden, n = 1)
   slice(offset, shape) = reshape(view(w, offset.+(1:prod(shape))), shape)

--- a/test/base.jl
+++ b/test/base.jl
@@ -40,6 +40,10 @@ end
   @test Base.elsize(xs) == sizeof(Int)
   @test CuArray{Int, 2}(xs) === xs
 
+  # test aggressive conversion to Float32, but only for floats
+  @test cu([1]) isa AbstractArray{Int}
+  @test cu(Float64[1]) isa AbstractArray{Float32}
+
   @test_throws ArgumentError Base.unsafe_convert(Ptr{Int}, xs)
   @test_throws ArgumentError Base.unsafe_convert(Ptr{Float32}, xs)
 

--- a/test/base.jl
+++ b/test/base.jl
@@ -39,9 +39,6 @@ end
   @test cu(1:3) === 1:3
   @test Base.elsize(xs) == sizeof(Int)
   @test CuArray{Int, 2}(xs) === xs
-  @test cu(Array{Float64,1}) == CuArray{Float64,1, Nothing}
-  @test cu(Array{Float64,4}) == CuArray{Float64,4, Nothing}
-  @test cu(Array{Float64}) == CuArray{Float64}
 
   @test_throws ArgumentError Base.unsafe_convert(Ptr{Int}, xs)
   @test_throws ArgumentError Base.unsafe_convert(Ptr{Float32}, xs)

--- a/test/base.jl
+++ b/test/base.jl
@@ -242,6 +242,9 @@ end
   @test testf((x,y)->copyto!(y, selectdim(x, 2, 1)), ones(2,2,2), zeros(2,2))
   ## inability to copyto! smaller destination
   @test testf((x,y)->copyto!(y, selectdim(x, 2, 1)), ones(2,2,2), zeros(3,3))
+
+  # but in conversion of indices (#506)
+  show(devnull, cu(view(ones(1), [1])))
 end
 
 @testset "reshape" begin


### PR DESCRIPTION
Make it more reasonable, and only convert to Float32 when dealing with arrays of floats.
Fixes https://github.com/JuliaGPU/CuArrays.jl/issues/506, where the integer SubArray indices were converted to Float32 too.

Also reverts https://github.com/JuliaGPU/CuArrays.jl/pull/522, because I realized it was wrong (not honoring the special Float32 conversion rules). @baggepinnen, why did you need this? The `adapt`-based functionality is inherently value based. However, `adapt(CuArray, ...)` not behaves as expected, so maybe you can use that?