### PR TITLE
GC.preserve some arrays when unsafely accessing them.

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -297,7 +297,7 @@ function Base.copyto!(dest::CuArray{T}, doffs::Integer, src::CuArray{T}, soffs::
 end
 
 function Base.unsafe_copyto!(dest::CuArray{T}, doffs, src::Array{T}, soffs, n) where T
-  unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n)
+  GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -306,7 +306,7 @@ function Base.unsafe_copyto!(dest::CuArray{T}, doffs, src::Array{T}, soffs, n) w
 end
 
 function Base.unsafe_copyto!(dest::Array{T}, doffs, src::CuArray{T}, soffs, n) where T
-  unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n)
+  GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")
@@ -315,7 +315,7 @@ function Base.unsafe_copyto!(dest::Array{T}, doffs, src::CuArray{T}, soffs, n) w
 end
 
 function Base.unsafe_copyto!(dest::CuArray{T}, doffs, src::CuArray{T}, soffs, n) where T
-  unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n)
+  GC.@preserve src dest unsafe_copyto!(pointer(dest, doffs), pointer(src, soffs), n)
   if Base.isbitsunion(T)
     # copy selector bytes
     error("Not implemented")

--- a/src/array.jl
+++ b/src/array.jl
@@ -48,7 +48,7 @@ function _unsafe_free!(xs::CuArray)
     if xs.parent === nothing
       # primary array with all references gone
       if xs.pooled && CUDAdrv.isvalid(xs.ctx)
-        free(convert(CuPtr{Nothing}, xs.ptr))
+        free(convert(CuPtr{Nothing}, pointer(xs)))
       end
     else
       # derived object
@@ -212,7 +212,7 @@ Base.convert(::Type{T}, x::T) where T <: CuArray = x
 function Base._reshape(parent::CuArray, dims::Dims)
   n = length(parent)
   prod(dims) == n || throw(DimensionMismatch("parent has $n elements, which is incompatible with size $dims"))
-  return CuArray{eltype(parent),length(dims)}(parent.ptr, dims, parent)
+  return CuArray{eltype(parent),length(dims)}(pointer(parent), dims, parent)
 end
 function Base._reshape(parent::CuArray{T,1}, dims::Tuple{Int}) where T
   n = length(parent)

