### PR TITLE
Support for Julia's multitasking.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,12 +39,30 @@ uuid = "c5f51814-7f29-56b8-a69c-e4d8f6be1fde"
 version = "6.2.0"
 
 [[CUDAnative]]
-deps = ["Adapt", "BinaryProvider", "CEnum", "CUDAapi", "CUDAdrv", "DataStructures", "InteractiveUtils", "LLVM", "Libdl", "MacroTools", "Pkg", "Printf", "TimerOutputs"]
-git-tree-sha1 = "e6742ce88d11f1fdf6a9357ba738735f86ce67b5"
-repo-rev = "58c6755445c05ff26f1bdc5c12c7ae0aa6c39bc2"
+deps = ["Adapt", "BinaryProvider", "CEnum", "CUDAapi", "CUDAdrv", "Cthulhu", "DataStructures", "InteractiveUtils", "LLVM", "Libdl", "MacroTools", "Pkg", "Printf", "TimerOutputs"]
+git-tree-sha1 = "e4133b359749007061751150b2f3739bac009ff0"
+repo-rev = "tb/multitasking"
 repo-url = "https://github.com/JuliaGPU/CUDAnative.jl.git"
 uuid = "be33ccc6-a3ff-5ff2-a52e-74243cff1e17"
 version = "2.10.2"
+
+[[CodeTracking]]
+deps = ["InteractiveUtils", "UUIDs"]
+git-tree-sha1 = "0becdab7e6fbbcb7b88d8de5b72e5bb2f28239f3"
+uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
+version = "0.5.8"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "ed2c4abadf84c53d9e58510b5fc48912c2336fbb"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "2.2.0"
+
+[[Cthulhu]]
+deps = ["CodeTracking", "InteractiveUtils", "TerminalMenus", "Unicode"]
+git-tree-sha1 = "5e0f928ccaab1fa2911fc4e204e8a6f5b0213eaf"
+uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
+version = "1.0.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
@@ -55,6 +73,10 @@ version = "0.17.10"
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -100,6 +122,9 @@ version = "0.5.4"
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[NNlib]]
 deps = ["BinaryProvider", "Libdl", "LinearAlgebra", "Requires", "Statistics"]
@@ -147,6 +172,10 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
@@ -157,6 +186,12 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[TerminalMenus]]
+deps = ["Compat", "REPL", "Test"]
+git-tree-sha1 = "9ae6ed0c94eee4d898e049820942af21daf15efc"
+uuid = "dc548174-15c3-5faf-af27-7997cfbde655"
+version = "0.1.0"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]

--- a/src/blas/CUBLAS.jl
+++ b/src/blas/CUBLAS.jl
@@ -25,68 +25,64 @@ include("wrappers.jl")
 # high-level integrations
 include("linalg.jl")
 
-const handles_lock = ReentrantLock()
-const created_handles = Dict{Tuple{UInt,Int},cublasHandle_t}()
-const created_xt_handles = Dict{Tuple{UInt,Int},cublasXtHandle_t}()
-const active_handles = Vector{Union{Nothing,cublasHandle_t}}()
-const active_xt_handles = Vector{Union{Nothing,cublasXtHandle_t}}()
+# thread cache for task-local library handles
+const thread_handles = Vector{Union{Nothing,cublasHandle_t}}()
+const thread_xt_handles = Vector{Union{Nothing,cublasXtHandle_t}}()
 
 function handle()
     tid = Threads.threadid()
-    if @inbounds active_handles[tid] === nothing
+    if @inbounds thread_handles[tid] === nothing
         ctx = context()
-        key = (objectid(ctx), tid)
-        lock(handles_lock) do
-            active_handles[tid] = get!(created_handles, key) do
-                handle = cublasCreate_v2()
-                atexit(()->CUDAdrv.isvalid(ctx) && cublasDestroy_v2(handle))
+        thread_handles[tid] = get!(task_local_storage(), (:CUBLAS, ctx)) do
+            handle = cublasCreate_v2()
+            atexit(()->CUDAdrv.isvalid(ctx) && cublasDestroy_v2(handle))
 
