### PR TITLE
Let cublasXT use host memory

### DIFF
--- a/res/wrap/pointers.json
+++ b/res/wrap/pointers.json
@@ -4460,9 +4460,9 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null
     },
     "cublasXtDtrsm": {
@@ -4474,9 +4474,9 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null
     },
     "cublasXtCtrsm": {
@@ -4488,9 +4488,9 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null
     },
     "cublasXtZtrsm": {
@@ -4502,9 +4502,9 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null
     },
     "cublasXtStrmm": {
@@ -4516,11 +4516,11 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtDtrmm": {
@@ -4532,11 +4532,11 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtCtrmm": {
@@ -4548,11 +4548,11 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtZtrmm": {
@@ -4564,11 +4564,11 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtSgemm": {
@@ -4579,12 +4579,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtDgemm": {
@@ -4595,12 +4595,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtCgemm": {
@@ -4611,12 +4611,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtZgemm": {
@@ -4627,12 +4627,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtSsyrk": {
@@ -4642,10 +4642,10 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtDsyrk": {
@@ -4655,10 +4655,10 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtCsyrk": {
@@ -4668,10 +4668,10 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtZsyrk": {
@@ -4681,10 +4681,10 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtCherk": {
@@ -4694,10 +4694,10 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtZherk": {
@@ -4707,10 +4707,10 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtSsyr2k": {
@@ -4720,12 +4720,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtDsyr2k": {
@@ -4735,12 +4735,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtCsyr2k": {
@@ -4750,12 +4750,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtZsyr2k": {
@@ -4765,12 +4765,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtCher2k": {
@@ -4780,12 +4780,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtZher2k": {
@@ -4795,12 +4795,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtSsyrkx": {
@@ -4810,12 +4810,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtDsyrkx": {
@@ -4825,12 +4825,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtCsyrkx": {
@@ -4840,12 +4840,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtZsyrkx": {
@@ -4855,12 +4855,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtCherkx": {
@@ -4870,12 +4870,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtZherkx": {
@@ -4885,12 +4885,12 @@
         "n": null,
         "k": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtSsymm": {
@@ -4900,12 +4900,12 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtDsymm": {
@@ -4915,12 +4915,12 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtCsymm": {
@@ -4930,12 +4930,12 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtZsymm": {
@@ -4945,12 +4945,12 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtChemm": {
@@ -4960,12 +4960,12 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cublasXtZhemm": {
@@ -4975,12 +4975,12 @@
         "m": null,
         "n": null,
         "alpha": "PtrOrCuPtr",
-        "A": "CuPtr",
+        "A": "PtrOrCuPtr",
         "lda": null,
-        "B": "CuPtr",
+        "B": "PtrOrCuPtr",
         "ldb": null,
         "beta": "PtrOrCuPtr",
-        "C": "CuPtr",
+        "C": "PtrOrCuPtr",
         "ldc": null
     },
     "cufftGetProperty": {

--- a/res/wrap/pointers.json
+++ b/res/wrap/pointers.json
@@ -191,8 +191,8 @@
         "currIdx": null,
         "loWinIdx": "Ptr",
         "hiWinIdx": "Ptr",
-        "devSeqLengthsQO": "Ptr",
-        "devSeqLengthsKV": "Ptr",
+        "seqLengthArrayQRO": "Ptr",
+        "seqLengthArrayKV": "Ptr",
         "qDesc": null,
         "queries": "CuPtr",
         "residuals": "CuPtr",
@@ -713,8 +713,8 @@
         "attnDesc": null,
         "loWinIdx": "Ptr",
         "hiWinIdx": "Ptr",
-        "devSeqLengthsDQDO": "Ptr",
-        "devSeqLengthsDKDV": "Ptr",
+        "seqLengthArrayDQDO": "Ptr",
+        "seqLengthArrayDKDV": "Ptr",
         "doDesc": null,
         "dout": "CuPtr",
         "dqDesc": null,
@@ -821,7 +821,7 @@
     },
     "cudnnGetAttnDescriptor": {
         "attnDesc": null,
-        "attnMode": "Ptr",
+        "queryMap": "Ptr",
         "nHeads": "Ptr",
         "smScaler": "Ptr",
         "dataType": "Ptr",
@@ -16775,5 +16775,9 @@
         "n": null,
         "nrhs": null,
         "lwork_bytes": "Ptr"
+    },
+    "cusparseSpMatGetNumBatches": {
+        "spMatDescr": null,
+        "batchCount": "Ptr"
     }
 }