--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -195,8 +195,9 @@ function axpy!(alpha::Ta,
     if minimum(rx) < 1 || maximum(rx) > length(x) || minimum(ry) < 1 || maximum(ry) > length(y)
         throw(BoundsError())
     end
-    axpy!(length(rx), convert(T, alpha), pointer(x)+(first(rx)-1)*sizeof(T),
-          step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
+    GC.@preserve x y axpy!(length(rx), convert(T, alpha),
+                           pointer(x)+(first(rx)-1)*sizeof(T), step(rx),
+                           pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
     y
 end
 
@@ -222,8 +223,9 @@ function axpby!(alpha::Ta,
     if minimum(rx) < 1 || maximum(rx) > length(x) || minimum(ry) < 1 || maximum(ry) > length(y)
         throw(BoundsError())
     end
-    axpby!(length(rx), convert(T, alpha), pointer(x)+(first(rx)-1)*sizeof(T),
-          step(rx), convert(T, beta), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
+    GC.@preserve x y axpby!(length(rx), convert(T, alpha),
+                            pointer(x)+(first(rx)-1)*sizeof(T), step(rx), convert(T, beta),
+                            pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
     y
 end
 

--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -72,4 +72,4 @@ GPUArrays.device(A::CuArray) = CUDAdrv.device(CUDAdrv.CuCurrentContext())
 GPUArrays.backend(::Type{<:CuArray}) = CuArrayBackend()
 
 GPUArrays.unsafe_reinterpret(::Type{T}, A::CuArray, size::NTuple{N, Integer}) where {T, N} =
-  CuArray{T,N}(convert(CuPtr{T}, A.ptr), size, A)
+  CuArray{T,N}(convert(CuPtr{T}, pointer(A)), size, A)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -4,11 +4,12 @@ using Printf
 using TimerOutputs
 
 using Base: @lock
+using Base.Threads: SpinLock
 
 # global lock for shared object dicts (allocated, requested).
 # stats are not covered by this and cannot be assumed to be exact.
 # each allocator needs to lock its own resources separately too.
-const memory_lock = ReentrantLock()
+const memory_lock = SpinLock()
 
 
 ## allocation statistics

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -32,7 +32,7 @@ end
 # for contiguous views just return a new CuArray
 @inline function _cuview(A::CuArray{T}, I::NTuple{N,ViewIndex}, dims::NTuple{M,Integer}) where {T,N,M}
     offset = compute_offset1(A, 1, I) * sizeof(T)
-    CuArray{T,M}(A.ptr + offset, dims, A)
+    CuArray{T,M}(pointer(A) + offset, dims, A)
 end
 
 # fallback to SubArray when the view is not contiguous

--- a/test/base.jl
+++ b/test/base.jl
@@ -391,8 +391,10 @@ end
     @test_throws ErrorException resize!(a, 2)
     @test_throws ErrorException resize!(b, 2)
 
-    c = unsafe_wrap(CuArray{Int}, pointer(b), 2)
-    @test_throws ErrorException resize!(c, 2)
+    GC.@preserve b begin
+      c = unsafe_wrap(CuArray{Int}, pointer(b), 2)
+      @test_throws ErrorException resize!(c, 2)
+    end
 end
 
 @testset "aliasing" begin


### PR DESCRIPTION
Maybe fixes https://github.com/JuliaGPU/CuArrays.jl/pull/638#issuecomment-602446718. Came across another one with ASAN+GC_DEBUG on master, so it's not tied to that PR. ASAN isn't strictly necessary, as GC_DEBUG scrubs when freeing, but I guess in drastically increases the frequency at which the GC is called.

```
mul! y = adjoint(A) * x * Complex{Float64}(a) + y * Complex{Float64}(b):
error in running finalizer: Base.KeyError(key=CUDAdrv.CuPtr{Nothing}(0xbbbbbbbbbbbbbbbb))
Error During Test at /home/tbesard/Julia/pkg/CuArrays/test/blas.jl:69
  Got exception outside of a @test
  CUDA error: invalid argument (code 1, ERROR_INVALID_VALUE)
  Stacktrace:
   [1] throw_api_error(::CUDAdrv.cudaError_enum) at /home/tbesard/Julia/pkg/CUDAdrv/src/error.jl:110
   [2] macro expansion at /home/tbesard/Julia/pkg/CUDAdrv/src/error.jl:117 [inlined]
   [3] cuMemcpyHtoD_v2(::CuPtr{Complex{Float64}}, ::Ptr{Complex{Float64}}, ::Int64) at /home/tbesard/Julia/pkg/CUDAapi/src/call.jl:93
   [4] #unsafe_copyto!#7 at /home/tbesard/Julia/pkg/CUDAdrv/src/memory.jl:314 [inlined]
   [5] unsafe_copyto! at /home/tbesard/Julia/pkg/CUDAdrv/src/memory.jl:307 [inlined]
   [6] unsafe_copyto! at /home/tbesard/Julia/pkg/CuArrays/src/array.jl:300 [inlined]
   [7] copyto! at /home/tbesard/Julia/pkg/CuArrays/src/array.jl:273 [inlined]
   [8] copyto! at /home/tbesard/Julia/pkg/GPUArrays/src/host/abstractarray.jl:112 [inlined]
   [9] CuArray at /home/tbesard/Julia/pkg/CuArrays/src/array.jl:192 [inlined]
   [10] CuArray(::Array{Complex{Float64},1}) at /home/tbesard/Julia/pkg/CuArrays/src/array.jl:202
   [11] top-level scope at /home/tbesard/Julia/pkg/CuArrays/test/blas.jl:71
   [12] top-level scope at /home/tbesard/Julia/julia/build/sanitize/usr/share/julia/stdlib/v1.3/Test/src/Test.jl:1180
   [13] top-level scope at /home/tbesard/Julia/pkg/CuArrays/test/blas.jl:69
   [14] top-level scope at /home/tbesard/Julia/julia/build/sanitize/usr/share/julia/stdlib/v1.3/Test/src/Test.jl:1107
   [15] top-level scope at /home/tbesard/Julia/pkg/CuArrays/test/blas.jl:54
   [16] top-level scope at /home/tbesard/Julia/julia/build/sanitize/usr/share/julia/stdlib/v1.3/Test/src/Test.jl:1180
   [17] top-level scope at /home/tbesard/Julia/pkg/CuArrays/test/blas.jl:49
   [18] top-level scope at /home/tbesard/Julia/julia/build/sanitize/usr/share/julia/stdlib/v1.3/Test/src/Test.jl:1107
   [19] top-level scope at /home/tbesard/Julia/pkg/CuArrays/test/blas.jl:5
   [20] include at ./boot.jl:328 [inlined]
   [21] include_relative(::Module, ::String) at ./loading.jl:1105
   [22] include(::Module, ::String) at ./Base.jl:31
   [23] include(::String) at ./client.jl:424
   [24] top-level scope at /home/tbesard/Julia/pkg/CuArrays/test/runtests.jl:55
   [25] top-level scope at /home/tbesard/Julia/julia/build/sanitize/usr/share/julia/stdlib/v1.3/Test/src/Test.jl:1107
   [26] top-level scope at /home/tbesard/Julia/pkg/CuArrays/test/runtests.jl:40
   [27] include at ./boot.jl:328 [inlined]
   [28] include_relative(::Module, ::String) at ./loading.jl:1105
   [29] include(::Module, ::String) at ./Base.jl:31
   [30] exec_options(::Base.JLOptions) at ./client.jl:287
   [31] _start() at ./client.jl:460
```

The keyerror is because the scrubbed pointer obviously doesn't exist in the pointer map, and I assume the invalid value error also comes from that.