-                # enable tensor math mode if our device supports it, and fast math is enabled
-                dev = CUDAdrv.device()
-                if Base.JLOptions().fast_math == 1 && CUDAdrv.capability(dev) >= v"7.0" && version() >= v"9"
-                    cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH)
-                end
-
-                handle
+            # enable tensor math mode if our device supports it, and fast math is enabled
+            dev = CUDAdrv.device()
+            if Base.JLOptions().fast_math == 1 && CUDAdrv.capability(dev) >= v"7.0" && version() >= v"9"
+                cublasSetMathMode(handle, CUBLAS_TENSOR_OP_MATH)
             end
+
+            handle
         end
     end
-    @inbounds active_handles[tid]
+    @inbounds thread_handles[tid]
 end
 
 function xt_handle()
     tid = Threads.threadid()
-    if @inbounds active_xt_handles[tid] === nothing
+    if @inbounds thread_xt_handles[tid] === nothing
         ctx = context()
-        key = (objectid(ctx), tid)
-        lock(handles_lock) do
-            active_xt_handles[tid] = get!(created_xt_handles, key) do
-                handle = cublasXtCreate()
-                atexit(()->CUDAdrv.isvalid(ctx) && cublasXtDestroy(handle))
+        thread_xt_handles[tid] = get!(task_local_storage(), (:CUBLASxt, ctx)) do
+            handle = cublasXtCreate()
+            atexit(()->CUDAdrv.isvalid(ctx) && cublasXtDestroy(handle))
 
-                # select the devices
-                # TODO: this is weird, since we typically use a single device per thread/context
-                devs = convert.(Cint, CUDAdrv.devices())
-                cublasXtDeviceSelect(handle, length(devs), devs)
+            # select the devices
+            # TODO: this is weird, since we typically use a single device per thread/context
+            devs = convert.(Cint, CUDAdrv.devices())
+            cublasXtDeviceSelect(handle, length(devs), devs)
 
-                handle
-            end
+            handle
         end
     end
-    @inbounds active_xt_handles[tid]
+    @inbounds thread_xt_handles[tid]
 end
 
 function __init__()
-    resize!(active_handles, Threads.nthreads())
-    fill!(active_handles, nothing)
+    resize!(thread_handles, Threads.nthreads())
+    fill!(thread_handles, nothing)
 
-    resize!(active_xt_handles, Threads.nthreads())
-    fill!(active_xt_handles, nothing)
+    resize!(thread_xt_handles, Threads.nthreads())
+    fill!(thread_xt_handles, nothing)
 
     CUDAnative.atcontextswitch() do tid, ctx
-        # we don't eagerly initialize handles, but do so lazily when requested
-        active_handles[tid] = nothing
-        active_xt_handles[tid] = nothing
+        thread_handles[tid] = nothing
+        thread_xt_handles[tid] = nothing
+    end
+
+    CUDAnative.attaskswitch() do tid, task
+        thread_handles[tid] = nothing
+        thread_xt_handles[tid] = nothing
     end
 end
 

--- a/src/blas/CUBLAS.jl
+++ b/src/blas/CUBLAS.jl
@@ -35,7 +35,7 @@ function handle()
         ctx = context()
         thread_handles[tid] = get!(task_local_storage(), (:CUBLAS, ctx)) do
             handle = cublasCreate_v2()
-            atexit() do
+            finalizer(current_task()) do task
                 CUDAdrv.isvalid(ctx) || return
                 context!(ctx) do
                     cublasDestroy_v2(handle)
@@ -60,7 +60,7 @@ function xt_handle()
         ctx = context()
         thread_xt_handles[tid] = get!(task_local_storage(), (:CUBLASxt, ctx)) do
             handle = cublasXtCreate()