--- a/src/blas/libcublas.jl
+++ b/src/blas/libcublas.jl
@@ -2437,8 +2437,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtSgemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasOperation_t, cublasOperation_t, Csize_t,
-                    Csize_t, Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t,
-                    CuPtr{Cfloat}, Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t),
+                    Csize_t, Csize_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t,
+                    PtrOrCuPtr{Cfloat}, Csize_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat},
+                    Csize_t),
                    handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2447,8 +2448,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtDgemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasOperation_t, cublasOperation_t, Csize_t,
-                    Csize_t, Csize_t, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t,
-                    CuPtr{Cdouble}, Csize_t, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t),
+                    Csize_t, Csize_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t,
+                    PtrOrCuPtr{Cdouble}, Csize_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble},
+                    Csize_t),
                    handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2457,9 +2459,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtCgemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasOperation_t, cublasOperation_t, Csize_t,
-                    Csize_t, Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Csize_t,
-                    CuPtr{cuComplex}, Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
-                    Csize_t),
+                    Csize_t, Csize_t, PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex},
+                    Csize_t, PtrOrCuPtr{cuComplex}, Csize_t, PtrOrCuPtr{cuComplex},
+                    PtrOrCuPtr{cuComplex}, Csize_t),
                    handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2468,9 +2470,10 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtZgemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasOperation_t, cublasOperation_t, Csize_t,
-                    Csize_t, Csize_t, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex},
-                    Csize_t, CuPtr{cuDoubleComplex}, Csize_t, PtrOrCuPtr{cuDoubleComplex},
-                    CuPtr{cuDoubleComplex}, Csize_t),
+                    Csize_t, Csize_t, PtrOrCuPtr{cuDoubleComplex},
+                    PtrOrCuPtr{cuDoubleComplex}, Csize_t, PtrOrCuPtr{cuDoubleComplex},
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
+                    Csize_t),
                    handle, transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2478,8 +2481,8 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtSsyrk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t,
-                    PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t),
+                    Csize_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t,
+                    PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -2487,8 +2490,8 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtDsyrk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t,
-                    PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t),
+                    Csize_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t,
+                    PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -2496,8 +2499,8 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtCsyrk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Csize_t,
-                    PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Csize_t),
+                    Csize_t, PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
+                    PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -2505,8 +2508,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtZsyrk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Csize_t,
-                    PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Csize_t),
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
+                    Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -2514,8 +2518,8 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtCherk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{cuComplex}, Csize_t,
-                    PtrOrCuPtr{Cfloat}, CuPtr{cuComplex}, Csize_t),
+                    Csize_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{cuComplex}, Csize_t,
+                    PtrOrCuPtr{Cfloat}, PtrOrCuPtr{cuComplex}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -2523,8 +2527,8 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtZherk, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{Cdouble}, CuPtr{cuDoubleComplex}, Csize_t,
-                    PtrOrCuPtr{Cdouble}, CuPtr{cuDoubleComplex}, Csize_t),
+                    Csize_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{cuDoubleComplex}, Csize_t,
+                    PtrOrCuPtr{Cdouble}, PtrOrCuPtr{cuDoubleComplex}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, beta, C, ldc)
 end
 
