### PR TITLE
Add direct BLAS calls for trmm! and trsm!

### DIFF
--- a/src/blas/linalg.jl
+++ b/src/blas/linalg.jl
@@ -301,3 +301,11 @@ LinearAlgebra.rdiv!(A::CuMatrix{T}, B::Transpose{T,<:LowerTriangular{T, <:CuMatr
     CUBLAS.trsm!('R', 'L', 'T', 'N', one(T), parent(parent(B)), A)
 LinearAlgebra.rdiv!(A::CuMatrix{T}, B::Transpose{T,<:UnitLowerTriangular{T, <:CuMatrix{T}}}) where T<:CublasFloat =
     CUBLAS.trsm!('R', 'L', 'T', 'U', one(T), parent(parent(B)), A)
+
+# Direct BLAS calls
+for T in Base.uniontypes(CublasFloat)
+    @eval LinearAlgebra.BLAS.trmm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar, alpha::$T, A::CuMatrix{$T}, B::CuMatrix{$T}) =
+        CuArrays.CUBLAS.trmm!(side, uplo, transa, diag, alpha, A, B, B)
+    @eval LinearAlgebra.BLAS.trsm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar, alpha::$T, A::CuMatrix{$T}, B::CuMatrix{$T}) =
+        CuArrays.CUBLAS.trsm!(side, uplo, transa, diag, alpha, A, B)
+end

--- a/src/blas/linalg.jl
+++ b/src/blas/linalg.jl
@@ -303,7 +303,7 @@ LinearAlgebra.rdiv!(A::CuMatrix{T}, B::Transpose{T,<:UnitLowerTriangular{T, <:Cu
     CUBLAS.trsm!('R', 'L', 'T', 'U', one(T), parent(parent(B)), A)
 
 # Direct BLAS calls
-for T in Base.uniontypes(CublasFloat)
+for T in Base.uniontypes(CublasFloat) # needed to avoid ambiguous method error
     @eval LinearAlgebra.BLAS.trmm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar, alpha::$T, A::CuMatrix{$T}, B::CuMatrix{$T}) =
         CuArrays.CUBLAS.trmm!(side, uplo, transa, diag, alpha, A, B, B)
     @eval LinearAlgebra.BLAS.trsm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar, alpha::$T, A::CuMatrix{$T}, B::CuMatrix{$T}) =

--- a/test/blas.jl
+++ b/test/blas.jl
@@ -781,6 +781,19 @@ end # level 1 testset
                 @test bC ≈ h_C
             end
         end
+
+        @testset "BLAS.trmm!" begin
+            A = copy(A)
+            B = copy(B)
+            dA = CuArray(A)
+            dB = CuArray(B)
+            dC = LinearAlgebra.BLAS.trmm!('L','U','N','N',one(elty),dA,dB)
+            C = LinearAlgebra.BLAS.trmm!('L','U','N','N',one(elty),A,B)
+            @test A ≈ Array(dA)
+            @test B ≈ Array(dB)
+            @test C ≈ Array(dC)
+        end
+
         B = rand(elty,m,n)
         C = rand(elty,m,n)
         d_B = CuArray(B)


### PR DESCRIPTION
This allows things like `UpperTriangular` which call these methods internally to work correctly with CuArrays.

Note that the `@eval` is needed to avoid method ambiguity. If there's a cleaner way to iterate over subtypes of `CublasFloat` I'm happy to do that.