-            atexit() do
+            finalizer(current_task()) do task
                 CUDAdrv.isvalid(ctx) || return
                 context!(ctx) do
                     cublasXtDestroy(handle)

--- a/src/blas/error.jl
+++ b/src/blas/error.jl
@@ -48,8 +48,7 @@ end
 end
 
 function initialize_api()
-    # make sure the calling thread has an active context
-    CUDAnative.initialize_context()
+    CUDAnative.prepare_cuda_call()
 end
 
 macro check(ex)

--- a/src/dnn/CUDNN.jl
+++ b/src/dnn/CUDNN.jl
@@ -39,33 +39,32 @@ include("nnlib.jl")
 
 include("compat.jl")
 
-const handles_lock = ReentrantLock()
-const created_handles = Dict{Tuple{UInt,Int},cudnnHandle_t}()
-const active_handles = Vector{Union{Nothing,cudnnHandle_t}}()
+# thread cache for task-local library handles
+const thread_handles = Vector{Union{Nothing,cudnnHandle_t}}()
 
 function handle()
     tid = Threads.threadid()
-    if @inbounds active_handles[tid] === nothing
+    if @inbounds thread_handles[tid] === nothing
         ctx = context()
-        key = (objectid(ctx), tid)
-        lock(handles_lock) do
-            active_handles[tid] = get!(created_handles, key) do
-                handle = cudnnCreate()
-                atexit(()->CUDAdrv.isvalid(ctx) && cudnnDestroy(handle))
-                handle
-            end
+        thread_handles[tid] = get!(task_local_storage(), (:CUDNN, ctx)) do
+            handle = cudnnCreate()
+            atexit(()->CUDAdrv.isvalid(ctx) && cudnnDestroy(handle))
+            handle
         end
     end
-    @inbounds active_handles[tid]
+    @inbounds thread_handles[tid]
 end
 
 function __init__()
-    resize!(active_handles, Threads.nthreads())
-    fill!(active_handles, nothing)
+    resize!(thread_handles, Threads.nthreads())
+    fill!(thread_handles, nothing)
 
     CUDAnative.atcontextswitch() do tid, ctx
-        # we don't eagerly initialize handles, but do so lazily when requested
-        active_handles[tid] = nothing
+        thread_handles[tid] = nothing
+    end
+
+    CUDAnative.attaskswitch() do tid, task
+        thread_handles[tid] = nothing
     end
 end
 

--- a/src/dnn/CUDNN.jl
+++ b/src/dnn/CUDNN.jl
@@ -48,7 +48,13 @@ function handle()
         ctx = context()
         thread_handles[tid] = get!(task_local_storage(), (:CUDNN, ctx)) do
             handle = cudnnCreate()
-            atexit(()->CUDAdrv.isvalid(ctx) && cudnnDestroy(handle))
+            atexit() do
+                CUDAdrv.isvalid(ctx) || return
+                context!(ctx) do
+                    cudnnDestroy(handle)
+                end
+            end
+
             handle
         end
     end

--- a/src/dnn/CUDNN.jl
+++ b/src/dnn/CUDNN.jl
@@ -48,7 +48,7 @@ function handle()
         ctx = context()
         thread_handles[tid] = get!(task_local_storage(), (:CUDNN, ctx)) do
             handle = cudnnCreate()
-            atexit() do
+            finalizer(current_task()) do task
                 CUDAdrv.isvalid(ctx) || return
                 context!(ctx) do
                     cudnnDestroy(handle)

--- a/src/dnn/error.jl
+++ b/src/dnn/error.jl
@@ -20,8 +20,7 @@ name(err::CUDNNError) = unsafe_string(cudnnGetErrorString(err))
 end
 
 function initialize_api()
-    # make sure the calling thread has an active context
-    CUDAnative.initialize_context()
+    CUDAnative.prepare_cuda_call()
 end
 
 macro check(ex)