@@ -2533,8 +2537,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtSsyr2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t, CuPtr{Cfloat},
-                    Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t),
+                    Csize_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t,
+                    PtrOrCuPtr{Cfloat}, Csize_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat},
+                    Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2543,8 +2548,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtDsyr2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t, CuPtr{Cdouble},
-                    Csize_t, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t),
+                    Csize_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t,
+                    PtrOrCuPtr{Cdouble}, Csize_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble},
+                    Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2553,9 +2559,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtCsyr2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Csize_t,
-                    CuPtr{cuComplex}, Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
-                    Csize_t),
+                    Csize_t, PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
+                    PtrOrCuPtr{cuComplex}, Csize_t, PtrOrCuPtr{cuComplex},
+                    PtrOrCuPtr{cuComplex}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2564,9 +2570,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtZsyr2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Csize_t,
-                    CuPtr{cuDoubleComplex}, Csize_t, PtrOrCuPtr{cuDoubleComplex},
-                    CuPtr{cuDoubleComplex}, Csize_t),
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, Csize_t,
+                    PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2575,9 +2581,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtCherkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Csize_t,
-                    CuPtr{cuComplex}, Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{cuComplex},
-                    Csize_t),
+                    Csize_t, PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
+                    PtrOrCuPtr{cuComplex}, Csize_t, PtrOrCuPtr{Cfloat},
+                    PtrOrCuPtr{cuComplex}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2586,9 +2592,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtZherkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Csize_t,
-                    CuPtr{cuDoubleComplex}, Csize_t, PtrOrCuPtr{Cdouble},
-                    CuPtr{cuDoubleComplex}, Csize_t),
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, Csize_t, PtrOrCuPtr{Cdouble},
+                    PtrOrCuPtr{cuDoubleComplex}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2597,7 +2603,8 @@ end
     @runtime_ccall((:cublasXtStrsm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
-                    PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t, CuPtr{Cfloat}, Csize_t),
+                    PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t, PtrOrCuPtr{Cfloat},
+                    Csize_t),
                    handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
 end
 
@@ -2606,7 +2613,8 @@ end
     @runtime_ccall((:cublasXtDtrsm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
-                    PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t, CuPtr{Cdouble}, Csize_t),
+                    PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t, PtrOrCuPtr{Cdouble},
+                    Csize_t),
                    handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
 end
 
@@ -2615,8 +2623,8 @@ end
     @runtime_ccall((:cublasXtCtrsm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
-                    PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Csize_t, CuPtr{cuComplex},
-                    Csize_t),
+                    PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
+                    PtrOrCuPtr{cuComplex}, Csize_t),
                    handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
 end
 
@@ -2625,8 +2633,8 @@ end
     @runtime_ccall((:cublasXtZtrsm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
-                    PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Csize_t,
-                    CuPtr{cuDoubleComplex}, Csize_t),
+                    PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex}, Csize_t,
+                    PtrOrCuPtr{cuDoubleComplex}, Csize_t),
                    handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb)
 end
 
@@ -2635,8 +2643,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtSsymm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t, CuPtr{Cfloat},
-                    Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t),
+                    Csize_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t,
+                    PtrOrCuPtr{Cfloat}, Csize_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat},
+                    Csize_t),
                    handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2645,8 +2654,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtDsymm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t, CuPtr{Cdouble},
-                    Csize_t, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t),
+                    Csize_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t,
+                    PtrOrCuPtr{Cdouble}, Csize_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble},
+                    Csize_t),
                    handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2655,9 +2665,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtCsymm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Csize_t,
-                    CuPtr{cuComplex}, Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
-                    Csize_t),
+                    Csize_t, PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
+                    PtrOrCuPtr{cuComplex}, Csize_t, PtrOrCuPtr{cuComplex},
+                    PtrOrCuPtr{cuComplex}, Csize_t),
                    handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2666,9 +2676,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtZsymm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Csize_t,
-                    CuPtr{cuDoubleComplex}, Csize_t, PtrOrCuPtr{cuDoubleComplex},
-                    CuPtr{cuDoubleComplex}, Csize_t),
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, Csize_t,
+                    PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex}, Csize_t),
                    handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2677,9 +2687,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtChemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Csize_t,
-                    CuPtr{cuComplex}, Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
-                    Csize_t),
+                    Csize_t, PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
+                    PtrOrCuPtr{cuComplex}, Csize_t, PtrOrCuPtr{cuComplex},
+                    PtrOrCuPtr{cuComplex}, Csize_t),
                    handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2688,9 +2698,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtZhemm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Csize_t,
-                    CuPtr{cuDoubleComplex}, Csize_t, PtrOrCuPtr{cuDoubleComplex},
-                    CuPtr{cuDoubleComplex}, Csize_t),
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, Csize_t,
+                    PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex}, Csize_t),
                    handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2699,8 +2709,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtSsyrkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t, CuPtr{Cfloat},
