### PR TITLE
fix ambiguity for Random.seed!(rng, nothing)

### DIFF
--- a/src/rand/random.jl
+++ b/src/rand/random.jl
@@ -47,6 +47,8 @@ function Random.seed!(rng::RNG, seed=Base.rand(UInt64), offset=0)
     return
 end
 
+Random.seed!(rng::RNG, ::Nothing) = Random.seed!(rng)
+
 # convenience function that seeds both generators
 function seed!(seed=Base.rand(UInt64))
     Random.seed!(generator(), seed)

--- a/test/rand.jl
+++ b/test/rand.jl
@@ -4,6 +4,7 @@ using CuArrays.CURAND
 
 rng = CURAND.generator()
 Random.seed!(rng)
+Random.seed!(rng, nothing)
 Random.seed!(rng, 1)
 Random.seed!(rng, 1, 0)
 


### PR DESCRIPTION
Prior to this PR we had that:

```julia
julia> Random.seed!(Random.default_rng(), nothing)
MersenneTwister(...)

julia> Random.seed!(CuArrays.CURAND.generator(), nothing)
ERROR: MethodError: seed!(::CuArrays.CURAND.RNG, ::Nothing) is ambiguous. Candidates:
  seed!(rng::CuArrays.CURAND.RNG, seed) in CuArrays.CURAND at /home/marius/.julia/packages/CuArrays/l0gXB/src/rand/random.jl:44
  seed!(rng::AbstractRNG, ::Nothing) in Random at /home/marius/src/julia-1.4/usr/share/julia/stdlib/v1.4/Random/src/Random.jl:426
```

Now the second one works as expected. 

I wasn't sure what to make of the calls to `Random.seed!` outside of a `@test` but I put the extra one with them, let me know if that's ok. 