### PR TITLE
RNN: Don't transpose 1D vectors.

### DIFF
--- a/src/dnn/rnn.jl
+++ b/src/dnn/rnn.jl
@@ -61,7 +61,7 @@ end
 function setweights!(d::RNNDesc, Wi, Wh, b)
   transpose!(d.weights[1], Wi)
   transpose!(d.weights[2], Wh)
-  transpose!(d.bias, b)
+  copyto!(d.bias, b)
   return
 end
 


### PR DESCRIPTION
`bias` as well as the `b` argument are `CuVector`s. The old transpose implementation allowed that, but that wasn't right.

We _really_ should have some tests for this functionality, this only triggered by testing Flux.