-                    Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t),
+                    Csize_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t,
+                    PtrOrCuPtr{Cfloat}, Csize_t, PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat},
+                    Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2709,8 +2720,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtDsyrkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t, CuPtr{Cdouble},
-                    Csize_t, PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t),
+                    Csize_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t,
+                    PtrOrCuPtr{Cdouble}, Csize_t, PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble},
+                    Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2719,9 +2731,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtCsyrkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Csize_t,
-                    CuPtr{cuComplex}, Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex},
-                    Csize_t),
+                    Csize_t, PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
+                    PtrOrCuPtr{cuComplex}, Csize_t, PtrOrCuPtr{cuComplex},
+                    PtrOrCuPtr{cuComplex}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2730,9 +2742,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtZsyrkx, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Csize_t,
-                    CuPtr{cuDoubleComplex}, Csize_t, PtrOrCuPtr{cuDoubleComplex},
-                    CuPtr{cuDoubleComplex}, Csize_t),
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, Csize_t,
+                    PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2741,9 +2753,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtCher2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Csize_t,
-                    CuPtr{cuComplex}, Csize_t, PtrOrCuPtr{Cfloat}, CuPtr{cuComplex},
-                    Csize_t),
+                    Csize_t, PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
+                    PtrOrCuPtr{cuComplex}, Csize_t, PtrOrCuPtr{Cfloat},
+                    PtrOrCuPtr{cuComplex}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2752,9 +2764,9 @@ end
     initialize_api()
     @runtime_ccall((:cublasXtZher2k, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasFillMode_t, cublasOperation_t, Csize_t,
-                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Csize_t,
-                    CuPtr{cuDoubleComplex}, Csize_t, PtrOrCuPtr{Cdouble},
-                    CuPtr{cuDoubleComplex}, Csize_t),
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex},
+                    Csize_t, PtrOrCuPtr{cuDoubleComplex}, Csize_t, PtrOrCuPtr{Cdouble},
+                    PtrOrCuPtr{cuDoubleComplex}, Csize_t),
                    handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 end
 
@@ -2801,8 +2813,8 @@ end
     @runtime_ccall((:cublasXtStrmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
-                    PtrOrCuPtr{Cfloat}, CuPtr{Cfloat}, Csize_t, CuPtr{Cfloat}, Csize_t,
-                    CuPtr{Cfloat}, Csize_t),
+                    PtrOrCuPtr{Cfloat}, PtrOrCuPtr{Cfloat}, Csize_t, PtrOrCuPtr{Cfloat},
+                    Csize_t, PtrOrCuPtr{Cfloat}, Csize_t),
                    handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
 end
 
@@ -2812,8 +2824,8 @@ end
     @runtime_ccall((:cublasXtDtrmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
-                    PtrOrCuPtr{Cdouble}, CuPtr{Cdouble}, Csize_t, CuPtr{Cdouble}, Csize_t,
-                    CuPtr{Cdouble}, Csize_t),
+                    PtrOrCuPtr{Cdouble}, PtrOrCuPtr{Cdouble}, Csize_t, PtrOrCuPtr{Cdouble},
+                    Csize_t, PtrOrCuPtr{Cdouble}, Csize_t),
                    handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
 end
 
@@ -2823,8 +2835,8 @@ end
     @runtime_ccall((:cublasXtCtrmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
-                    PtrOrCuPtr{cuComplex}, CuPtr{cuComplex}, Csize_t, CuPtr{cuComplex},
-                    Csize_t, CuPtr{cuComplex}, Csize_t),
+                    PtrOrCuPtr{cuComplex}, PtrOrCuPtr{cuComplex}, Csize_t,
+                    PtrOrCuPtr{cuComplex}, Csize_t, PtrOrCuPtr{cuComplex}, Csize_t),
                    handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
 end
 
@@ -2834,7 +2846,8 @@ end
     @runtime_ccall((:cublasXtZtrmm, libcublas()), cublasStatus_t,
                    (cublasXtHandle_t, cublasSideMode_t, cublasFillMode_t,
                     cublasOperation_t, cublasDiagType_t, Csize_t, Csize_t,
-                    PtrOrCuPtr{cuDoubleComplex}, CuPtr{cuDoubleComplex}, Csize_t,
-                    CuPtr{cuDoubleComplex}, Csize_t, CuPtr{cuDoubleComplex}, Csize_t),
+                    PtrOrCuPtr{cuDoubleComplex}, PtrOrCuPtr{cuDoubleComplex}, Csize_t,
+                    PtrOrCuPtr{cuDoubleComplex}, Csize_t, PtrOrCuPtr{cuDoubleComplex},
+                    Csize_t),
                    handle, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb, C, ldc)
 end