--- a/src/fft/error.jl
+++ b/src/fft/error.jl
@@ -62,8 +62,7 @@ end
 end
 
 function initialize_api()
-    # make sure the calling thread has an active context
-    CUDAnative.initialize_context()
+    CUDAnative.prepare_cuda_call()
 end
 
 macro check(ex)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -297,7 +297,7 @@ synchronized right before and after executing `ex` to exclude any external effec
 macro time(ex)
     quote
         # @time might surround an application, so be sure to initialize CUDA before that
-        CUDAnative.initialize_context()
+        CUDAnative.prepare_cuda_call()
 
         # coarse synchronization to exclude effects from previously-executed code
         CUDAdrv.synchronize()

--- a/src/rand/error.jl
+++ b/src/rand/error.jl
@@ -54,8 +54,7 @@ end
 end
 
 function initialize_api()
-    # make sure the calling thread has an active context
-    CUDAnative.initialize_context()
+    CUDAnative.prepare_cuda_call()
 end
 
 macro check(ex)

--- a/src/rand/random.jl
+++ b/src/rand/random.jl
@@ -29,7 +29,8 @@ mutable struct RNG <: Random.AbstractRNG
 end
 
 function unsafe_destroy!(rng::RNG)
-    if CUDAdrv.isvalid(rng.ctx)
+    CUDAdrv.isvalid(rng.ctx) || return
+    context!(rng.ctx) do
         curandDestroyGenerator(rng)
     end
 end

--- a/src/solver/CUSOLVER.jl
+++ b/src/solver/CUSOLVER.jl
@@ -37,7 +37,13 @@ function dense_handle()
         ctx = context()
         thread_dense_handles[tid] = get!(task_local_storage(), (:CUSOLVER, :dense, ctx)) do
             handle = cusolverDnCreate()
-            atexit(()->CUDAdrv.isvalid(ctx) && cusolverDnDestroy(handle))
+            atexit() do
+                CUDAdrv.isvalid(ctx) || return
+                context!(ctx) do
+                    cusolverDnDestroy(handle)
+                end
+            end
+
             handle
         end
     end
@@ -50,7 +56,13 @@ function sparse_handle()
         ctx = context()
         thread_sparse_handles[tid] = get!(task_local_storage(), (:CUSOLVER, :sparse, ctx)) do
             handle = cusolverSpCreate()
-            atexit(()->CUDAdrv.isvalid(ctx) && cusolverSpDestroy(handle))
+            atexit() do
+                CUDAdrv.isvalid(ctx) || return
+                context!(ctx) do
+                    cusolverSpDestroy(handle)
+                end
+            end
+
             handle
         end
     end

--- a/src/solver/CUSOLVER.jl
+++ b/src/solver/CUSOLVER.jl
@@ -37,7 +37,7 @@ function dense_handle()
         ctx = context()
         thread_dense_handles[tid] = get!(task_local_storage(), (:CUSOLVER, :dense, ctx)) do
             handle = cusolverDnCreate()
-            atexit() do
+            finalizer(current_task()) do task
                 CUDAdrv.isvalid(ctx) || return
                 context!(ctx) do
                     cusolverDnDestroy(handle)
@@ -56,7 +56,7 @@ function sparse_handle()
         ctx = context()
         thread_sparse_handles[tid] = get!(task_local_storage(), (:CUSOLVER, :sparse, ctx)) do
             handle = cusolverSpCreate()
-            atexit() do
+            finalizer(current_task()) do task
                 CUDAdrv.isvalid(ctx) || return
                 context!(ctx) do
                     cusolverSpDestroy(handle)

--- a/src/solver/CUSOLVER.jl
+++ b/src/solver/CUSOLVER.jl
@@ -27,55 +27,51 @@ include("wrappers.jl")
 # high-level integrations
 include("linalg.jl")
 
