### PR TITLE
RFC: provide a function to generate a contraction plan, and let contraction use it

### DIFF
--- a/src/tensor/wrappers.jl
+++ b/src/tensor/wrappers.jl
@@ -261,7 +261,7 @@ function contraction!(
     return C
 end
 
-function contraction_plan(
+function plan_contraction(
     A::CuArray, Ainds::ModeType, opA::cutensorOperator_t,
     B::CuArray, Binds::ModeType, opB::cutensorOperator_t,
     C::CuArray, Cinds::ModeType, opC::cutensorOperator_t,

--- a/test/tensor.jl
+++ b/test/tensor.jl
@@ -457,7 +457,7 @@ end
             opB = CUTENSOR.CUTENSOR_OP_IDENTITY
             opC = CUTENSOR.CUTENSOR_OP_IDENTITY
             opOut = CUTENSOR.CUTENSOR_OP_IDENTITY
-            plan = CUTENSOR.contraction_plan(dA, indsA, opA, dB, indsB, opB, dC, indsC, opC, opOut)
+            plan  = CUTENSOR.plan_contraction(dA, indsA, opA, dB, indsB, opB, dC, indsC, opC, opOut)
             dC = CUTENSOR.contraction!(1, dA, indsA, opA, dB, indsB, opB,
                                         0, dC, indsC, opC, opOut, plan=plan)
             C = collect(dC)

--- a/test/tensor.jl
+++ b/test/tensor.jl
@@ -452,6 +452,18 @@ end
             mC = reshape(permutedims(C, ipC), (loA, loB))
             @test mC ≈ mA * mB
             
+            # simple case with plan storage
+            opA = CUTENSOR.CUTENSOR_OP_IDENTITY
+            opB = CUTENSOR.CUTENSOR_OP_IDENTITY
+            opC = CUTENSOR.CUTENSOR_OP_IDENTITY
+            opOut = CUTENSOR.CUTENSOR_OP_IDENTITY
+            plan = CUTENSOR.contraction_plan(dA, indsA, opA, dB, indsB, opB, dC, indsC, opC, opOut)
+            dC = CUTENSOR.contraction!(1, dA, indsA, opA, dB, indsB, opB,
+                                        0, dC, indsC, opC, opOut, plan=plan)
+            C = collect(dC)
+            mC = reshape(permutedims(C, ipC), (loA, loB))
+            @test mC ≈ mA * mB
+            
             # with non-trivial α
             α = rand(eltyC)
             dC = CUTENSOR.contraction!(α, dA, indsA, opA, dB, indsB, opB,


### PR DESCRIPTION
The idea is to let people take advantage of CUTENSOR's plan generation and reuse, if they want. If they don't provide a plan, CUTENSOR will just make one for them.