--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -1769,10 +1769,10 @@ for (fname, elty) in
         function xt_gemm!(transA::Char,
                        transB::Char,
                        alpha::($elty),
-                       A::CuVecOrMat{$elty},
-                       B::CuVecOrMat{$elty},
+                       A::Union{CuVecOrMat{$elty}, VecOrMat{$elty}},
+                       B::Union{CuVecOrMat{$elty}, VecOrMat{$elty}},
                        beta::($elty),
-                       C::CuVecOrMat{$elty})
+                       C::Union{CuVecOrMat{$elty}, VecOrMat{$elty}})
             m = size(A, transA == 'N' ? 1 : 2)
             k = size(A, transA == 'N' ? 2 : 1)
             n = size(B, transB == 'N' ? 2 : 1)
@@ -1790,16 +1790,16 @@ for (fname, elty) in
         function xt_gemm(transA::Char,
                       transB::Char,
                       alpha::($elty),
-                      A::CuMatrix{$elty},
-                      B::CuMatrix{$elty})
+                      A::Union{CuVecOrMat{$elty}, VecOrMat{$elty}},
+                      B::Union{CuVecOrMat{$elty}, VecOrMat{$elty}})
             xt_gemm!(transA, transB, alpha, A, B, zero($elty),
                   similar(B, $elty, (size(A, transA == 'N' ? 1 : 2),
                                      size(B, transB == 'N' ? 2 : 1))))
         end
         function xt_gemm(transA::Char,
                       transB::Char,
-                      A::CuMatrix{$elty},
-                      B::CuMatrix{$elty})
+                      A::Union{CuVecOrMat{$elty}, VecOrMat{$elty}},
+                      B::Union{CuVecOrMat{$elty}, VecOrMat{$elty}})
             xt_gemm(transA, transB, one($elty), A, B)
         end
     end
@@ -1819,10 +1819,10 @@ for (fname, elty) in ((:cublasXtZhemm,:ComplexF64),
        function xt_hemm!(side::Char,
                       uplo::Char,
                       alpha::($elty),
-                      A::CuMatrix{$elty},
-                      B::CuMatrix{$elty},
+                      A::Union{Matrix{$elty}, CuMatrix{$elty}},
+                      B::Union{Matrix{$elty}, CuMatrix{$elty}},
                       beta::($elty),
-                      C::CuMatrix{$elty})
+                      C::Union{Matrix{$elty}, CuMatrix{$elty}})
            cuside = cublasside(side)
            cuuplo = cublasfill(uplo)
            mA, nA = size(A)
@@ -1841,12 +1841,12 @@ for (fname, elty) in ((:cublasXtZhemm,:ComplexF64),
        function xt_hemm(uplo::Char,
                      trans::Char,
                      alpha::($elty),
-                     A::CuMatrix{$elty},
-                     B::CuMatrix{$elty})
+                     A::Union{Matrix{$elty}, CuMatrix{$elty}},
+                     B::Union{Matrix{$elty}, CuMatrix{$elty}})
            m,n = size(B)
            xt_hemm!( uplo, trans, alpha, A, B, zero($elty), similar(B, $elty, (m,n) ) )
        end
-       xt_hemm( uplo::Char, trans::Char, A::CuMatrix{$elty}, B::CuMatrix{$elty}) = xt_hemm( uplo, trans, one($elty), A, B)
+       xt_hemm( uplo::Char, trans::Char, A::Union{Matrix{$elty}, CuMatrix{$elty}}, B::Union{Matrix{$elty}, CuMatrix{$elty}}) = xt_hemm( uplo, trans, one($elty), A, B)
     end
 end
 
@@ -1865,10 +1865,10 @@ for (fname, elty) in ((:cublasXtDsymm,:Float64),
         function xt_symm!(side::Char,
                        uplo::Char,
                        alpha::($elty),
-                       A::CuMatrix{$elty},
-                       B::CuMatrix{$elty},
+                       A::Union{Matrix{$elty}, CuMatrix{$elty}},
+                       B::Union{Matrix{$elty}, CuMatrix{$elty}},
                        beta::($elty),
-                       C::CuMatrix{$elty})
+                       C::Union{Matrix{$elty}, CuMatrix{$elty}})
             cuside = cublasside(side)
             cuuplo = cublasfill(uplo)
             k, nA = size(A)
