### PR TITLE
Add mul! for trmm! and tests.

### DIFF
--- a/src/blas/linalg.jl
+++ b/src/blas/linalg.jl
@@ -302,6 +302,68 @@ LinearAlgebra.rdiv!(A::CuMatrix{T}, B::Transpose{T,<:LowerTriangular{T, <:CuMatr
 LinearAlgebra.rdiv!(A::CuMatrix{T}, B::Transpose{T,<:UnitLowerTriangular{T, <:CuMatrix{T}}}) where T<:CublasFloat =
     CUBLAS.trsm!('R', 'L', 'T', 'U', one(T), parent(parent(B)), A)
 
+
+# TRMM
+
+# Left mul!
+## No transpose/adjoint
+LinearAlgebra.mul!(X::CuMatrix{T}, A::UpperTriangular{T, <:CuMatrix{T}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'U', 'N', 'N', one(T), parent(A), B, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::UnitUpperTriangular{T, <:CuMatrix{T}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'U', 'N', 'U', one(T), parent(A), B, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::LowerTriangular{T, <:CuMatrix{T}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'L', 'N', 'N', one(T), parent(A), B, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::UnitLowerTriangular{T, <:CuMatrix{T}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'L', 'N', 'U', one(T), parent(A), B, X)
+## Adjoint
+LinearAlgebra.mul!(X::CuMatrix{T}, A::Adjoint{T,<:UpperTriangular{T, <:CuMatrix{T}}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'U', 'C', 'N', one(T), parent(parent(A)), B, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::Adjoint{T,<:UnitUpperTriangular{T, <:CuMatrix{T}}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'U', 'C', 'U', one(T), parent(parent(A)), B, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::Adjoint{T,<:LowerTriangular{T, <:CuMatrix{T}}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'L', 'C', 'N', one(T), parent(parent(A)), B, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::Adjoint{T,<:UnitLowerTriangular{T, <:CuMatrix{T}}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'L', 'C', 'U', one(T), parent(parent(A)), B, X)
+## Transpose
+LinearAlgebra.mul!(X::CuMatrix{T}, A::Transpose{T,<:UpperTriangular{T, <:CuMatrix{T}}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'U', 'T', 'N', one(T), parent(parent(A)), B, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::Transpose{T,<:UnitUpperTriangular{T, <:CuMatrix{T}}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'U', 'T', 'U', one(T), parent(parent(A)), B, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::Transpose{T,<:LowerTriangular{T, <:CuMatrix{T}}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'L', 'T', 'N', one(T), parent(parent(A)), B, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::Transpose{T,<:UnitLowerTriangular{T, <:CuMatrix{T}}}, B::CuMatrix{T}) where T<:CublasFloat =
+    CUBLAS.trmm!('L', 'L', 'T', 'U', one(T), parent(parent(A)), B, X)
+
+# Right mul!
+## No transpose/adjoint
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::UpperTriangular{T, <:CuMatrix{T}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'U', 'N', 'N', one(T), parent(B), A, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::UnitUpperTriangular{T, <:CuMatrix{T}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'U', 'N', 'U', one(T), parent(B), A, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::LowerTriangular{T, <:CuMatrix{T}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'L', 'N', 'N', one(T), parent(B), A, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::UnitLowerTriangular{T, <:CuMatrix{T}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'L', 'N', 'U', one(T), parent(B), A, X)
+## Adjoint
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::Adjoint{T,<:UpperTriangular{T, <:CuMatrix{T}}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'U', 'C', 'N', one(T), parent(parent(B)), A, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::Adjoint{T,<:UnitUpperTriangular{T, <:CuMatrix{T}}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'U', 'C', 'U', one(T), parent(parent(B)), A, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::Adjoint{T,<:LowerTriangular{T, <:CuMatrix{T}}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'L', 'C', 'N', one(T), parent(parent(B)), A, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::Adjoint{T,<:UnitLowerTriangular{T, <:CuMatrix{T}}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'L', 'C', 'U', one(T), parent(parent(B)), A, X)
+## Transpose
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::Transpose{T,<:UpperTriangular{T, <:CuMatrix{T}}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'U', 'T', 'N', one(T), parent(parent(B)), A, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::Transpose{T,<:UnitUpperTriangular{T, <:CuMatrix{T}}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'U', 'T', 'U', one(T), parent(parent(B)), A, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::Transpose{T,<:LowerTriangular{T, <:CuMatrix{T}}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'L', 'T', 'N', one(T), parent(parent(B)), A, X)
+LinearAlgebra.mul!(X::CuMatrix{T}, A::CuMatrix{T}, B::Transpose{T,<:UnitLowerTriangular{T, <:CuMatrix{T}}}) where T<:CublasFloat =
+    CUBLAS.trmm!('R', 'L', 'T', 'U', one(T), parent(parent(B)), A, X)
+
+
 # Direct BLAS calls
 for T in Base.uniontypes(CublasFloat) # needed to avoid ambiguous method error
     @eval LinearAlgebra.BLAS.trmm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar, alpha::$T, A::CuMatrix{$T}, B::CuMatrix{$T}) =

--- a/test/blas.jl
+++ b/test/blas.jl
@@ -805,6 +805,33 @@ end # level 1 testset
             @test B ≈ Array(dB)
             @test C ≈ Array(dC)
         end
+
+        @testset "mul! trmm!" begin
+            for t in (identity, transpose, adjoint), TR in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
+                A = copy(sA) |> TR
+                B_L = copy(B)
+                B_R = copy(B')
+                C_L = copy(C)
+                C_R = copy(C')
+                dA = CuArray(parent(A)) |> TR
+                dB_L = CuArray(parent(B_L))
+                dB_R = CuArray(parent(B_R))
+                dC_L = CuArray(C_L)
+                dC_R = CuArray(C_R)
+                
+                D_L = mul!(C_L, t(A), B_L)
+                dD_L = mul!(dC_L, t(dA), dB_L)
+                
+                D_R = mul!(C_R, B_R, t(A))
+                dD_R = mul!(dC_R, dB_R, t(dA))
+                
+                @test C_L ≈ Array(dC_L)
+                @test D_L ≈ Array(dD_L)
+                @test C_R ≈ Array(dC_R)
+                @test D_R ≈ Array(dD_R)
+            end
+        end
+
         B = rand(elty,m,n)
         C = rand(elty,m,n)
         d_B = CuArray(B)

--- a/test/blas.jl
+++ b/test/blas.jl
@@ -787,13 +787,24 @@ end # level 1 testset
             B = copy(B)
             dA = CuArray(A)
             dB = CuArray(B)
-            dC = LinearAlgebra.BLAS.trmm!('L','U','N','N',one(elty),dA,dB)
-            C = LinearAlgebra.BLAS.trmm!('L','U','N','N',one(elty),A,B)
+            dC = LinearAlgebra.BLAS.trmm!('L','U','N','N',alpha,dA,dB)
+            C = LinearAlgebra.BLAS.trmm!('L','U','N','N',alpha,A,B)
             @test A ≈ Array(dA)
             @test B ≈ Array(dB)
             @test C ≈ Array(dC)
         end
 
+        @testset "BLAS.trsm!" begin
+            A = copy(A)
+            B = copy(B)
+            dA = CuArray(A)
+            dB = CuArray(B)
+            dC = LinearAlgebra.BLAS.trsm!('L','U','N','N',alpha,dA,dB)
+            C = LinearAlgebra.BLAS.trsm!('L','U','N','N',alpha,A,B)
+            @test A ≈ Array(dA)
+            @test B ≈ Array(dB)
+            @test C ≈ Array(dC)
+        end
         B = rand(elty,m,n)
         C = rand(elty,m,n)
         d_B = CuArray(B)


### PR DESCRIPTION
This adds `mul!` for various triangular types, which are called directly in Cholesky adjoint and probably elsewhere too. It should improve performance for triangular matrix-matrix multiplies. All cases are tested to ensure no typos.