-const handles_lock = ReentrantLock()
-const created_dense_handles = Dict{Tuple{UInt,Int},cusolverDnHandle_t}()
-const created_sparse_handles = Dict{Tuple{UInt,Int},cusolverSpHandle_t}()
-const active_dense_handles = Vector{Union{Nothing,cusolverDnHandle_t}}()
-const active_sparse_handles = Vector{Union{Nothing,cusolverSpHandle_t}}()
+# thread cache for task-local library handles
+const thread_dense_handles = Vector{Union{Nothing,cusolverDnHandle_t}}()
+const thread_sparse_handles = Vector{Union{Nothing,cusolverSpHandle_t}}()
 
 function dense_handle()
     tid = Threads.threadid()
-    if @inbounds active_dense_handles[tid] === nothing
+    if @inbounds thread_dense_handles[tid] === nothing
         ctx = context()
-        key = (objectid(ctx), tid)
-        lock(handles_lock) do
-            active_dense_handles[tid] = get!(created_dense_handles, key) do
-                handle = cusolverDnCreate()
-                atexit(()->CUDAdrv.isvalid(ctx) && cusolverDnDestroy(handle))
-                handle
-            end
+        thread_dense_handles[tid] = get!(task_local_storage(), (:CUSOLVER, :dense, ctx)) do
+            handle = cusolverDnCreate()
+            atexit(()->CUDAdrv.isvalid(ctx) && cusolverDnDestroy(handle))
+            handle
         end
     end
-    @inbounds active_dense_handles[tid]
+    @inbounds thread_dense_handles[tid]
 end
 
 function sparse_handle()
     tid = Threads.threadid()
-    if @inbounds active_sparse_handles[tid] === nothing
+    if @inbounds thread_sparse_handles[tid] === nothing
         ctx = context()
-        key = (objectid(ctx), tid)
-        lock(handles_lock) do
-            active_sparse_handles[tid] = get!(created_sparse_handles, key) do
-                handle = cusolverSpCreate()
-                atexit(()->CUDAdrv.isvalid(ctx) && cusolverSpDestroy(handle))
-                handle
-            end
+        thread_sparse_handles[tid] = get!(task_local_storage(), (:CUSOLVER, :sparse, ctx)) do
+            handle = cusolverSpCreate()
+            atexit(()->CUDAdrv.isvalid(ctx) && cusolverSpDestroy(handle))
+            handle
         end
     end
-    @inbounds active_sparse_handles[tid]
+    @inbounds thread_sparse_handles[tid]
 end
 
 function __init__()
-    resize!(active_dense_handles, Threads.nthreads())
-    fill!(active_dense_handles, nothing)
+    resize!(thread_dense_handles, Threads.nthreads())
+    fill!(thread_dense_handles, nothing)
 
-    resize!(active_sparse_handles, Threads.nthreads())
-    fill!(active_sparse_handles, nothing)
+    resize!(thread_sparse_handles, Threads.nthreads())
+    fill!(thread_sparse_handles, nothing)
 
     CUDAnative.atcontextswitch() do tid, ctx
-        # we don't eagerly initialize handles, but do so lazily when requested
-        active_dense_handles[tid] = nothing
-        active_sparse_handles[tid] = nothing
+        thread_dense_handles[tid] = nothing
+        thread_sparse_handles[tid] = nothing
+    end
+
+    CUDAnative.attaskswitch() do tid, task
+        thread_dense_handles[tid] = nothing
+        thread_sparse_handles[tid] = nothing
     end
 end
 

--- a/src/solver/error.jl
+++ b/src/solver/error.jl
@@ -44,8 +44,7 @@ end
 end
 
 function initialize_api()
-    # make sure the calling thread has an active context
-    CUDAnative.initialize_context()
+    CUDAnative.prepare_cuda_call()
 end
 
 macro check(ex)