@@ -1888,14 +1888,14 @@ for (fname, elty) in ((:cublasXtDsymm,:Float64),
         function xt_symm(side::Char,
                       uplo::Char,
                       alpha::($elty),
-                      A::CuMatrix{$elty},
-                      B::CuMatrix{$elty})
+                      A::Union{Matrix{$elty}, CuMatrix{$elty}},
+                      B::Union{Matrix{$elty}, CuMatrix{$elty}})
             xt_symm!(side, uplo, alpha, A, B, zero($elty), similar(B))
         end
         function xt_symm(side::Char,
                       uplo::Char,
-                      A::CuMatrix{$elty},
-                      B::CuMatrix{$elty})
+                      A::Union{Matrix{$elty}, CuMatrix{$elty}},
+                      B::Union{Matrix{$elty}, CuMatrix{$elty}})
             xt_symm(side, uplo, one($elty), A, B)
         end
     end
@@ -1914,9 +1914,9 @@ for (fname, elty) in ((:cublasXtDsyrk,:Float64),
        function xt_syrk!(uplo::Char,
                       trans::Char,
                       alpha::($elty),
-                      A::CuVecOrMat{$elty},
+                      A::Union{VecOrMat{$elty}, CuVecOrMat{$elty}},
                       beta::($elty),
-                      C::CuMatrix{$elty})
+                      C::Union{Matrix{$elty}, CuMatrix{$elty}})
            cuuplo = cublasfill(uplo)
            cutrans = cublasop(trans)
            mC, n = size(C)
@@ -1934,14 +1934,12 @@ end
 function xt_syrk(uplo::Char,
               trans::Char,
               alpha::Number,
-              A::CuVecOrMat)
+              A::Union{VecOrMat, CuVecOrMat})
     T = eltype(A)
     n = size(A, trans == 'N' ? 1 : 2)
     xt_syrk!(uplo, trans, convert(T,alpha), A, zero(T), similar(A, T, (n, n)))
 end
