### PR TITLE
Fix sparse-dense matmul, with transposed dense

### DIFF
--- a/src/sparse/interfaces.jl
+++ b/src/sparse/interfaces.jl
@@ -17,9 +17,9 @@ LinearAlgebra.mul!(C::CuVector{T},transA::Transpose{<:Any, <:HermOrSym{T,<:CuSpa
 LinearAlgebra.mul!(C::CuVector{T},adjA::Adjoint{<:Any, <:HermOrSym{T,<:CuSparseMatrix{T}}},B::CuVector{T}) where {T} = mv!('C',one(T),parent(adjA),B,zero(T),C,'O')
 
 LinearAlgebra.mul!(C::CuMatrix{T},A::CuSparseMatrix{T},B::CuMatrix{T}) where {T} = mm2!('N','N',one(T),A,B,zero(T),C,'O')
-LinearAlgebra.mul!(C::CuMatrix{T},A::CuSparseMatrix{T},transB::Transpose{<:Any, CuMatrix{T}})  where {T} = mm2!('N','T',one(T),A,parent(transB),zero(T),C,'O')
+LinearAlgebra.mul!(C::CuMatrix{T},A::CuSparseMatrix{T},transB::Transpose{<:Any, <:CuMatrix{T}})  where {T} = mm2!('N','T',one(T),A,parent(transB),zero(T),C,'O')
 LinearAlgebra.mul!(C::CuMatrix{T},transA::Transpose{<:Any, <:CuSparseMatrix{T}},B::CuMatrix{T})  where {T} = mm2!('T','N',one(T),parent(transA),B,zero(T),C,'O')
-LinearAlgebra.mul!(C::CuMatrix{T},transA::Transpose{<:Any, <:CuSparseMatrix{T}},transB::Transpose{<:Any, CuMatrix{T}}) where {T} = mm2!('T','T',one(T),parent(transA),parent(transB),zero(T),C,'O')
+LinearAlgebra.mul!(C::CuMatrix{T},transA::Transpose{<:Any, <:CuSparseMatrix{T}},transB::Transpose{<:Any, <:CuMatrix{T}}) where {T} = mm2!('T','T',one(T),parent(transA),parent(transB),zero(T),C,'O')
 LinearAlgebra.mul!(C::CuMatrix{T},adjA::Adjoint{<:Any, <:CuSparseMatrix{T}},B::CuMatrix{T})  where {T} = mm2!('C','N',one(T),parent(adjA),B,zero(T),C,'O')
 
 LinearAlgebra.mul!(C::CuMatrix{T},A::HermOrSym{<:Number, <:CuSparseMatrix},B::CuMatrix) where {T} = mm!('N',one(T),A,B,zero(T),C,'O')

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -1769,10 +1769,7 @@ end
             @test D ≈ h_C
             d_Bᵀ = CuArray(Bᵀ)
             d_C = CuArray(C)
-            mul!(d_C, d_A, transpose(d_Bᵀ))
-            h_C = collect(d_C)
-            D = A * transpose(Bᵀ)
-            @test D ≈ h_C
+            @test_throws CUSPARSEError mul!(d_C, d_A, transpose(d_Bᵀ))
         end
     end
 end

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -1731,6 +1731,7 @@ end
         A = sparse(rand(elty,m,k))
         B = rand(elty,k,n)
         C = rand(elty,m,n)
+        Bᵀ = collect(transpose(B))
         alpha = rand(elty)
         beta = rand(elty)
         @testset "csr" begin
@@ -1746,6 +1747,12 @@ end
             h_C = collect(d_C)
             D = A * B
             @test D ≈ h_C
+            d_Bᵀ = CuArray(Bᵀ)
+            d_C = CuArray(C)
+            mul!(d_C, d_A, transpose(d_Bᵀ))
+            h_C = collect(d_C)
+            D = A * transpose(Bᵀ)
+            @test D ≈ h_C
         end
         @testset "csc" begin
             d_B = CuArray(B)
@@ -1759,6 +1766,12 @@ end
             mul!(d_C, d_A, d_B)
             h_C = collect(d_C)
             D = A * B
+            @test D ≈ h_C
+            d_Bᵀ = CuArray(Bᵀ)
+            d_C = CuArray(C)
+            mul!(d_C, d_A, transpose(d_Bᵀ))
+            h_C = collect(d_C)
+            D = A * transpose(Bᵀ)
             @test D ≈ h_C
         end
     end


### PR DESCRIPTION
Declaring the argument to be a subtype of CuMatrix{T} seems to fix issue #725, where a sparse * transposed(dense) matmul defaults to generic methods despite methods being defined in interfaces.jl. 

where sparsematrixcsc is sparse, and densematrix is dense (as seen in more detail in the issue)
```julia

# before the patch
densematrix_T = transpose(densematrix)
@which mul!(similar(densematrix_T, Float32, (size(sparsecscmatrix,1), size(densematrix_T,2))), sparsecscmatrix, densematrix_T)
# mul!(C, A, B) at stdlib/v1.4/LinearAlgebra/src/matmul.jl:208

# after the proposed patch
@which mul!(similar(densematrix_T, Float32, (size(sparsecscmatrix,1), size(densematrix_T,2))), sparsecscmatrix, densematrix_T)
# mul!(C::CuArray{T,2,P} where P, A::Union{CuArrays.CUSPARSE.CuSparseMatrixBSR{T}, CuArrays.CUSPARSE.CuSparseMatrixCSC{T}, CuArrays.CUSPARSE.CuSparseMatrixCSR{T}, CuArrays.CUSPARSE.CuSparseMatrixHYB{T}}, transB::Transpose{#s243,#s242} where #s242<:(CuArray{T,2,P} where P) where #s243) where T at CuArrays/l0gXB/src/sparse/interfaces.jl:20
```