--- a/src/sparse/CUSPARSE.jl
+++ b/src/sparse/CUSPARSE.jl
@@ -36,7 +36,7 @@ function handle()
         ctx = context()
         thread_handles[tid] = get!(task_local_storage(), (:CUSPARSE, ctx)) do
             handle = cusparseCreate()
-            atexit() do
+            finalizer(current_task()) do task
                 CUDAdrv.isvalid(ctx) || return
                 context!(ctx) do
                     cusparseDestroy(handle)

--- a/src/sparse/CUSPARSE.jl
+++ b/src/sparse/CUSPARSE.jl
@@ -36,7 +36,13 @@ function handle()
         ctx = context()
         thread_handles[tid] = get!(task_local_storage(), (:CUSPARSE, ctx)) do
             handle = cusparseCreate()
-            atexit(()->CUDAdrv.isvalid(ctx) && cusparseDestroy(handle))
+            atexit() do
+                CUDAdrv.isvalid(ctx) || return
+                context!(ctx) do
+                    cusparseDestroy(handle)
+                end
+            end
+
             handle
         end
     end

--- a/src/sparse/error.jl
+++ b/src/sparse/error.jl
@@ -22,8 +22,7 @@ description(err::CUSPARSEError) = unsafe_string(cusparseGetErrorString(err))
 end
 
 function initialize_api()
-    # make sure the calling thread has an active context
-    CUDAnative.initialize_context()
+    CUDAnative.prepare_cuda_call()
 end
 
 macro check(ex)

--- a/src/tensor/CUTENSOR.jl
+++ b/src/tensor/CUTENSOR.jl
@@ -26,33 +26,32 @@ include("wrappers.jl")
 # high-level integrations
 include("interfaces.jl")
 
-const handles_lock = ReentrantLock()
-const created_handles = Dict{Tuple{UInt,Int},Ref{cutensorHandle_t}}()
-const active_handles = Vector{Union{Nothing,Ref{cutensorHandle_t}}}()
+# thread cache for task-local library handles
+const thread_handles = Vector{Union{Nothing,Ref{cutensorHandle_t}}}()
 
 function handle()
     tid = Threads.threadid()
-    if @inbounds active_handles[tid] === nothing
+    if @inbounds thread_handles[tid] === nothing
         ctx = context()
-        key = (objectid(ctx), tid)
-        lock(handles_lock) do
-            active_handles[tid] = get!(created_handles, key) do
-                handle = Ref{cutensorHandle_t}()
-                cutensorInit(handle)
-                handle
-            end
+        thread_handles[tid] = get!(task_local_storage(), (:CUTENSOR, ctx)) do
+            handle = Ref{cutensorHandle_t}()
+            cutensorInit(handle)
+            handle
         end
     end
-    @inbounds active_handles[tid]
+    @inbounds thread_handles[tid]
 end
 
 function __init__()
-    resize!(active_handles, Threads.nthreads())
-    fill!(active_handles, nothing)
+    resize!(thread_handles, Threads.nthreads())
+    fill!(thread_handles, nothing)
 
     CUDAnative.atcontextswitch() do tid, ctx
-        # we don't eagerly initialize handles, but do so lazily when requested
-        active_handles[tid] = nothing
+        thread_handles[tid] = nothing
+    end
+
+    CUDAnative.attaskswitch() do tid, task
+        thread_handles[tid] = nothing
     end
 end
 

--- a/src/tensor/error.jl
+++ b/src/tensor/error.jl
@@ -56,8 +56,7 @@ end
 end
 
 function initialize_api()
-    # make sure the calling thread has an active context
-    CUDAnative.initialize_context()
+    CUDAnative.prepare_cuda_call()
 end
 
 macro check(ex)


### PR DESCRIPTION
Adapt to https://github.com/JuliaGPU/CUDAnative.jl/pull/609.

Now that CUDAnative knows about tasks, we can just use task local storage to store handles. However, that is fairly slow (80ns), so we maintain a thread-local cache of library handles which is much faster (5ns). This matters since we need to get a handle for most library calls.