-xt_syrk(uplo::Char, trans::Char, A::CuVecOrMat) = xt_syrk(uplo, trans,
-                                                              one(eltype(A)),
-                                                              A)
+xt_syrk(uplo::Char, trans::Char, A::Union{VecOrMat, CuVecOrMat}) = xt_syrk(uplo, trans, one(eltype(A)), A)
 
 for (fname, elty) in ((:cublasXtDsyrkx,:Float64),
                       (:cublasXtSsyrkx,:Float32),
@@ -1956,10 +1954,10 @@ for (fname, elty) in ((:cublasXtDsyrkx,:Float64),
        function xt_syrkx!(uplo::Char,
                       trans::Char,
                       alpha::($elty),
-                      A::CuVecOrMat{$elty},
-                      B::CuVecOrMat{$elty},
+                      A::Union{VecOrMat{$elty}, CuVecOrMat{$elty}},
+                      B::Union{VecOrMat{$elty}, CuVecOrMat{$elty}},
                       beta::($elty),
-                      C::CuMatrix{$elty})
+                      C::Union{Matrix{$elty}, CuMatrix{$elty}})
            cuuplo = cublasfill(uplo)
            cutrans = cublasop(trans)
            mC, n = size(C)
@@ -1978,14 +1976,14 @@ end
 function xt_syrkx(uplo::Char,
               trans::Char,
               alpha::Number,
-              A::CuVecOrMat,
-              B::CuVecOrMat,
+              A::Union{VecOrMat, CuVecOrMat},
+              B::Union{VecOrMat, CuVecOrMat},
               beta::Number)
     T = eltype(A)
     n = size(A, trans == 'N' ? 1 : 2)
     xt_syrkx!(uplo, trans, convert(T,alpha), A, B, convert(T,beta), similar(A, T, (n, n)))
 end
-xt_syrkx(uplo::Char, trans::Char, A::CuVecOrMat, B::CuVecOrMat) = xt_syrkx(uplo, trans,
+xt_syrkx(uplo::Char, trans::Char, A::Union{VecOrMat, CuVecOrMat}, B::Union{VecOrMat, CuVecOrMat}) = xt_syrkx(uplo, trans,
                                                                  one(eltype(A)), A, B,
                                                                  zero(eltype(B)))
 
@@ -2000,9 +1998,9 @@ for (fname, elty) in ((:cublasXtZherk,:ComplexF64),
        function xt_herk!(uplo::Char,
                       trans::Char,
                       alpha::($elty),
-                      A::CuVecOrMat{$elty},
+                      A::Union{VecOrMat{$elty}, CuVecOrMat{$elty}},
                       beta::($elty),
-                      C::CuMatrix{$elty})
+                      C::Union{Matrix{$elty}, CuMatrix{$elty}})
            cuuplo = cublasfill(uplo)
            cutrans = cublasop(trans)
            mC, n = size(C)
@@ -2015,11 +2013,11 @@ for (fname, elty) in ((:cublasXtZherk,:ComplexF64),
            $fname(xt_handle(), cuuplo, cutrans, n, k, [alpha], A, lda, [beta], C, ldc)
            C
        end
-       function xt_herk(uplo::Char, trans::Char, alpha::($elty), A::CuVecOrMat{$elty})
+       function xt_herk(uplo::Char, trans::Char, alpha::($elty), A::Union{VecOrMat{$elty}, CuVecOrMat{$elty}})
            n = size(A, trans == 'N' ? 1 : 2)
            xt_herk!(uplo, trans, alpha, A, zero($elty), similar(A, $elty, (n,n)))
        end
-       xt_herk(uplo::Char, trans::Char, A::CuVecOrMat{$elty}) = xt_herk(uplo, trans, one($elty), A)
+       xt_herk(uplo::Char, trans::Char, A::Union{VecOrMat{$elty}, CuVecOrMat{$elty}}) = xt_herk(uplo, trans, one($elty), A)
    end
 end
 
@@ -2035,10 +2033,10 @@ for (fname, elty1, elty2) in ((:cublasXtZher2k,:ComplexF64,:Float64),
        function xt_her2k!(uplo::Char,
                        trans::Char,
                        alpha::($elty1),
-                       A::CuVecOrMat{$elty1},
-                       B::CuVecOrMat{$elty1},
+                       A::Union{VecOrMat{$elty1}, CuVecOrMat{$elty1}},
+                       B::Union{VecOrMat{$elty1}, CuVecOrMat{$elty1}},
                        beta::($elty2),
-                       C::CuMatrix{$elty1})
+                       C::Union{Matrix{$elty1}, CuMatrix{$elty1}})
            # TODO: check size of B in julia (her2k!)
            cuuplo = cublasfill(uplo)
            cutrans = cublasop(trans)
@@ -2061,15 +2059,15 @@ for (fname, elty1, elty2) in ((:cublasXtZher2k,:ComplexF64,:Float64),
        function xt_her2k(uplo::Char,
                       trans::Char,
                       alpha::($elty1),
-                      A::CuVecOrMat{$elty1},
-                      B::CuVecOrMat{$elty1})
+                      A::Union{VecOrMat{$elty1}, CuVecOrMat{$elty1}},
+                      B::Union{VecOrMat{$elty1}, CuVecOrMat{$elty1}})
            n = size(A, trans == 'N' ? 1 : 2)
            xt_her2k!(uplo, trans, alpha, A, B, zero($elty2), similar(A, $elty1, (n,n)))
        end
        xt_her2k(uplo::Char,
              trans::Char,
-             A::CuVecOrMat{$elty1},
-             B::CuVecOrMat{$elty1}) = xt_her2k(uplo, trans, one($elty1), A, B)
+             A::Union{VecOrMat{$elty1}, CuVecOrMat{$elty1}},
+             B::Union{VecOrMat{$elty1}, CuVecOrMat{$elty1}}) = xt_her2k(uplo, trans, one($elty1), A, B)
    end
 end
 
@@ -2094,9 +2092,9 @@ for (mmname, smname, elty) in
                        transa::Char,
                        diag::Char,
                        alpha::($elty),
-                       A::CuMatrix{$elty},
-                       B::CuMatrix{$elty},
-                       C::CuMatrix{$elty})
+                       A::Union{Matrix{$elty}, CuMatrix{$elty}},
+                       B::Union{Matrix{$elty}, CuMatrix{$elty}},
+                       C::Union{Matrix{$elty}, CuMatrix{$elty}})
             cuside = cublasside(side)
             cuuplo = cublasfill(uplo)
             cutransa = cublasop(transa)
