### PR TITLE
findfirst should return nothing if no matching element is found

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -120,7 +120,7 @@ function Base.findfirst(testf::Function, xs::CuArray)
     @cuda name="findfirst" config=configurator kernel(y, xs)
 
     first_i = @allowscalar y[1]
-    return keys(xs)[first_i]
+    return first_i == typemax(Int) ? nothing : keys(xs)[first_i]
 end
 
 Base.findfirst(xs::CuArray{Bool}) = findfirst(identity, xs)

--- a/test/base.jl
+++ b/test/base.jl
@@ -312,6 +312,9 @@ end
     # 1D
     @test testf(x->findfirst(x), rand(Bool, 100))
     @test testf(x->findfirst(y->y>0.5, x), rand(100))
+    let x = fill(false, 10)
+      @test findfirst(x) == findfirst(CuArray(x))
+    end
 
     # ND
     let x = rand(Bool, 10, 10)


### PR DESCRIPTION
While porting some code from CPU to GPU I encountered the problem that the GPU version of findfirst crashes with an illegal index access when no element matches the findfirst criteria. I made the GPU implementation also returns nothing when no matching element is found.

Hope it helps.