@@ -2119,8 +2117,8 @@ for (mmname, smname, elty) in
                       transa::Char,
                       diag::Char,
                       alpha::($elty),
-                      A::CuMatrix{$elty},
-                      B::CuMatrix{$elty})
+                      A::Union{CuMatrix{$elty}, Matrix{$elty}},
+                      B::Union{CuMatrix{$elty}, Matrix{$elty}})
             xt_trmm!(side, uplo, transa, diag, alpha, A, B, similar(B))
         end
         # cublasStatus_t cublasDtrsm(cublasHandle_t handle,
@@ -2135,8 +2133,8 @@ for (mmname, smname, elty) in
                        transa::Char,
                        diag::Char,
                        alpha::($elty),
-                       A::CuMatrix{$elty},
-                       B::CuMatrix{$elty})
+                       A::Union{CuMatrix{$elty}, Matrix{$elty}},
+                       B::Union{CuMatrix{$elty}, Matrix{$elty}})
             cuside = cublasside(side)
             cuuplo = cublasfill(uplo)
             cutransa = cublasop(transa)
@@ -2156,8 +2154,8 @@ for (mmname, smname, elty) in
                       transa::Char,
                       diag::Char,
                       alpha::($elty),
-                      A::CuMatrix{$elty},
-                      B::CuMatrix{$elty})
+                      A::Union{CuMatrix{$elty}, Matrix{$elty}},
+                      B::Union{CuMatrix{$elty}, Matrix{$elty}})
             xt_trsm!(side, uplo, transa, diag, alpha, A, copy(B))
         end
     end

--- a/test/blas.jl
+++ b/test/blas.jl
@@ -986,8 +986,8 @@ end # level 1 testset
             end
             @testset "xt_herk! gpu" begin
                 d_C = CuArray(dhA)
+                C = alpha*(A*A') + beta*Array(d_C)
                 CUBLAS.xt_herk!('U','N',alpha,d_A,beta,d_C)
-                C = alpha*(A*A') + beta*C
                 C = triu(C)
                 # move to host and compare
                 h_C = Array(d_C)
@@ -995,9 +995,9 @@ end # level 1 testset
                 @test C ≈ h_C
             end
             @testset "xt_herk! cpu" begin
-                h_C = copy(dhA)
+                h_C = Array(dhA)
                 CUBLAS.xt_herk!('U','N',alpha,Array(d_A),beta,h_C)
-                C = alpha*(A*A') + beta*C
+                C = alpha*(A*A') + beta*Array(dhA)
                 C = triu(C)
                 # move to host and compare
                 h_C = triu(h_C)

--- a/test/blas.jl
+++ b/test/blas.jl
@@ -931,10 +931,8 @@ end # level 1 testset
             # generate matrices
             syrkx_A = rand(elty, n, k)
             syrkx_B = rand(elty, n, k)
-            h_syrkx_C = CUBLAS.xt_syrkx('U','N',syrkx_A,syrkx_B)
+            h_C = CUBLAS.xt_syrkx('U','N',syrkx_A,syrkx_B)
             final_C = syrkx_A*transpose(syrkx_B)
-            # move to host and compare
-            h_C = Array(d_syrkx_C)
             @test triu(final_C) ≈ triu(h_C)
         end
         @testset "syrk" begin
@@ -997,8 +995,7 @@ end # level 1 testset
                 @test C ≈ h_C
             end
             @testset "xt_herk! cpu" begin
-                d_C = CuArray(dhA)
-                h_C = Array(d_C)
+                h_C = copy(dhA)
                 CUBLAS.xt_herk!('U','N',alpha,Array(d_A),beta,h_C)
                 C = alpha*(A*A') + beta*C
                 C = triu(C)


### PR DESCRIPTION
the whole point of cublasXT is to allocate host arrays that are too big for one GPU, and then it farms out the chunks for you. not sure I did the wrapper updates right. seeing a lot of ugly test failures if anyone else wants to take a run at this.